### PR TITLE
Improvement in search ref using LIKE

### DIFF
--- a/app/Filter/TaskReferenceFilter.php
+++ b/app/Filter/TaskReferenceFilter.php
@@ -32,6 +32,12 @@ class TaskReferenceFilter extends BaseFilter implements FilterInterface
      */
     public function apply()
     {
+        if (strpos($this->value, "*") >= 0)
+        {
+            $this->query->like(TaskModel::TABLE.'.reference', str_replace('*', '%', $this->value));
+            return $this;
+        }
+
         $this->query->eq(TaskModel::TABLE.'.reference', $this->value);
         return $this;
     }


### PR DESCRIPTION
Using this improvement, we can search:

ref:TES*

And result tasks with refer start with “TES”.

Other example: Tasks with ref “TEST” can be searched with:

ref:*EST
OR
ref:\*ES\*
