### PR TITLE
Add settings field to control default project columns

### DIFF
--- a/app/Model/Project.php
+++ b/app/Model/Project.php
@@ -496,13 +496,14 @@ class Project extends Base
         }
 
         $project_id = $this->db->getConnection()->getLastId();
+        
+        $default_columns = explode(",",$this->config->get('default_columns', 'Backlog,Ready,Work in Progress,Done'));
+        $columns = array();
+        foreach ($default_columns as $column) {
+            $columns[] = array('title' => t(trim($column)), 'task_limit' => 0);
+        }
 
-        $this->board->create($project_id, array(
-            array('title' => t('Backlog'), 'task_limit' => 0),
-            array('title' => t('Ready'), 'task_limit' => 0),
-            array('title' => t('Work in progress'), 'task_limit' => 0),
-            array('title' => t('Done'), 'task_limit' => 0),
-        ));
+        $this->board->create($project_id, $columns);
 
         $this->db->closeTransaction();
 

--- a/app/Schema/Mysql.php
+++ b/app/Schema/Mysql.php
@@ -4,7 +4,12 @@ namespace Schema;
 
 use Core\Security;
 
-const VERSION = 25;
+const VERSION = 26;
+
+function version_26($pdo)
+{
+    $pdo->exec("ALTER TABLE config ADD COLUMN default_columns VARCHAR(255) DEFAULT 'Backlog,Ready,Work in Progress,Done'");
+}
 
 function version_25($pdo)
 {

--- a/app/Schema/Postgres.php
+++ b/app/Schema/Postgres.php
@@ -4,7 +4,12 @@ namespace Schema;
 
 use Core\Security;
 
-const VERSION = 6;
+const VERSION = 7;
+
+function version_7($pdo)
+{
+    $pdo->exec("ALTER TABLE config ADD COLUMN default_columns VARCHAR(255) DEFAULT 'Backlog,Ready,Work in Progress,Done'");
+}
 
 function version_6($pdo)
 {

--- a/app/Schema/Sqlite.php
+++ b/app/Schema/Sqlite.php
@@ -4,7 +4,12 @@ namespace Schema;
 
 use Core\Security;
 
-const VERSION = 25;
+const VERSION = 26;
+
+function version_26($pdo)
+{
+    $pdo->exec("ALTER TABLE config ADD COLUMN default_columns TEXT DEFAULT 'Backlog,Ready,Work in Progress,Done'");
+}
 
 function version_25($pdo)
 {

--- a/app/Templates/config_index.php
+++ b/app/Templates/config_index.php
@@ -20,6 +20,9 @@
         <?= Helper\form_label(t('Webhook URL for task modification'), 'webhooks_url_task_modification') ?>
         <?= Helper\form_text('webhooks_url_task_modification', $values, $errors) ?><br/>
 
+        <?= Helper\form_label(t('Default Columns for new Projects (Comma-separated)'), 'default_columns') ?>
+        <?= Helper\form_text('default_columns', $values, $errors) ?><br/>
+
         <div class="form-actions">
             <input type="submit" value="<?= t('Save') ?>" class="btn btn-blue"/>
         </div>


### PR DESCRIPTION
Right now when new projects are created the default columns are hardcoded. This patch adds a simple comma-separated string settings field that allows the user to change the default columns for newly created projects.
