### PR TITLE
Define a default filter phrase in config.php instead of the hard-coded 'status:open'

### DIFF
--- a/app/Core/User/UserSession.php
+++ b/app/Core/User/UserSession.php
@@ -176,7 +176,7 @@ class UserSession extends Base
      */
     public function getFilters($project_id)
     {
-        return ! empty($this->sessionStorage->filters[$project_id]) ? $this->sessionStorage->filters[$project_id] : 'status:open';
+        return ! empty($this->sessionStorage->filters[$project_id]) ? $this->sessionStorage->filters[$project_id] : DEFAULT_FILTER." ".ADDITIONAL_FILTER;
     }
 
     /**

--- a/app/Template/app/filters_helper.php
+++ b/app/Template/app/filters_helper.php
@@ -3,15 +3,15 @@
     <a href="#" class="dropdown-menu dropdown-menu-link-icon" title="<?= t('Default filters') ?>"><i class="fa fa-filter fa-fw"></i><i class="fa fa-caret-down"></i></a>
     <ul>
         <li><a href="#" class="filter-helper filter-reset" data-filter="<?= isset($reset) ? $reset : '' ?>" title="<?= t('Keyboard shortcut: "%s"', 'r') ?>"><?= t('Reset filters') ?></a></li>
-        <li><a href="#" class="filter-helper" data-filter="status:open assignee:me"><?= t('My tasks') ?></a></li>
-        <li><a href="#" class="filter-helper" data-filter="status:open assignee:me due:tomorrow"><?= t('My tasks due tomorrow') ?></a></li>
-        <li><a href="#" class="filter-helper" data-filter="status:open due:today"><?= t('Tasks due today') ?></a></li>
-        <li><a href="#" class="filter-helper" data-filter="status:open due:tomorrow"><?= t('Tasks due tomorrow') ?></a></li>
-        <li><a href="#" class="filter-helper" data-filter="status:open due:yesterday"><?= t('Tasks due yesterday') ?></a></li>
-        <li><a href="#" class="filter-helper" data-filter="status:closed"><?= t('Closed tasks') ?></a></li>
-        <li><a href="#" class="filter-helper" data-filter="status:open"><?= t('Open tasks') ?></a></li>
-        <li><a href="#" class="filter-helper" data-filter="status:open assignee:nobody"><?= t('Not assigned') ?></a></li>
-        <li><a href="#" class="filter-helper" data-filter="status:open category:none"><?= t('No category') ?></a></li>
+        <li><a href="#" class="filter-helper" data-filter="status:open assignee:me <?= ADDITIONAL_FILTER ?>"><?= t('My tasks') ?></a></li>
+        <li><a href="#" class="filter-helper" data-filter="status:open assignee:me due:tomorrow <?= ADDITIONAL_FILTER ?>"><?= t('My tasks due tomorrow') ?></a></li>
+        <li><a href="#" class="filter-helper" data-filter="status:open due:today <?= ADDITIONAL_FILTER ?>"><?= t('Tasks due today') ?></a></li>
+        <li><a href="#" class="filter-helper" data-filter="status:open due:tomorrow <?= ADDITIONAL_FILTER ?>"><?= t('Tasks due tomorrow') ?></a></li>
+        <li><a href="#" class="filter-helper" data-filter="status:open due:yesterday <?= ADDITIONAL_FILTER ?>"><?= t('Tasks due yesterday') ?></a></li>
+        <li><a href="#" class="filter-helper" data-filter="status:closed <?= ADDITIONAL_FILTER ?>"><?= t('Closed tasks') ?></a></li>
+        <li><a href="#" class="filter-helper" data-filter="status:open <?= ADDITIONAL_FILTER ?>"><?= t('Open tasks') ?></a></li>
+        <li><a href="#" class="filter-helper" data-filter="status:open assignee:nobody <?= ADDITIONAL_FILTER ?>"><?= t('Not assigned') ?></a></li>
+        <li><a href="#" class="filter-helper" data-filter="status:open category:none <?= ADDITIONAL_FILTER ?>"><?= t('No category') ?></a></li>
         <li>
             <?= $this->url->doc(t('View advanced search syntax'), 'search') ?>
         </li>

--- a/app/Template/project_header/search.php
+++ b/app/Template/project_header/search.php
@@ -8,7 +8,7 @@
         <div class="input-addon">
             <?= $this->form->text('search', $filters, array(), array('placeholder="'.t('Filter').'"'), 'input-addon-field') ?>
             <div class="input-addon-item">
-                <?= $this->render('app/filters_helper', array('reset' => 'status:open', 'project' => $project)) ?>
+                <?= $this->render('app/filters_helper', array('reset' => DEFAULT_FILTER." ".ADDITIONAL_FILTER, 'project' => $project)) ?>
             </div>
 
             <?php if (isset($custom_filters_list) && ! empty($custom_filters_list)): ?>

--- a/app/constants.php
+++ b/app/constants.php
@@ -146,3 +146,7 @@ defined('HTTP_PROXY_PASSWORD') or define('HTTP_PROXY_PASSWORD', '');
 defined('HTTP_VERIFY_SSL_CERTIFICATE') or define('HTTP_VERIFY_SSL_CERTIFICATE', true);
 
 defined('TOTP_ISSUER') or define('TOTP_ISSUER', 'Kanboard');
+
+// default and additional filter phrases
+defined('DEFAULT_FILTER') or define('DEFAULT_FILTER', 'status:open');
+defined('ADDITIONAL_FILTER') or define('ADDITIONAL_FILTER', '');

--- a/config.default.php
+++ b/config.default.php
@@ -237,3 +237,10 @@ define('HTTP_VERIFY_SSL_CERTIFICATE', true);
 
 // TOTP (2FA) issuer name
 define('TOTP_ISSUER', 'Kanboard');
+
+// default filter expression
+define('DEFAULT_FILTER', 'status:open');
+
+// an expression that will be added to the predefined filters
+// define('ADDITIONAL_FILTER', 'board_date:<=today');  // use this when plugin TaskBoardDate is installed
+define('ADDITIONAL_FILTER', '');  // use this otherwise


### PR DESCRIPTION
Instead of using the hard-coded default filter "status:open", I propose to define the default filter phrase in the config.php file. This addresses e.g. issue 1295

In addition it opens the possibility for a different approach to filter out the tasks not yet visible with the TaskBoardDate plugin.

Please note: I am not a developer. So there is a good chance that I did something wrong or in bad style. I will be happy to be corrected!
