### PR TITLE
Allow Unassigned task creation in team projects with one active user …

### DIFF
--- a/app/Controller/TaskBulkController.php
+++ b/app/Controller/TaskBulkController.php
@@ -32,7 +32,7 @@ class TaskBulkController extends BaseController
             'project' => $project,
             'values' => $values,
             'errors' => $errors,
-            'users_list' => $this->projectUserRoleModel->getAssignableUsersList($project['id'], true, false, true),
+            'users_list' => $this->projectUserRoleModel->getAssignableUsersList($project['id'], true, false, $project['is_private']),
             'colors_list' => $this->colorModel->getList(),
             'categories_list' => $this->categoryModel->getList($project['id']),
         )));

--- a/app/Controller/TaskCreationController.php
+++ b/app/Controller/TaskCreationController.php
@@ -40,7 +40,7 @@ class TaskCreationController extends BaseController
             'errors' => $errors,
             'values' => $values + array('project_id' => $project['id']),
             'columns_list' => $this->columnModel->getList($project['id']),
-            'users_list' => $this->projectUserRoleModel->getAssignableUsersList($project['id'], true, false, true),
+            'users_list' => $this->projectUserRoleModel->getAssignableUsersList($project['id'], true, false, $project['is_private']),
             'categories_list' => $this->categoryModel->getList($project['id']),
             'swimlanes_list' => $swimlanes_list,
             'title' => $project['name'].' &gt; '.t('New task')

--- a/app/Controller/TaskGanttCreationController.php
+++ b/app/Controller/TaskGanttCreationController.php
@@ -35,7 +35,7 @@ class TaskGanttCreationController extends BaseController
             'project' => $project,
             'errors' => $errors,
             'values' => $values,
-            'users_list' => $this->projectUserRoleModel->getAssignableUsersList($project['id'], true, false, true),
+            'users_list' => $this->projectUserRoleModel->getAssignableUsersList($project['id'], true, false, $project['is_private']),
             'categories_list' => $this->categoryModel->getList($project['id']),
             'swimlanes_list' => $this->swimlaneModel->getList($project['id'], false, true),
             'title' => $project['name'].' &gt; '.t('New task')


### PR DESCRIPTION
I create some team projects and start to creating tasks to see the whole picture.
Users are not assigned to projects yet, so all of the tasks are assigned to me because of missing Unassigned option in assignee selection list.

This makes difficult to distinguish between these newly created tasks and tasks that are actually assigned.

I see a parameter for getAssignableUsersList() function named single_user.
I think it would be better to allow Unassigned option for Team projects.
