### PR TITLE
Fixed invalid constraint for comments table in sqlite schema

### DIFF
--- a/common.php
+++ b/common.php
@@ -6,7 +6,7 @@ require __DIR__.'/core/translator.php';
 
 $registry = new Core\Registry;
 
-$registry->db_version = 10;
+$registry->db_version = 11;
 
 $registry->db = function() use ($registry) {
     require __DIR__.'/vendor/PicoDb/Database.php';

--- a/schemas/sqlite.php
+++ b/schemas/sqlite.php
@@ -2,6 +2,33 @@
 
 namespace Schema;
 
+function version_11($pdo)
+{
+    $pdo->exec(
+        'ALTER TABLE comments RENAME TO comments_bak'
+    );
+
+    $pdo->exec(
+        'CREATE TABLE comments (
+            id INTEGER PRIMARY KEY,
+            task_id INTEGER,
+            user_id INTEGER,
+            date INTEGER,
+            comment TEXT,
+            FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+            FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+        )'
+    );
+
+    $pdo->exec(
+       'INSERT INTO comments SELECT * FROM comments_bak'
+    );
+
+    $pdo->exec(
+       'DROP TABLE comments_bak'
+    );
+}
+
 function version_10($pdo)
 {
     $pdo->exec(


### PR DESCRIPTION
I noticed that there is probably a mistake in schema defining comments table for sqlite. There are two foreign keys defined:

FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE,
FOREIGN KEY(user_id) REFERENCES tasks(id) ON DELETE CASCADE

Note that second one is referring to **tasks** table, not to **users**.

To fix this I have added new version function (version_11) which alters this constraint. Because as far as I know in sqlite it is not possible to alter constraint in existing table, I had to rename comments table to temporary name, then create new table with correct constraints, then copy all content from old table to the new one, and finally drop temporary table.

If there is simpler solution, I will be happy to hear about it :)

Thanks.
