### PR TITLE
Small UI tweaks to improve tablet usage

### DIFF
--- a/assets/sass/_board.sass
+++ b/assets/sass/_board.sass
@@ -11,7 +11,7 @@
   overflow-x: auto
 
 #board
-  table-layout: fixed
+  table-layout: inherit
   margin-bottom: 0
   th.board-column-header
     width: 240px

--- a/assets/sass/_sidebar.sass
+++ b/assets/sass/_sidebar.sass
@@ -9,7 +9,15 @@
   @include grid_width(82/100)
   @include xs-device
     @include grid_width(1)
-
+      
+@media (min-width: 1px) {
+  .sidebar-content
+    width: 70%;
+    
+@media (min-width: 1000px) {
+  .sidebar-content
+    width: 75%;
+    
 .sidebar
   max-width: 240px
   min-width: 190px


### PR DESCRIPTION
This pull contains 2 minor changes to improve UI for mobile usage on tablets.

## **#board** 

Table with id=board uses the width given by the mother element. With that change (table-layout: fixed => inherit) the whole board uses only the "visible" width, avoiding scroll bars.

![screenshot from 2017-03-17 14 39 10](https://cloud.githubusercontent.com/assets/381727/24045536/be0b0f0a-0b1f-11e7-82fe-0df1a0c5857f.png)


## .sidebar-content

Class .sidebar-content has a different width, depending on the **min-width** value. With that change, the sidebar-content, such as task information, is place right of the sidebar, instead of dropping to the bottom.

![screenshot from 2017-03-17 14 38 58](https://cloud.githubusercontent.com/assets/381727/24045589/eaf701d6-0b1f-11e7-8369-c2cbf81c3ad6.png)

## General

Made to work with tablets, but using a smaller device width should be supported.