### PR TITLE
Add date_started parameter to task API calls

### DIFF
--- a/app/Api/Procedure/TaskProcedure.php
+++ b/app/Api/Procedure/TaskProcedure.php
@@ -89,7 +89,7 @@ class TaskProcedure extends BaseProcedure
     public function createTask($title, $project_id, $color_id = '', $column_id = 0, $owner_id = 0, $creator_id = 0,
                                $date_due = '', $description = '', $category_id = 0, $score = 0, $swimlane_id = 0, $priority = 0,
                                $recurrence_status = 0, $recurrence_trigger = 0, $recurrence_factor = 0, $recurrence_timeframe = 0,
-                               $recurrence_basedate = 0, $reference = '', array $tags = array())
+                               $recurrence_basedate = 0, $reference = '', array $tags = array(), $date_started = '')
     {
         ProjectAuthorization::getInstance($this->container)->check($this->getClassName(), 'createTask', $project_id);
 
@@ -121,6 +121,7 @@ class TaskProcedure extends BaseProcedure
             'reference' => $reference,
             'priority' => $priority,
             'tags' => $tags,
+            'date_started' => $date_started,
         );
 
         list($valid, ) = $this->taskValidator->validateCreation($values);
@@ -131,7 +132,7 @@ class TaskProcedure extends BaseProcedure
     public function updateTask($id, $title = null, $color_id = null, $owner_id = null,
                                $date_due = null, $description = null, $category_id = null, $score = null, $priority = null,
                                $recurrence_status = null, $recurrence_trigger = null, $recurrence_factor = null,
-                               $recurrence_timeframe = null, $recurrence_basedate = null, $reference = null, $tags = null)
+                               $recurrence_timeframe = null, $recurrence_basedate = null, $reference = null, $tags = null, $date_started = null)
     {
         TaskAuthorization::getInstance($this->container)->check($this->getClassName(), 'updateTask', $id);
         $project_id = $this->taskFinderModel->getProjectId($id);
@@ -161,6 +162,7 @@ class TaskProcedure extends BaseProcedure
             'reference' => $reference,
             'priority' => $priority,
             'tags' => $tags,
+            'date_started' => $date_started,
         ));
 
         list($valid) = $this->taskValidator->validateApiModification($values);

--- a/doc/en_US/api-task-procedures.markdown
+++ b/doc/en_US/api-task-procedures.markdown
@@ -23,6 +23,7 @@ API Task Procedures
     - **recurrence_timeframe** (integer, optional)
     - **recurrence_basedate** (integer, optional)
     - **tags** ([]string, optional)
+    - **date_started**: ISO8601 format (string, optional)
 - Result on success: **task_id**
 - Result on failure: **false**
 
@@ -407,6 +408,7 @@ Response example:
     - **recurrence_timeframe** (integer, optional)
     - **recurrence_basedate** (integer, optional)
     - **tags** ([]string, optional)
+    - **date_started**: ISO8601 format (string, optional)    
 - Result on success: **true**
 - Result on failure: **false**
 

--- a/doc/en_US/api-task-procedures.markdown
+++ b/doc/en_US/api-task-procedures.markdown
@@ -23,7 +23,7 @@ API Task Procedures
     - **recurrence_timeframe** (integer, optional)
     - **recurrence_basedate** (integer, optional)
     - **tags** ([]string, optional)
-    - **date_started**: ISO8601 format (string, optional)
+    - **date_started**: d/m/Y H:i format (string, optional)
 - Result on success: **task_id**
 - Result on failure: **false**
 


### PR DESCRIPTION
Hi,

I implement the possibility to set or update the "started date" via the API procedures createTask or updateTask (https://github.com/kanboard/kanboard/issues/3020)

Rémy
