### PR TITLE
Change translation of 'Ready' (project column)

### DIFF
--- a/app/Locale/ru_RU/translations.php
+++ b/app/Locale/ru_RU/translations.php
@@ -134,7 +134,7 @@ return array(
     'User removed successfully.' => 'Пользователь удалён.',
     'Unable to remove this user.' => 'Не удалось удалить пользователя.',
     'Board updated successfully.' => 'Доска успешно обновлена.',
-    'Ready' => 'Готовые',
+    'Ready' => 'Согласованные',
     'Backlog' => 'Ожидающие',
     'Work in progress' => 'В процессе',
     'Done' => 'Выполнено',


### PR DESCRIPTION
Change translation of 'Ready' to 'Согласованные' instead of 'Готовые' as more preferable ( see https://goo.gl/Zc0b3S — search for "согласовано (ready)")