### PR TITLE
Add dashboard showing project and task info for current user

### DIFF
--- a/app/Controller/App.php
+++ b/app/Controller/App.php
@@ -26,4 +26,28 @@ class App extends Base
             $this->redirectNoProject();
         }
     }
+    
+    public function dashboard()
+    {
+        // Get my projects
+        $board_selector = $this->projectPermission->getAllowedProjects($this->acl->getUserId());
+
+        // Get activity of tasks in my projects (including tasks assigned to others in my projects)
+        $related_activity = $this->user->getUserProjectActivity($this->acl->getUserId());
+
+        // Get tasks assigned to me
+        $assigned_tasks = $this->task->getRecentTasksAssigned($this->acl->getUserId(), 25);
+
+        // Get activity of tasks assigned to me
+        $assigned_activity = $this->user->getUserAssignedActivity($this->acl->getUserId());
+
+
+        $this->response->html($this->template->layout('app_dashboard', array(
+            'menu' => 'dashboard',
+            'board_selector' => $board_selector,
+            'assigned_tasks' => $assigned_tasks,
+            'assigned_activity' => $assigned_activity,
+            'related_activity' => $related_activity
+        )));
+    }
 }

--- a/app/Locales/de_DE/translations.php
+++ b/app/Locales/de_DE/translations.php
@@ -503,4 +503,9 @@ return array(
     // '[%s][Position Change] %s (#%d)' => '',
     // '[%s][Assignee Change] %s (#%d)' => '',
     // 'New password for the user "%s"' => '',
+    // 'Dashboard' => '',
+    // 'My projects' => '',
+    // 'Recent activity on my projects' => '',
+    // 'My recent assigned tasks' => '',
+    // 'Recent activity on my assigned tasks' => '',
 );

--- a/app/Locales/es_ES/translations.php
+++ b/app/Locales/es_ES/translations.php
@@ -503,4 +503,9 @@ return array(
     // '[%s][Position Change] %s (#%d)' => '',
     // '[%s][Assignee Change] %s (#%d)' => '',
     // 'New password for the user "%s"' => '',
+    // 'Dashboard' => '',
+    // 'My projects' => '',
+    // 'Recent activity on my projects' => '',
+    // 'My recent assigned tasks' => '',
+    // 'Recent activity on my assigned tasks' => '',
 );

--- a/app/Locales/fi_FI/translations.php
+++ b/app/Locales/fi_FI/translations.php
@@ -503,4 +503,9 @@ return array(
     // '[%s][Position Change] %s (#%d)' => '',
     // '[%s][Assignee Change] %s (#%d)' => '',
     // 'New password for the user "%s"' => '',
+    // 'Dashboard' => '',
+    // 'My projects' => '',
+    // 'Recent activity on my projects' => '',
+    // 'My recent assigned tasks' => '',
+    // 'Recent activity on my assigned tasks' => '',
 );

--- a/app/Locales/fr_FR/translations.php
+++ b/app/Locales/fr_FR/translations.php
@@ -503,4 +503,9 @@ return array(
     '[%s][Position Change] %s (#%d)' => '[%s][Changement de position] %s (#%d)',
     '[%s][Assignee Change] %s (#%d)' => '[%s][Changement d\'assigné] %s (#%d)',
     'New password for the user "%s"' => 'Nouveau mot de passe pour l\'utilisateur « %s »',
+    // 'Dashboard' => '',
+    // 'My projects' => '',
+    // 'Recent activity on my projects' => '',
+    // 'My recent assigned tasks' => '',
+    // 'Recent activity on my assigned tasks' => '',
 );

--- a/app/Locales/it_IT/translations.php
+++ b/app/Locales/it_IT/translations.php
@@ -503,4 +503,9 @@ return array(
     // '[%s][Position Change] %s (#%d)' => '',
     // '[%s][Assignee Change] %s (#%d)' => '',
     // 'New password for the user "%s"' => '',
+    // 'Dashboard' => '',
+    // 'My projects' => '',
+    // 'Recent activity on my projects' => '',
+    // 'My recent assigned tasks' => '',
+    // 'Recent activity on my assigned tasks' => '',
 );

--- a/app/Locales/pl_PL/translations.php
+++ b/app/Locales/pl_PL/translations.php
@@ -503,4 +503,9 @@ return array(
     // '[%s][Position Change] %s (#%d)' => '',
     // '[%s][Assignee Change] %s (#%d)' => '',
     // 'New password for the user "%s"' => '',
+    // 'Dashboard' => '',
+    // 'My projects' => '',
+    // 'Recent activity on my projects' => '',
+    // 'My recent assigned tasks' => '',
+    // 'Recent activity on my assigned tasks' => '',
 );

