### PR TITLE
Hide empty parts of task details page

### DIFF
--- a/app/Template/task/show.php
+++ b/app/Template/task/show.php
@@ -7,9 +7,12 @@
     'editable' => $this->user->hasProjectAccess('TaskModificationController', 'edit', $project['id']),
 )) ?>
 
+<?php if(!empty($task['description'])): ?>
 <?= $this->hook->render('template:task:show:before-description', array('task' => $task, 'project' => $project)) ?>
 <?= $this->render('task/description', array('task' => $task)) ?>
+<?php endif ?>
 
+<?php if(!empty($subtasks)): ?>
 <?= $this->hook->render('template:task:show:before-subtasks', array('task' => $task, 'project' => $project)) ?>
 <?= $this->render('subtask/show', array(
     'task' => $task,
@@ -17,7 +20,9 @@
     'project' => $project,
     'editable' => true,
 )) ?>
+<?php endif ?>
 
+<?php if(!empty($internal_links)): ?>
 <?= $this->hook->render('template:task:show:before-internal-links', array('task' => $task, 'project' => $project)) ?>
 <?= $this->render('task_internal_link/show', array(
     'task' => $task,
@@ -27,21 +32,27 @@
     'editable' => true,
     'is_public' => false,
 )) ?>
+<?php endif ?>
 
+<?php if(!empty($external_links)): ?>
 <?= $this->hook->render('template:task:show:before-external-links', array('task' => $task, 'project' => $project)) ?>
 <?= $this->render('task_external_link/show', array(
     'task' => $task,
     'links' => $external_links,
     'project' => $project,
 )) ?>
+<?php endif ?>
 
+<?php if(!empty($files)): ?>
 <?= $this->hook->render('template:task:show:before-attachments', array('task' => $task, 'project' => $project)) ?>
 <?= $this->render('task_file/show', array(
     'task' => $task,
     'files' => $files,
     'images' => $images
 )) ?>
+<?php endif ?>
 
+<?php if(!empty($comments)): ?>
 <?= $this->hook->render('template:task:show:before-comments', array('task' => $task, 'project' => $project)) ?>
 <?= $this->render('comments/show', array(
     'task' => $task,
@@ -49,5 +60,6 @@
     'project' => $project,
     'editable' => $this->user->hasProjectAccess('CommentController', 'edit', $project['id']),
 )) ?>
+<?php endif ?>
 
 <?= $this->hook->render('template:task:show:bottom', array('task' => $task, 'project' => $project)) ?>


### PR DESCRIPTION
A little patch to hide empty folding lists on task detail page.

For example, if the task has no internal links then no "Internal Links" folder will be shown. But if the task has internal links then that folder and it's content will be shown as before.

Just to make the details view more convenient.

