### PR TITLE
Disable auto-assignment in task dialogs

### DIFF
--- a/app/Template/task_creation/show.php
+++ b/app/Template/task_creation/show.php
@@ -16,7 +16,8 @@
 
         <div class="task-form-secondary-column">
             <?= $this->task->renderColorField($values) ?>
-            <?= $this->task->renderAssigneeField($users_list, $values, $errors) ?>
+            <?php $filtered_values = array_filter($values, function ($key) { return $key != 'owner_id'; }, ARRAY_FILTER_USE_KEY); ?>
+            <?= $this->task->renderAssigneeField($users_list, $filtered_values, $errors) ?>
             <?= $this->task->renderCategoryField($categories_list, $values, $errors) ?>
             <?= $this->task->renderSwimlaneField($swimlanes_list, $values, $errors) ?>
             <?= $this->task->renderColumnField($columns_list, $values, $errors) ?>


### PR DESCRIPTION
In most cases you don't want to automatically self-assign newly created tasks.
Having to manually change the assignee field every time you want to create a new
task is cumbersome. Additionally, the "assign me" button is kind of useless when
the creator is pre-selected anyway. So the default should be "unspecified".