### PR TITLE
Use shorter date display, and add icon.

### DIFF
--- a/app/Template/board/task.php
+++ b/app/Template/board/task.php
@@ -83,7 +83,7 @@
 
     <?php if (! empty($task['date_due'])): ?>
     <div class="task-board-date <?= time() > $task['date_due'] ? 'task-board-date-overdue' : '' ?>">
-        <?= dt('%B %e, %Y', $task['date_due']) ?>
+        <i class="fa fa-calendar"></i> <?= dt('%b %e, %Y', $task['date_due']) ?>
     </div>
     <?php endif ?>
 


### PR DESCRIPTION
This reduces the clutter on large board / small screen, and avoids overlapping/truncated text.
