### PR TITLE
Allow enter new comments directly from task summary page

### DIFF
--- a/app/Controller/Task.php
+++ b/app/Controller/Task.php
@@ -63,6 +63,7 @@ class Task extends Base
             'task' => $task,
             'columns_list' => $this->board->getColumnsList($task['project_id']),
             'colors_list' => $this->color->getList(),
+            'user_id' => $this->acl->getUserId(),
             'menu' => 'tasks',
             'title' => $task['title'],
         )));

--- a/app/Templates/comment_create.php
+++ b/app/Templates/comment_create.php
@@ -11,7 +11,9 @@
 
     <div class="form-actions">
         <input type="submit" value="<?= t('Save') ?>" class="btn btn-blue"/>
-        <?= t('or') ?>
-        <a href="?controller=task&amp;action=show&amp;task_id=<?= $task['id'] ?>"><?= t('cancel') ?></a>
+        <? if (!$skip_cancel): ?>
+            <?= t('or') ?>
+            <a href="?controller=task&amp;action=show&amp;task_id=<?= $task['id'] ?>"><?= t('cancel') ?></a>
+        <? endif ?>
     </div>
 </form>

--- a/app/Templates/task_show.php
+++ b/app/Templates/task_show.php
@@ -12,3 +12,11 @@
 <?php endif ?>
 
 <?= Helper\template('task_comments', array('task' => $task, 'comments' => $comments)) ?>
+
+<?= Helper\template('comment_create', array('skip_cancel' => true,
+                                        'values' => array(
+                                            'user_id' => $user_id,
+                                            'task_id' => $task['id'],
+                                        ),
+                                        'errors' => array(),
+                                        'task' => $task)); ?>


### PR DESCRIPTION
It's not so nice to have to go to a separate page to enter a new comment, especially when one often needs to refer to the task description/comment thread. This patch renders the comment form at the bottom of the task page comment thread.