--- a/app/Locales/pt_BR/translations.php
+++ b/app/Locales/pt_BR/translations.php
@@ -503,4 +503,9 @@ return array(
     // '[%s][Position Change] %s (#%d)' => '',
     // '[%s][Assignee Change] %s (#%d)' => '',
     // 'New password for the user "%s"' => '',
+    // 'Dashboard' => '',
+    // 'My projects' => '',
+    // 'Recent activity on my projects' => '',
+    // 'My recent assigned tasks' => '',
+    // 'Recent activity on my assigned tasks' => '',
 );

--- a/app/Locales/ru_RU/translations.php
+++ b/app/Locales/ru_RU/translations.php
@@ -503,4 +503,9 @@ return array(
     // '[%s][Position Change] %s (#%d)' => '',
     // '[%s][Assignee Change] %s (#%d)' => '',
     // 'New password for the user "%s"' => '',
+    // 'Dashboard' => '',
+    // 'My projects' => '',
+    // 'Recent activity on my projects' => '',
+    // 'My recent assigned tasks' => '',
+    // 'Recent activity on my assigned tasks' => '',
 );

--- a/app/Locales/sv_SE/translations.php
+++ b/app/Locales/sv_SE/translations.php
@@ -503,4 +503,9 @@ return array(
     // '[%s][Position Change] %s (#%d)' => '',
     // '[%s][Assignee Change] %s (#%d)' => '',
     // 'New password for the user "%s"' => '',
+    // 'Dashboard' => '',
+    // 'My projects' => '',
+    // 'Recent activity on my projects' => '',
+    // 'My recent assigned tasks' => '',
+    // 'Recent activity on my assigned tasks' => '',
 );

--- a/app/Locales/zh_CN/translations.php
+++ b/app/Locales/zh_CN/translations.php
@@ -503,4 +503,9 @@ return array(
     // '[%s][Position Change] %s (#%d)' => '',
     // '[%s][Assignee Change] %s (#%d)' => '',
     // 'New password for the user "%s"' => '',
+    // 'Dashboard' => '',
+    // 'My projects' => '',
+    // 'Recent activity on my projects' => '',
+    // 'My recent assigned tasks' => '',
+    // 'Recent activity on my assigned tasks' => '',
 );

--- a/app/Model/Acl.php
+++ b/app/Model/Acl.php
@@ -30,7 +30,7 @@ class Acl extends Base
      * @var array
      */
     private $user_actions = array(
-        'app' => array('index'),
+        'app' => array('index', 'dashboard'),
         'board' => array('index', 'show', 'save', 'check', 'changeassignee', 'updateassignee', 'changecategory', 'updatecategory'),
         'project' => array('tasks', 'index', 'forbidden', 'search', 'export', 'show', 'activity'),
         'user' => array('index', 'edit', 'forbidden', 'logout', 'index', 'show', 'external', 'unlinkgoogle', 'unlinkgithub', 'sessions', 'removesession', 'last', 'notifications', 'password'),

--- a/app/Model/Task.php
+++ b/app/Model/Task.php
@@ -71,6 +71,41 @@ class Task extends Base
     }
 
     /**
+     * Get a list of recently updated tasks assigned to user
+     *
+     * @access public
+     * @param  integer   $user_id       User id
+     * @param  integer   $limit         Max number of rows to fetch
+     * @return array
+     */
+    public function getRecentTasksAssigned($user_id, $limit=false)
+    {
+        $tasks = $this->db->table(self::TABLE)
+                    ->columns(
+                        self::TABLE.'.id',
+                        self::TABLE.'.title',
+                        self::TABLE.'.date_due',
+                        self::TABLE.'.project_id',
+                        Project::TABLE.'.name AS project_name',
+                        User::TABLE.'.username AS assignee_username',
+                        User::TABLE.'.name AS assignee_name',
+                        'columns.title AS column_title'
+                    )
+                    ->join(Project::TABLE, 'id', 'project_id')
+                    ->join(User::TABLE, 'id', 'owner_id')
+                    ->join('columns', 'id', 'column_id')
+                    ->eq(Project::TABLE.'.is_active', 1)
+                    ->eq(self::TABLE.'.is_active', 1)
+                    ->eq(self::TABLE.'.owner_id', $user_id)
+                    ->desc(self::TABLE.'.date_modification');
+        if ($limit) {
+            $tasks->limit($limit);
+        }
+
+        return $tasks->findAll();;
+    }
+
+    /**
      * Get task details (fetch more information from other tables)
      *
      * @access public

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -426,4 +426,66 @@ class User extends Base
 
         return t('Unknown');
     }
+
+    /**
+     * Get activity on user's projects
+     *
+     * @access public
+     * @param  integer   $user_id   User id
+     * @return array
+     */
+    public function getUserProjectActivity($user_id)
+    {
+        $comments = $this->commentHistory->getAllContentRelatedTo($user_id, 25);
+        $tasks = $this->taskHistory->getAllContentRelatedTo($user_id, 25);
+        $subtasks = $this->subtaskHistory->getAllContentRelatedTo($user_id, 25);
+        $activity = array();
+
+        foreach ($tasks as &$task) {
+            $activity[$task['date_creation'].'-'.$task['id']] = $task;
+        }
+
+        foreach ($subtasks as &$subtask) {
+            $activity[$subtask['date_creation'].'-'.$subtask['id']] = $subtask;
+        }
+
+        foreach ($comments as &$comment) {
+            $activity[$comment['date_creation'].'-'.$comment['id']] = $comment;
+        }
+
+        krsort($activity);
+        
+        return $activity;
+    }
+
+    /**
+     * Get activity on user's assigned tasks
+     *
+     * @access public
+     * @param  integer   $user_id   User id
+     * @return array
+     */
+    public function getUserAssignedActivity($user_id)
+    {
+        $comments = $this->commentHistory->getAllContentAssignedTo($user_id, 25);
+        $tasks = $this->taskHistory->getAllContentAssignedTo($user_id, 25);
+        $subtasks = $this->subtaskHistory->getAllContentAssignedTo($user_id, 25);
+        $activity = array();
+
+        foreach ($tasks as &$task) {
+            $activity[$task['date_creation'].'-'.$task['id']] = $task;
+        }
+
+        foreach ($subtasks as &$subtask) {
+            $activity[$subtask['date_creation'].'-'.$subtask['id']] = $subtask;
+        }
+
+        foreach ($comments as &$comment) {
+            $activity[$comment['date_creation'].'-'.$comment['id']] = $comment;
+        }
+
+        krsort($activity);
+
+        return $activity;
+    }
 }

