### PR TITLE
Add column dropdown to edit task

### DIFF
--- a/app/Controller/TaskModificationController.php
+++ b/app/Controller/TaskModificationController.php
@@ -101,6 +101,7 @@ class TaskModificationController extends BaseController
             'users_list' => $this->projectUserRoleModel->getAssignableUsersList($task['project_id']),
             'colors_list' => $this->colorModel->getList(),
             'categories_list' => $this->categoryModel->getList($task['project_id']),
+            'columns_list' => $this->columnModel->getList($task['project_id']),
         )));
     }
 

--- a/app/Template/task_modification/edit_task.php
+++ b/app/Template/task_modification/edit_task.php
@@ -9,6 +9,7 @@
     <div class="form-column">
         <?= $this->form->label(t('Title'), 'title') ?>
         <?= $this->form->text('title', $values, $errors, array('autofocus', 'required', 'maxlength="200"', 'tabindex="1"')) ?>
+        <?= $this->task->selectColumn($columns_list, $values, $errors) ?>
         <?= $this->task->selectAssignee($users_list, $values, $errors) ?>
         <?= $this->task->selectCategory($categories_list, $values, $errors) ?>
         <?= $this->task->selectPriority($project, $values) ?>


### PR DESCRIPTION
This allows users to move a task to a different column without having
to drag it.

fix #1879