### PR TITLE
Show task count in each column even if no limit is set.

### DIFF
--- a/app/Templates/board_show.php
+++ b/app/Templates/board_show.php
@@ -15,6 +15,10 @@
                  <?= Helper\escape($column['task_limit']) ?>
                 )
             </span>
+        <?php else: ?>
+            <span title="<?= t('Task count') ?>" class="task-count">
+                (<span id="task-number-column-<?= $column['id'] ?>"><?= count($column['tasks']) ?></span>)
+            </span>
         <?php endif ?>
     </th>
     <?php endforeach ?>

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -564,6 +564,11 @@ a.filter-on {
     line-height: 70%;
 }
 
+.task-count {
+    color: #888;
+    font-weight: normal;
+}
+
 /* task inside the board */
 .task-board {
     position: relative;


### PR DESCRIPTION
When task limit is not set, the count is displayed in a lighter shade.
Display when task limit is set is not affected.
