### PR TITLE
array_combine error on task creation

### DIFF
--- a/app/Core/ExternalTask/ExternalTaskManager.php
+++ b/app/Core/ExternalTask/ExternalTaskManager.php
@@ -48,6 +48,8 @@ class ExternalTaskManager
     public function getProvidersList()
     {
         $providers = array_keys($this->providers);
-        return array_combine($providers, $providers);
+        if (count($providers)) {
+            return array_combine($providers, $providers);
+        }
     }
 }


### PR DESCRIPTION
PHP 5.3 throws error
Warning: array_combine(): Both parameters should have at least 1 element in /var/www/ccc/kanboard/app/Core/ExternalTask/ExternalTaskManager.php on line 51

This PR fixes this :smile: 

Have a nice day!
![array_combine](https://cloud.githubusercontent.com/assets/12938119/21344101/5ee03f92-c69a-11e6-80a8-ea6c031155aa.jpg)
