### PR TITLE
Implement LDAP user lookup.

### DIFF
--- a/app/Model/Ldap.php
+++ b/app/Model/Ldap.php
@@ -24,6 +24,11 @@ class Ldap extends Base
             die('The PHP LDAP extension is required');
         }
 
+        if (!LDAP_SSL_VERIFY) {
+            //Skip SSL certificate verification
+            putenv('LDAPTLS_REQCERT=never');
+        }
+
         $ldap = ldap_connect(LDAP_SERVER, LDAP_PORT);
 
         if (! is_resource($ldap)) {

--- a/app/common.php
+++ b/app/common.php
@@ -44,6 +44,7 @@ defined('DB_NAME') or define('DB_NAME', 'kanboard');
 defined('LDAP_AUTH') or define('LDAP_AUTH', false);
 defined('LDAP_SERVER') or define('LDAP_SERVER', '');
 defined('LDAP_PORT') or define('LDAP_PORT', 389);
+defined('LDAP_SSL_VERIFY') or define('LDAP_SSL_VERIFY', true);
 defined('LDAP_ACCOUNT_FULLNAME') or define('LDAP_ACCOUNT_FULLNAME', 'displayname');
 defined('LDAP_ACCOUNT_EMAIL') or define('LDAP_ACCOUNT_EMAIL', 'mail');
 

--- a/config.default.php
+++ b/config.default.php
@@ -30,6 +30,9 @@ define('LDAP_SERVER', '');
 // LDAP server port (389 by default)
 define('LDAP_PORT', 389);
 
+// By default, require certificate to be verified for ldaps:// style URL. Set to false to skip the verification.
+define('LDAP_SSL_VERIFY', true);
+
 // LDAP username to connect with. NULL for anonymous bind (by default).
 define('LDAP_USERNAME', null);
 


### PR DESCRIPTION
This is required to improve compatibility when the DN cannot be easily
computed from the user name. Additionally, this allows automatically
getting the full name and email address from LDAP.
