### PR TITLE
Add a specific Kanboard description parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@
 *.sqlite
 *.sqlite-journal
 
+# IDE generated files #
+######################
+.buildpath
+.project
+
 # OS generated files #
 ######################
 .DS_Store

--- a/core/helper.php
+++ b/core/helper.php
@@ -23,6 +23,13 @@ function get_username()
     return $_SESSION['user']['username'];
 }
 
+function parse($text)
+{
+    $text = markdown($text);
+    $text = preg_replace('!#(\d+)!i', '<a href="?controller=task&action=show&task_id=$1">$0</a>', $text);
+    return $text;
+}
+
 function markdown($text)
 {
     require_once __DIR__.'/../vendor/Michelf/MarkdownExtra.inc.php';

--- a/templates/task_show.php
+++ b/templates/task_show.php
@@ -72,7 +72,7 @@
             <h2><?= t('Description') ?></h2>
             <?php if ($task['description']): ?>
                 <article class="markdown task-show-description">
-                    <?= Helper\markdown($task['description']) ?: t('There is no description.') ?>
+                    <?= Helper\parse($task['description']) ?: t('There is no description.') ?>
                 </article>
             <?php else: ?>
                 <form method="post" action="?controller=task&amp;action=description&amp;task_id=<?= $task['id'] ?>" autocomplete="off">


### PR DESCRIPTION
This parser still calls the markdown parser, but also replace #<task number> to a link to the given task.
