### PR TITLE
Update Cloudron source code link

### DIFF
--- a/doc/cloudron.markdown
+++ b/doc/cloudron.markdown
@@ -17,12 +17,12 @@ becomes a Kanboard administrator automatically.
 Installing Plugins
 ------------------
 
-Plugins can be installed and configured using the [Cloudron CLI](https://cloudron.io/references/cli.html)
+Plugins can be installed and configured using the [Cloudron CLI](https://git.cloudron.io/cloudron/cloudron-cli)
 tool. See the [app description](https://cloudron.io/appstore.html?app=net.kanboard.cloudronapp) for
 more information.
 
 Application Source code
 ----------------------
 
-The source code for the Cloudron app is [here](https://github.com/cloudron-io/kanboard-app).
+The source code for the Cloudron app is [here](https://git.cloudron.io/cloudron/kanboard-app).
 

--- a/doc/ru_RU/cloudron.markdown
+++ b/doc/ru_RU/cloudron.markdown
@@ -22,7 +22,7 @@
 
 
 
-Плагины могут быть установлены и настроены с помощью утилиты [Cloudron CLI](https://cloudron.io/references/cli.html). Для подробной информации смотрите [описание приложения](https://cloudron.io/appstore.html?app=net.kanboard.cloudronapp).
+Плагины могут быть установлены и настроены с помощью утилиты [Cloudron CLI](https://git.cloudron.io/cloudron/kanboard-app). Для подробной информации смотрите [описание приложения](https://cloudron.io/appstore.html?app=net.kanboard.cloudronapp).
 
 
 
@@ -31,7 +31,7 @@
 
 
 
-Исходный код приложения Cloudron находится [здесь](https://github.com/cloudron-io/kanboard-app).
+Исходный код приложения Cloudron находится [здесь](https://git.cloudron.io/cloudron/kanboard-app).
 
 
 


### PR DESCRIPTION
We moved our source code from GitHub to GitLab.