### PR TITLE
Allow priority changes for inverted priority scales

### DIFF
--- a/app/Helper/TaskHelper.php
+++ b/app/Helper/TaskHelper.php
@@ -148,7 +148,7 @@ class TaskHelper extends Base
     {
         $html = '';
 
-        if ($project['priority_end'] > $project['priority_start']) {
+        if ($project['priority_end'] != $project['priority_start']) {
             $range = range($project['priority_start'], $project['priority_end']);
             $options = array_combine($range, $range);
             $values += array('priority' => $project['priority_default']);

--- a/app/Helper/TaskHelper.php
+++ b/app/Helper/TaskHelper.php
@@ -228,7 +228,7 @@ class TaskHelper extends Base
     {
         $html = '';
 
-        if ($project['priority_end'] > $project['priority_start']) {
+        if ($project['priority_end'] != $project['priority_start']) {
             $html .= '<span class="task-board-priority" title="'.t('Task priority').'">';
             $html .= $task['priority'] >= 0 ? 'P'.$task['priority'] : '-P'.abs($task['priority']);
             $html .= '</span>';


### PR DESCRIPTION
It's common to want an 'inverted' priority range, for example where P0 is the highest. The task helper logic would hide priority editing when `priority_end` was larger than `priority_start`. This logic change allows it by checking that `priority_start` and `priority_end` are different instead.