### PR TITLE
Redirect to original target page after logging in

### DIFF
--- a/app/Controller/Base.php
+++ b/app/Controller/Base.php
@@ -124,7 +124,7 @@ abstract class Base
 
         // Authentication
         if (! $this->authentication->isAuthenticated($controller, $action)) {
-            $this->response->redirect('?controller=user&action=login');
+            $this->response->redirect('?controller=user&action=login&redirect_query='.urlencode($this->request->getQueryString()));
         }
 
         // Check if the user is allowed to see this page

--- a/app/Controller/User.php
+++ b/app/Controller/User.php
@@ -34,10 +34,12 @@ class User extends Base
             $this->response->redirect('?controller=app');
         }
 
+        $redirect_query = $this->request->getStringParam('redirect_query');
         $this->response->html($this->template->layout('user_login', array(
             'errors' => array(),
             'values' => array(),
             'no_layout' => true,
+            'redirect_query' => $redirect_query,
             'title' => t('Login')
         )));
     }
@@ -49,17 +51,23 @@ class User extends Base
      */
     public function check()
     {
+        $redirect_query = $this->request->getStringParam('redirect_query');
         $values = $this->request->getValues();
         list($valid, $errors) = $this->authentication->validateForm($values);
 
         if ($valid) {
-            $this->response->redirect('?controller=board');
+            if ($redirect_query != "") {
+                $this->response->redirect('?'.$redirect_query);
+            } else {
+                $this->response->redirect('?controller=board');
+            }
         }
 
         $this->response->html($this->template->layout('user_login', array(
             'errors' => $errors,
             'values' => $values,
             'no_layout' => true,
+            'redirect_query' => $redirect_query,
             'title' => t('Login')
         )));
     }

--- a/app/Core/Request.php
+++ b/app/Core/Request.php
@@ -136,4 +136,16 @@ class Request
         $name = 'HTTP_'.str_replace('-', '_', strtoupper($name));
         return isset($_SERVER[$name]) ? $_SERVER[$name] : '';
     }
+
+    /**
+     * Returns current request's query string, useful for redirecting
+     *
+     * @access public
+     * @return string
+     */
+    public function getQueryString()
+    {
+        return $_SERVER['QUERY_STRING'];
+    }
+
 }

--- a/app/Templates/user_login.php
+++ b/app/Templates/user_login.php
@@ -8,7 +8,7 @@
         <p class="alert alert-error"><?= Helper\escape($errors['login']) ?></p>
     <?php endif ?>
 
-    <form method="post" action="?controller=user&amp;action=check">
+    <form method="post" action="?controller=user&amp;action=check&amp;redirect_query=<?= urlencode($redirect_query) ?>">
 
         <?= Helper\form_csrf() ?>
 


### PR DESCRIPTION
Often when one clicks "View task on Kanboard" from the email notification, one gets redirected to the login page because the session has expired. But upon logging in one always ends up at the default board. This patch makes it so that information on the original target page is preserved so that Kanboard redirects to the original target page after successful login.
