### PR TITLE
update ubuntu installation to include apache2 restart

### DIFF
--- a/docs/ubuntu-installation.markdown
+++ b/docs/ubuntu-installation.markdown
@@ -11,6 +11,12 @@ sudo apt-get update
 sudo apt-get install -y php5 php5-sqlite unzip
 ```
 
+In case your webserver was running restart to make sure the php modules are reloaded
+
+```bash
+service apache2 restart
+```
+
 Install Kanboard:
 
 ```bash


### PR DESCRIPTION
this cost me half an hour until I discovered that phpinfo(); didn't name the sqlite under pdo

This resulted in the strange error "data not writeable" being thrown out.
