### PR TITLE
Properly resize task list height on column toggle #3069

### DIFF
--- a/assets/js/src/BoardColumnView.js
+++ b/assets/js/src/BoardColumnView.js
@@ -38,6 +38,7 @@ Kanboard.BoardColumnView.prototype.toggle = function(columnId) {
     else {
         this.hideColumn(columnId);
     }
+    this.app.get("BoardDragAndDrop").dragAndDrop();
 };
 
 Kanboard.BoardColumnView.prototype.hideColumn = function(columnId) {

--- a/assets/js/src/BoardDragAndDrop.js
+++ b/assets/js/src/BoardDragAndDrop.js
@@ -48,13 +48,9 @@ Kanboard.BoardDragAndDrop.prototype.dragAndDrop = function() {
         params.handle = ".task-board-sort-handle";
     }
 
-    // Set visible dropzone height to the height of the table cell
+    // Set dropzone height to the height of the table cell
     dropzone.each(function() {
-        if ($(this).filter(':visible').length) { // This drop zone is visible
-            $(this).css("min-height", $(this).parent().height());
-        } else { // Remove min-height
-            $(this).css("min-height", '');
-        }
+        $(this).css("min-height", $(this).parent().height());
     });
 
     dropzone.sortable(params);

--- a/assets/js/src/BoardDragAndDrop.js
+++ b/assets/js/src/BoardDragAndDrop.js
@@ -5,8 +5,8 @@ Kanboard.BoardDragAndDrop = function(app) {
 
 Kanboard.BoardDragAndDrop.prototype.execute = function() {
     if (this.app.hasId("board")) {
-        this.dragAndDrop();
         this.executeListeners();
+        this.dragAndDrop();
     }
 };
 
@@ -48,9 +48,13 @@ Kanboard.BoardDragAndDrop.prototype.dragAndDrop = function() {
         params.handle = ".task-board-sort-handle";
     }
 
-    // Set dropzone height to the height of the table cell
+    // Set visible dropzone height to the height of the table cell
     dropzone.each(function() {
-        $(this).css("min-height", $(this).parent().height());
+        if ($(this).filter(':visible').length) { // This drop zone is visible
+            $(this).css("min-height", $(this).parent().height());
+        } else { // Remove min-height
+            $(this).css("min-height", '');
+        }
     });
 
     dropzone.sortable(params);
@@ -101,8 +105,8 @@ Kanboard.BoardDragAndDrop.prototype.refresh = function(data) {
     $("#board-container").replaceWith(data);
 
     this.app.hideLoadingIcon();
-    this.dragAndDrop();
     this.executeListeners();
+    this.dragAndDrop();
 };
 
 Kanboard.BoardDragAndDrop.prototype.executeListeners = function() {


### PR DESCRIPTION
Cause:
Every task list height was set before column visibility toggle -> even actually hidden columns contributed to resulting <td> height. Now column visibility is set first and then DnD is getting refreshed. Also DnD is getting refreshed after manual column visibility toggle