### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -77,7 +77,7 @@ Requirements
 
 - Apache or Nginx
 - PHP >= 5.3.3
-- PHP extensions required: mbstring and pdo_sqlite
+- PHP extensions required: mbstring and pdo_sqlite (don't forget to enable extensions)
 - A web browser with HTML5 drag and drop support
 
 Installation
@@ -159,6 +159,7 @@ open http://localhost:8000/
 ```bash
 apt-get update
 apt-get install -y php5 php5-sqlite
+echo 'extension=sqlite.so' >> /etc/php5/conf.d/sqlite.ini
 cd /var/www/
 wget http://kanboard.net/kanboard-VERSION.zip
 unzip kanboard-VERSION.zip


### PR DESCRIPTION
Hey,

j'ai installé Kanboard pour tester ça a l'air sympa.
L'installation sur debian ne m'a pris que quelques minutes.
Il faut juste penser à activer sqlite.

En effet sinon on a le message d'erreur :

```
PHP extension required: pdo_sqlite
```

pour cela il suffit de rajouter la ligne suivante à `/etc/php5/conf.d/sqlite.ini` (et créer le fichier si nécessaire):

```
extension=sqlite.so
```

je me permet de mettre à jour le readme au passage (avec un echo crade certes) mais il faudra répercuter ça sur le site.