--- a/app/Templates/app_dashboard.php
+++ b/app/Templates/app_dashboard.php
@@ -1,0 +1,72 @@
+<section id="main">
+
+    <div class="page-header">
+        <h2>
+            <?= t('Dashboard'); ?>
+        </h2>
+    </div>
+    <section id="dashboard">
+        <h3>
+            <a class="toggle-section" data-target="projects-div" href="#"><?= t('My projects') ?></a> |
+            <a class="toggle-section" data-target="related-activity-div" href="#"><?= t('Recent activity on my projects') ?></a> |
+            <a class="toggle-section" data-target="assigned-tasks-div" href="#"><?= t('My recent assigned tasks') ?></a> |
+            <a class="toggle-section" data-target="assigned-activity-div" href="#"><?= t('Recent activity on my assigned tasks') ?></a>
+        </h3>
+        <div id="projects-div" class="dashboard-block">
+        <ul class="project-listing">
+        <?php foreach($board_selector as $board_id => $board_name): ?>
+            <li><a href="?controller=board&action=show&project_id=<?= $board_id ?>"><?= Helper\escape($board_name) ?></a></li>
+        <?php endforeach ?>
+        </ul>
+        </div>
+        <div id="related-activity-div" style="display:none" class="dashboard-block">
+        <?php foreach ($related_activity as $event): ?>
+        <div class="activity-event">
+            <p class="activity-datetime">
+                <?php if ($event['event_type'] === 'task'): ?>
+                    <i class="fa fa-newspaper-o"></i>
+                <?php elseif ($event['event_type'] === 'subtask'): ?>
+                    <i class="fa fa-tasks"></i>
+                <?php elseif ($event['event_type'] === 'comment'): ?>
+                    <i class="fa fa-comments-o"></i>
+                <?php endif ?>
+                &nbsp;<?= dt('%B %e, %Y at %k:%M %p', $event['date_creation']) ?>
+                &nbsp;<?= t('Project') ?>: <a href="?controller=board&action=show&project_id=<?= $event['project_id'] ?>"><?= $event['project_name'] ?></a>
+            </p>
+            <div class="activity-content"><?= $event['event_content'] ?></div>
+        </div>
+        <?php endforeach ?>
+        
+        </div>
+        <div id="assigned-tasks-div" style="display:none" class="dashboard-block">
+        <ul class="task-listing">
+        <?php foreach ($assigned_tasks as $task): ?>
+            <li><a href="?controller=task&action=show&task_id=<?= $task['id'] ?>">#<?= $task['id'] ?></a> <?= $task['title'] ?><br />
+                <ul class="task-listing-description">
+                    <li>(<?= $task['column_title'] ?>) - 
+                    <a href="?controller=board&action=show&project_id=<?= $task['project_id'] ?>"><?= Helper\escape($task['project_name']) ?></a></li>
+                </ul>
+            </li>
+        <?php endforeach ?>
+        </ul>
+        </div>
+        <div id="assigned-activity-div" style="display:none" class="dashboard-block">
+        <?php foreach ($assigned_activity as $event): ?>
+        <div class="activity-event">
+            <p class="activity-datetime">
+                <?php if ($event['event_type'] === 'task'): ?>
+                    <i class="fa fa-newspaper-o"></i>
+                <?php elseif ($event['event_type'] === 'subtask'): ?>
+                    <i class="fa fa-tasks"></i>
+                <?php elseif ($event['event_type'] === 'comment'): ?>
+                    <i class="fa fa-comments-o"></i>
+                <?php endif ?>
+                &nbsp;<?= dt('%B %e, %Y at %k:%M %p', $event['date_creation']) ?>
+                &nbsp;<?= t('Project') ?>: <a href="?controller=board&action=show&project_id=<?= $event['project_id'] ?>"><?= $event['project_name'] ?></a>
+            </p>
+            <div class="activity-content"><?= $event['event_content'] ?></div>
+        </div>
+        <?php endforeach ?>
+        </div>
+    </section>
+</section>

