### PR TITLE
Dont send notifications to people who dont have access to a project

### DIFF
--- a/app/Model/Notification.php
+++ b/app/Model/Notification.php
@@ -55,6 +55,11 @@ class Notification extends Base
                                  ->eq('user_id', $user['id'])
                                  ->findAllByColumn('project_id');
 
+            // check first if user has access to this project in the first place
+            if (! $this->projectPermission->isUserAllowed($project_id, $user['id'])) {
+                unset($users[$index]);
+            }
+            
             // The user have selected only some projects
             if (! empty($projects)) {
 


### PR DESCRIPTION
Currently email notifications ignore user access to projects, so that, for eg, a user that sets his/her settings to receive all email notifications will receive notifications even for projects he/she is not supposed to have access to. Small patch to fix this.
