### PR TITLE
Edit-Links + FA icons on board_index

### DIFF
--- a/app/Templates/board_index.php
+++ b/app/Templates/board_index.php
@@ -2,6 +2,9 @@
 
     <div class="page-header board">
         <h2>
+            <?php if(Helper\is_admin()): ?>
+            <a href="?controller=project&amp;action=show&amp;project_id=<?= $current_project_id ?>"><i class="fa fa-cog"></i></a>
+            <?php endif ?>
             <?= t('Project "%s"', $current_project_name) ?>
         </h2>
     </div>
@@ -17,9 +20,12 @@
                 <?= Helper\form_select('category_id', $categories, $filters) ?>
             </li>
             <li><a href="#" id="filter-due-date"><?= t('Filter by due date') ?></a></li>
-            <li><a href="?controller=project&amp;action=search&amp;project_id=<?= $current_project_id ?>"><?= t('Search') ?></a></li>
-            <li><a href="?controller=project&amp;action=tasks&amp;project_id=<?= $current_project_id ?>"><?= t('Completed tasks') ?></a></li>
-            <li><a href="?controller=project&amp;action=activity&amp;project_id=<?= $current_project_id ?>"><?= t('Activity') ?></a></li>
+            <li><i class="fa fa-search"></i> <a href="?controller=project&amp;action=search&amp;project_id=<?= $current_project_id ?>"><?= t('Search') ?></a></li>
+            <li><i class="fa fa-check-square-o"></i> <a href="?controller=project&amp;action=tasks&amp;project_id=<?= $current_project_id ?>"><?= t('Completed tasks') ?></a></li>
+            <li><i class="fa fa-dashboard"></i> <a href="?controller=project&amp;action=activity&amp;project_id=<?= $current_project_id ?>"><?= t('Activity') ?></a></li>
+            <?php if(Helper\is_admin()): ?>
+            <li><i class="fa fa-cog"></i> <a href="?controller=board&amp;action=edit&amp;project_id=<?= $current_project_id ?>"><?= t('Edit board') ?></a></li>
+            <?php endif ?>
         </ul>
     </div>
 


### PR DESCRIPTION
Adding edit links for board and project to board_index and putting some nice FA icons before board links on board_index.

Edit:
Maybe I should write something about why I created the PR in the first place...
I constantly was annoyed be the click amounts to do before I can edit a config for a board or a project. I came up with the simple idea to just add short links in the form of a cog for the currently displayed project and board, hoping the links stay out of peoples ways. The FA icons are just my personal taste... I like FA icons before / as links as important as the board links.
