### PR TITLE
Script to find locale strings missing from translations.php

### DIFF
--- a/scripts/find-strings.sh
+++ b/scripts/find-strings.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-REF_LANG=${1:=fr_FR}
+REF_LANG=${1:-fr_FR}
 
 ###
 APP_DIR=`dirname $0`/../app


### PR DESCRIPTION
I think it could be of great help to have a script that automatically gets all the t() and e() calls and checks if the used string is within a languages translations.php.

The script itself should be quite self explaining, also the regex gave me some headaches.
