### PR TITLE
Reverse proxy authentication option

### DIFF
--- a/app/Controller/Base.php
+++ b/app/Controller/Base.php
@@ -25,7 +25,7 @@ use Model\LastLogin;
  * @property \Model\Ldap        $ldap
  * @property \Model\Project     $project
  * @property \Model\RememberMe  $rememberMe
- * @property \Model\ProxyAuth   $proxyAuth
+ * @property \Model\ReverseProxyAuth   $reverseProxyAuth
  * @property \Model\SubTask     $subTask
  * @property \Model\Task        $task
  * @property \Model\User        $user
@@ -127,11 +127,8 @@ abstract class Base
             // Try the remember me authentication first
             if (! $this->rememberMe->authenticate()) {
 
-                // automatic proxy header authentication
-                if(PROXY_AUTH && $this->proxyAuth->authenticate()) {
-                    // ok, do nothing
-                }
-                else {
+                // automatic reverse proxy header authentication
+                if(! (REVERSE_PROXY_AUTH && $this->reverseProxyAuth->authenticate()) ) {
                     // Redirect to the login form if not authenticated
                     $this->response->redirect('?controller=user&action=login');
                 }

--- a/app/Model/LastLogin.php
+++ b/app/Model/LastLogin.php
@@ -34,7 +34,7 @@ class LastLogin extends Base
     const AUTH_LDAP        = 'ldap';
     const AUTH_GOOGLE      = 'google';
     const AUTH_GITHUB      = 'github';
-    const AUTH_PROXY       = 'proxy';
+    const AUTH_REVERSE_PROXY = 'reverse_proxy';
 
     /**
      * Create a new record

--- a/app/Model/ReverseProxyAuth.php
+++ b/app/Model/ReverseProxyAuth.php
@@ -5,12 +5,12 @@ namespace Model;
 use Core\Security;
 
 /**
- * Proxy model
+ * ReverseProxyAuth model
  *
  * @package  model
  * @author   Sylvain Veyrié
  */
-class ProxyAuth extends Base
+class ReverseProxyAuth extends Base
 {
     /**
      * Authenticate the user with the HTTP header
@@ -20,9 +20,9 @@ class ProxyAuth extends Base
      */
     public function authenticate()
     {
-        if(isset($_SERVER[PROXY_USER_HEADER])) {
+        if(isset($_SERVER[REVERSE_PROXY_USER_HEADER])) {
 
-            $login = $_SERVER[PROXY_USER_HEADER];
+            $login = $_SERVER[REVERSE_PROXY_USER_HEADER];
             $userModel = new User($this->db, $this->event);
             $user = $userModel->getByUsername($login);
         
@@ -37,7 +37,7 @@ class ProxyAuth extends Base
             // Update login history
             $lastLogin = new LastLogin($this->db, $this->event);
             $lastLogin->create(
-                LastLogin::AUTH_PROXY,
+                LastLogin::AUTH_REVERSE_PROXY,
                 $user['id'],
                 $userModel->getIpAddress(),
                 $userModel->getUserAgent()
@@ -51,7 +51,7 @@ class ProxyAuth extends Base
     {
         $userModel = new User($this->db, $this->event);
 
-        $is_admin = PROXY_DEFAULT_ADMIN === $login;
+        $is_admin = REVERSE_PROXY_DEFAULT_ADMIN === $login;
 
         return $userModel->create(array(
             'email' => $login,

--- a/app/common.php
+++ b/app/common.php
@@ -58,10 +58,10 @@ defined('GITHUB_AUTH') or define('GITHUB_AUTH', false);
 defined('GITHUB_CLIENT_ID') or define('GITHUB_CLIENT_ID', '');
 defined('GITHUB_CLIENT_SECRET') or define('GITHUB_CLIENT_SECRET', '');
 
-// Proxy authentification
-defined('PROXY_AUTH') or define('PROXY_AUTH', false);
-defined('PROXY_USER_HEADER') or define('PROXY_USER_HEADER', 'REMOTE_USER');
-defined('PROXY_DEFAULT_ADMIN') or define('PROXY_DEFAULT_ADMIN', '');
+// Proxy authentication
+defined('REVERSE_PROXY_AUTH') or define('REVERSE_PROXY_AUTH', false);
+defined('REVERSE_PROXY_USER_HEADER') or define('REVERSE_PROXY_USER_HEADER', 'REMOTE_USER');
+defined('REVERSE_PROXY_DEFAULT_ADMIN') or define('REVERSE_PROXY_DEFAULT_ADMIN', '');
 
 $loader = new Loader;
 $loader->execute();


### PR DESCRIPTION
Adds an option to delegate the authentication to a reverse proxy, that passes the login through an HTTP header. By default, this header is the classical Apache's REMOTE_USER.

This option must be used with caution, and only if the app is behind a secured reverse proxy. Otherwise, anyone setting the HTTP header could access the application.
