### PR TITLE
Fix modal dialog position. Closes #3196

### DIFF
--- a/assets/js/core/modal.js
+++ b/assets/js/core/modal.js
@@ -102,7 +102,7 @@
 
         var boxElement = KB.dom('div')
             .attr('id', 'modal-box')
-            .style('width', width)
+            .style('min-width', width)
             .add(headerElement)
             .add(contentElement)
             .build();

--- a/assets/sass/_modal.sass
+++ b/assets/sass/_modal.sass
@@ -2,6 +2,7 @@
 @import mixins
 
 #modal-overlay
+  text-align: center
   position: fixed
   top: 0
   left: 0
@@ -12,11 +13,9 @@
   z-index: 100
 
 #modal-box
-  position: fixed
-  max-height: calc(100% - 30px)
-  top: 2%
-  left: 50%
-  transform: translateX(-50%)
+  display: inline-block
+  text-align: left
+  margin-top: 1%
   background: #fff
   overflow: auto
   border-radius: 5px


### PR DESCRIPTION
Fix modal dialog position. Closes #3196
The dialog width is the same as before.