### PR TITLE
Improve labels in change password interface

### DIFF
--- a/app/Locales/de_DE/translations.php
+++ b/app/Locales/de_DE/translations.php
@@ -496,4 +496,5 @@ return array(
     // 'Activity' => '',
     // 'Default values are "%s"' => '',
     // 'Default columns for new projects (Comma-separated)' => '',
+    // 'New password for the user "%s"' => '',
 );

--- a/app/Locales/es_ES/translations.php
+++ b/app/Locales/es_ES/translations.php
@@ -496,4 +496,5 @@ return array(
     'Activity' => 'Actividad',
     'Default values are "%s"' => 'Los valores por defecto son "%s"',
     'Default columns for new projects (Comma-separated)' => 'Columnas por defecto de los nuevos proyectos (Separadas mediante comas)',
+    // 'New password for the user "%s"' => '',
 );

--- a/app/Locales/fi_FI/translations.php
+++ b/app/Locales/fi_FI/translations.php
@@ -496,4 +496,5 @@ return array(
     // 'Activity' => '',
     // 'Default values are "%s"' => '',
     // 'Default columns for new projects (Comma-separated)' => '',
+    // 'New password for the user "%s"' => '',
 );

--- a/app/Locales/fr_FR/translations.php
+++ b/app/Locales/fr_FR/translations.php
@@ -502,4 +502,5 @@ return array(
     '[%s][Column Change] %s (#%d)' => '[%s][Changement de colonne] %s (#%d)',
     '[%s][Position Change] %s (#%d)' => '[%s][Changement de position] %s (#%d)',
     '[%s][Assignee Change] %s (#%d)' => '[%s][Changement d\'assigné] %s (#%d)',
+    // 'New password for the user "%s"' => '',
 );

--- a/app/Locales/it_IT/translations.php
+++ b/app/Locales/it_IT/translations.php
@@ -496,4 +496,5 @@ return array(
     // 'Activity' => '',
     // 'Default values are "%s"' => '',
     // 'Default columns for new projects (Comma-separated)' => '',
+    // 'New password for the user "%s"' => '',
 );

--- a/app/Locales/pl_PL/translations.php
+++ b/app/Locales/pl_PL/translations.php
@@ -496,4 +496,5 @@ return array(
     // 'Activity' => '',
     // 'Default values are "%s"' => '',
     // 'Default columns for new projects (Comma-separated)' => '',
+    // 'New password for the user "%s"' => '',
 );

--- a/app/Locales/pt_BR/translations.php
+++ b/app/Locales/pt_BR/translations.php
@@ -496,4 +496,5 @@ return array(
     // 'Activity' => '',
     // 'Default values are "%s"' => '',
     // 'Default columns for new projects (Comma-separated)' => '',
+    // 'New password for the user "%s"' => '',
 );

--- a/app/Locales/ru_RU/translations.php
+++ b/app/Locales/ru_RU/translations.php
@@ -496,4 +496,5 @@ return array(
     'Activity' => 'Активность',
     'Default values are "%s"' => 'Колонки по умолчанию: "%s"',
     'Default columns for new projects (Comma-separated)' => 'Колонки по умолчанию для новых проектов (разделять запятой)',
+    // 'New password for the user "%s"' => '',
 );

--- a/app/Locales/sv_SE/translations.php
+++ b/app/Locales/sv_SE/translations.php
@@ -496,4 +496,5 @@ return array(
     // 'Activity' => '',
     // 'Default values are "%s"' => '',
     // 'Default columns for new projects (Comma-separated)' => '',
+    // 'New password for the user "%s"' => '',
 );

--- a/app/Locales/zh_CN/translations.php
+++ b/app/Locales/zh_CN/translations.php
@@ -496,4 +496,5 @@ return array(
     // 'Activity' => '',
     // 'Default values are "%s"' => '',
     // 'Default columns for new projects (Comma-separated)' => '',
+    // 'New password for the user "%s"' => '',
 );

--- a/app/Templates/user_password.php
+++ b/app/Templates/user_password.php
@@ -10,7 +10,7 @@
     <?= Helper\form_label(t('Current password for the user "%s"', Helper\get_username()), 'current_password') ?>
     <?= Helper\form_password('current_password', $values, $errors) ?><br/>
 
-    <?= Helper\form_label(t('Password'), 'password') ?>
+    <?= Helper\form_label(t('New password for the user "%s"', Helper\get_username($user)), 'password') ?>
     <?= Helper\form_password('password', $values, $errors) ?><br/>
 
     <?= Helper\form_label(t('Confirmation'), 'confirmation') ?>

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -35,9 +35,10 @@ function is_admin()
     return $_SESSION['user']['is_admin'] == 1;
 }
 
-function get_username()
+function get_username($user = false)
 {
-    return $_SESSION['user']['name'] ?: $_SESSION['user']['username'];
+    return $user ? ($user['name'] ?: $user['username'])
+                : ($_SESSION['user']['name'] ?: $_SESSION['user']['username']);
 }
 
 function get_user_id()


### PR DESCRIPTION
I received complaints from admin users trying to change other users' password that it was confusing because when say admin user "A" selects a user "B" under "Users" and then clicks "Change Password", the first label says

"Current password for the user "A""

Resulting in them questioning whether they're changing the password for "A" or for "B". Hope that explanation made sense :) Anyway, this is a proposed patch that simply makes it explicit by changing the label for the second field from just "Password" to

"New password for the user "B""

My company is experimenting with moving to Kanboard for project/task management and I'll be doing some patching to help fit my company's needs. I'll be sending pull requests to hopefully have most of them upstreamed :)
