### PR TITLE
Story Points translation missing

### DIFF
--- a/locales/pl_PL/translations.php
+++ b/locales/pl_PL/translations.php
@@ -190,7 +190,7 @@ return array(
     'Details' => 'Informacje',
     'Sorry, I didn\'t found this information in my database!' => 'Niestety nie znaleziono tej informacji w bazie danych',
     'Page not found' => 'Strona nie istnieje',
-    'Story Points' => '',
+    'Story Points' => 'Poziom trudności',
     'limit' => 'limit',
     'Task limit' => 'Limit zadań',
     'This value must be greater than %d' => 'Wartość musi być większa niż %d',


### PR DESCRIPTION
Since story points are way to measure the level of difficulty, that's why it's "stopień trudności" which means "difficulty level". There's no expression for "story points" in Polish AFAIK
