### PR TITLE
Exclude current user in email notifications

### DIFF
--- a/app/Model/Notification.php
+++ b/app/Model/Notification.php
@@ -10,6 +10,7 @@ use Event\FileNotificationListener;
 use Event\SubTaskNotificationListener;
 use Swift_Message;
 use Swift_Mailer;
+use Helper;
 
 /**
  * Notification model
@@ -46,7 +47,11 @@ class Notification extends Base
             $projects = $this->db->table(self::TABLE)
                                  ->eq('user_id', $user['id'])
                                  ->findAllByColumn('project_id');
-
+            // don't send notifications to the current user for their own actions
+            if ($user['id'] == Helper\get_user_id()) {
+                unset($users[$index]);
+                continue;
+            }
             // The user have selected only some projects
             if (! empty($projects)) {
 


### PR DESCRIPTION
Email notifications should probably only go to other participants, ie one should probably not receive email notifications for one's own actions to avoid useless email spam. This patch implements that.

I think it makes sense for this to simply be default behavior, but if you think it's better for it to be configurable let me know and I'll make it so.
