### PR TITLE
update to sqlite schema - fixing existing table

### DIFF
--- a/app/Schema/Sqlite.php
+++ b/app/Schema/Sqlite.php
@@ -8,7 +8,34 @@ use Kanboard\Core\Security\Token;
 use Kanboard\Core\Security\Role;
 use PDO;
 
-const VERSION = 112;
+const VERSION = 113;
+
+function version_113(PDO $pdo)
+{
+    $pdo->exec(
+        'ALTER TABLE project_activities RENAME TO project_activities_bak'
+    );
+    $pdo->exec("
+      CREATE TABLE project_activities (
+          id INTEGER PRIMARY KEY,
+          date_creation INTEGER NOT NULL,
+          event_name TEXT NOT NULL,
+          creator_id INTEGER NOT NULL,
+          project_id INTEGER NOT NULL,
+          task_id INTEGER NOT NULL,
+          data TEXT,
+          FOREIGN KEY(creator_id) REFERENCES users(id) ON DELETE CASCADE,
+          FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE,
+          FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE
+      )
+    ");
+    $pdo->exec(
+        'INSERT INTO project_activities SELECT * FROM project_activities_bak'
+    );
+    $pdo->exec(
+        'DROP TABLE project_activities_bak'
+    );
+}
 
 function version_112(PDO $pdo)
 {


### PR DESCRIPTION
table project_activities contains a typo in schema, this corrects the typo on existing installations
