### PR TITLE
Update helpers.php, function a()

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -570,7 +570,7 @@ function form_numeric($name, $values = array(), array $errors = array(), array $
  */
 function a($label, $controller, $action, array $params = array(), $csrf = false, $class = '')
 {
-    return '<a href="'.u($controller, $action, $params, $csrf).'" class="'.$class.'"/>'.$label.'</a>';
+    return '<a href="'.u($controller, $action, $params, $csrf).'" class="'.$class.'">'.$label.'</a>';
 }
 
 /**


### PR DESCRIPTION
In helpers.php is a function a() used for link generation, i. e. by markdown(). In the opening <a> element was a /, which is ignored by many (all? most?) browsers, but leads to interesting result with jQuery inserting of HTML generated by that function.

I stumbled upon this while developing code for a preview of textareas and not being able to show a link to a task (#1).
