### PR TITLE
fix selfsigned ssl certificates swift mail

### DIFF
--- a/app/Core/Mail/Transport/Smtp.php
+++ b/app/Core/Mail/Transport/Smtp.php
@@ -24,6 +24,9 @@ class Smtp extends Mail
         $transport->setUsername(MAIL_SMTP_USERNAME);
         $transport->setPassword(MAIL_SMTP_PASSWORD);
         $transport->setEncryption(MAIL_SMTP_ENCRYPTION);
+        if (HTTP_VERIFY_SSL_CERTIFICATE === false) {
+            $transport->setStreamOptions(array('ssl' => array('allow_self_signed' => true, 'verify_peer' => false, 'verify_peer_name' => false,)));
+        }
 
         return $transport;
     }


### PR DESCRIPTION
Related to: #2162

This feature request makes kanboard connect with TLS/SSL to mailservers with self-signed certificates.

I took the source from 

https://github.com/kanboard/kanboard/blob/cf7bac18607d03dbd9420e9f1feef0aaeb0b8875/app/Core/Http/Client.php#L214

and applied it to app/Core/Mail/Transport/Smtp.php


**Steps to reproduce**

1. Host Kanboard on PHP 5.6+
2. Mailserver with self-signed certificate
3. Try to authenticate

**Configuration**

Kanboard version:  Docker: kanboard/kanboard ~ v1.0.32 
PHP version: 7.0.8
