### PR TITLE
Fix RSS Feeds

### DIFF
--- a/app/Controller/Project.php
+++ b/app/Controller/Project.php
@@ -364,7 +364,7 @@ class Project extends Base
         }
 
         $this->response->xml($this->template->load('project_feed', array(
-            'events' => $this->projectActivity->getAll($project['id']),
+            'events' => $this->projectActivity->getProject($project['id']),
             'project' => $project,
         )));
     }


### PR DESCRIPTION
[Controller\Project::feed](https://github.com/fguillot/kanboard/blob/master/app/Controller/Project.php#L351-L370) still calls `Model\ProjectActivity::getAll` which was renamed to `getProject` in [286b1935663ef3071ad6a0aae3078ad3a42b48e4](https://github.com/fguillot/kanboard/commit/286b1935663ef3071ad6a0aae3078ad3a42b48e4#diff-75fabb5d8cad19628ef2e510fecd927bL64) causing 

``` php
PHP Fatal error:  Call to undefined method Model\ProjectActivity::getAll() in /kanboard/app/Controller/Project.php on line 367
PHP Stack trace:
PHP   1. {main}() /kanboard/index.php:0
PHP   2. Core\Router->execute() /kanboard/index.php:9
PHP   3. Core\Router->load() /kanboard/app/Core/Router.php:109
PHP   4. Controller\Project->feed() /kanboard/app/Core/Router.php:90
192.168.3.42:8526 [500]: /?controller=project&action=feed&token=d69a6735acb1517262e3cc6f41137838c12deb0d35899696b4bbe227697e - Call to undefined method Model\ProjectActivity::getAll() in /kanboard/app/Controller/Project.php on line 367
```
