### PR TITLE
fixed description in doc for this->hook->on to comply with new HookHelper args

### DIFF
--- a/doc/plugin-hooks.markdown
+++ b/doc/plugin-hooks.markdown
@@ -105,7 +105,7 @@ class Plugin extends Base
 {
     public function initialize()
     {
-        $this->hook->on('template:layout:css', 'plugins/Css/skin.css');
+        $this->hook->on('template:layout:css', array('template' => 'plugins/Css/skin.css'));
     }
 }
 ```


### PR DESCRIPTION
The HookHelper has changed to allow custom variables and such. However, with this change the $this->hook->on() method has a different call. I changed this in the documentation.