### PR TITLE
Fix Kanboard installation errors on MySQL 8.0.0

### DIFF
--- a/app/Schema/Mysql.php
+++ b/app/Schema/Mysql.php
@@ -63,9 +63,9 @@ function version_113(PDO $pdo)
     $pdo->exec("
         CREATE TABLE project_has_roles (
             role_id INT NOT NULL AUTO_INCREMENT,
-            role VARCHAR(255) NOT NULL,
+            `role` VARCHAR(255) NOT NULL,
             project_id INT NOT NULL,
-            UNIQUE(project_id, role),
+            UNIQUE(project_id, `role`),
             FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE,
             PRIMARY KEY(role_id)
         ) ENGINE=InnoDB CHARSET=utf8


### PR DESCRIPTION
As per MySQL 8.0.0 [**Keywords and Reserved Words**](https://dev.mysql.com/doc/refman/8.0/en/keywords.html) **role** is a reserved keyword.
This is a quick and dirty fix for **"Internal Error: Unable to run SQL migrations: Running migration \Schema\version_113, SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'role VARCHAR(255) NOT NULL,"**.

