### PR TITLE
Return HTTP 403 when access is forbidden

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -27,7 +27,7 @@ class AppController extends Base
             $this->response->html($this->helper->layout->app('app/forbidden', array(
                 'title' => t('Access Forbidden'),
                 'no_layout' => $withoutLayout,
-            )));
+            )), 403);
         }
     }
 


### PR DESCRIPTION
This would allow servers to handle wrong access (for example redirect to a custom error page).