### PR TITLE
Popover css small screen fix

### DIFF
--- a/assets/css/popover.css
+++ b/assets/css/popover.css
@@ -1,19 +1,19 @@
 /* popover */
 #popover-container {
-position: fixed;
-top: 0;
-left: 0;
-width: 100%;
-height: 100%;
-background: rgba(0, 0, 0, 0.8);
-overflow: auto;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    overflow: auto;
 }
 #popover-content {
-position: absolute;
-width: 70%;
-margin: 0 0 0 -35%;
-left: 50%;
-top: 5%;
-padding: 15px;
-background: #fff;
+    position: absolute;
+    width: 70%;
+    margin: 0 0 0 -35%;
+    left: 50%;
+    top: 5%;
+    padding: 15px;
+    background: #fff;
 }


### PR DESCRIPTION
resulting change: on small screens you can now scroll to reach the bottom of modal popover windows, fixing Issue #469. 

I was  unable to run "make-assets.sh" (did not find the files); tested by manually copying to app.css; Displays correctly in Firefox (34) and Chromium (39)