--- a/app/Templates/layout.php
+++ b/app/Templates/layout.php
@@ -50,6 +50,9 @@
                         </select>
                     </li>
                     <?php endif ?>
+                    <li <?= isset($menu) && $menu === 'dashboard' ? 'class="active"' : '' ?>>
+                        <a href="?controller=app&action=dashboard"><?= t('Dashboard') ?></a>
+                    </li>
                     <li <?= isset($menu) && $menu === 'boards' ? 'class="active"' : '' ?>>
                         <a href="?controller=board"><?= t('Boards') ?></a>
                     </li>

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1179,3 +1179,39 @@ tr td.task-orange,
         font-size: 1.5em;
     }
 }
+
+/* dashboard */
+.task-listing {
+    border-left: 3px solid #000;
+    margin-left: 35px;
+    padding-bottom: 10px;
+    max-width: 700px;
+}
+
+.task-listing li {
+    font-size: 1.3em;
+    line-height: 1.7em;
+    list-style-type: none;
+    margin-left: 20px;
+    border-bottom: 1px dashed #ccc;
+}
+
+.task-listing li:hover {
+    border-color: #333;
+}
+
+.task-listing a {
+    text-decoration: none;
+}
+
+.task-listing a:hover,
+.task-listing a:focus {
+    color: #000;
+}
+
+.task-listing-description li {
+    font-size: 0.8em;
+    line-height: 1.0em;
+    color: #aaa;
+    padding-top: 5px;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -272,6 +272,29 @@ Kanboard.Project = (function() {
 
 })();
 
+// Dashboard related functions
+Kanboard.Dashboard = (function() {
+
+    return {
+        Init: function() {
+            // Project select box
+            $("#board-selector").chosen({
+                width: 180
+            });
+
+            $("#board-selector").change(function() {
+                window.location = "?controller=board&action=show&project_id=" + $(this).val();
+            });
+            
+            $('.toggle-section').click(function() {
+                $('.dashboard-block').hide();
+                $('#' + $(this).data("target")).show();
+                return false;
+            });
+        }
+    };
+
+})();
 
 // Initialization
 $(function() {
@@ -284,5 +307,8 @@ $(function() {
     }
     else if ($("#project-section").length) {
         Kanboard.Project.Init();
+    }
+    else if ($("#dashboard").length) {
+        Kanboard.Dashboard.Init();
     }
 });


### PR DESCRIPTION
We have about 10-15 projects now and have many users that are involved in multiple projects. Under such conditions we ran into some inconveniences in particular it's somewhat difficult to effectively manage one's tasks across multiple projects. This is a proposed solution - to have a user-centric "dashboard" page that shows links to a user's projects, combined activity feed of all that user's projects minus his own actions, list of user's assigned tasks across all his projects, and activity feed of that user's assigned tasks only.

We've been running with this for awhile now and think it's valuable. It'll also partially address issue #242 . I haven't gotten to writing tests for the new functions I introduced yet, but I figure it'd be good to try to get this in first, I'll try and follow up with some tests if this gets merged. I'm also thinking of adding an option to allow setting this dashboard page as default landing page after login.
