### PR TITLE
docs, update: tell users to copy entire `data` dir

### DIFF
--- a/docs/update.markdown
+++ b/docs/update.markdown
@@ -8,7 +8,7 @@ From the archive (stable version)
 
 1. Close your session (logout)
 2. Rename your actual Kanboard directory (to keep a backup)
-3. Uncompress the new archive and copy your database file `db.sqlite` in the directory `data`
+3. Uncompress the new archive and copy your `data` directory to the newly uncompressed directory.
 4. Make the directory `data` writeable by the web server user
 5. Login and check if everything is ok
 6. Remove the old Kanboard directory


### PR DESCRIPTION
Previously, the document told users to only copy `data/db.sqlite`.
However, if there are attachments uploaded (stored in `data/files`),
they will be lost.
To solve this, this commit changes the doc so it tells users
to copy the entire `data` dir.

This resolves #405 
