### PR TITLE
Update Config.php to implement getNativeLanguages

### DIFF
--- a/app/Model/Config.php
+++ b/app/Model/Config.php
@@ -59,6 +59,30 @@ class Config extends Base
     }
 
     /**
+     * Get available languages using native language of everyone
+     *
+     * @access public
+     * @return array
+     */
+    public function getNativeLanguages()
+    {
+        $languages = array(
+                'de_DE' => 'Deutsch',
+                'en_US' => 'English',
+                'es_ES' => 'Español',
+                'fr_FR' => 'Français',
+                'pl_PL' => 'Polski',
+                'pt_BR' => 'Português (Brasil)',
+                'sv_SE' => 'Svenska',
+                'zh_CN' => '中文(简体)',
+        );
+    
+        asort($languages);
+    
+        return $languages;
+    }
+    
+    /**
      * Get a config variable from the session or the database
      *
      * @access public


### PR DESCRIPTION
Added getNativeLanguages function to return languages list using native word of everyone.
This way there is no need to make translations as people always can read their onw language.
This is made as an alternative to translation under a proposal by Sašo Smolej...
As I do not know chich solution is better, I have made changes in order to be tested to decide which one is best.
