### PR TITLE
Adding functionality for getting more info from reverse proxy auth

### DIFF
--- a/app/Auth/ReverseProxyAuth.php
+++ b/app/Auth/ReverseProxyAuth.php
@@ -43,15 +43,18 @@ class ReverseProxyAuth extends Base implements PreAuthenticationProviderInterfac
     public function authenticate()
     {
         $username = $this->request->getRemoteUser();
+        $fullname = $this->request->getRemoteFullname();
+        $email = $this->request->getRemoteEmail();
 
         if (! empty($username)) {
             $userProfile = $this->userCacheDecorator->getByUsername($username);
-            $this->userInfo = new ReverseProxyUserProvider($username, $userProfile ?: array());
+            $this->userInfo = new ReverseProxyUserProvider($username, $fullname, $email, $userProfile ?: array());
             return true;
         }
 
         return false;
     }
+    
 
     /**
      * Check if the user session is valid

--- a/app/Core/Http/Request.php
+++ b/app/Core/Http/Request.php
@@ -260,6 +260,28 @@ class Request extends Base
     }
 
     /**
+     * Get remote full name
+     *
+     * @access public
+     * @return string
+     */
+    public function getRemoteFullname()
+    {
+        return $this->getServerVariable(REVERSE_PROXY_FULLNAME_HEADER);
+    }
+
+    /**
+     * Get remote email address
+     *
+     * @access public
+     * @return string
+     */
+    public function getRemoteEmail()
+    {
+        return $this->getServerVariable(REVERSE_PROXY_EMAIL_HEADER);
+    }
+
+    /**
      * Returns query string
      *
      * @access public

--- a/app/User/ReverseProxyUserProvider.php
+++ b/app/User/ReverseProxyUserProvider.php
@@ -22,6 +22,22 @@ class ReverseProxyUserProvider implements UserProviderInterface
     protected $username = '';
 
     /**
+     * Fullname
+     *
+     * @access protected
+     * @var string
+     */
+    protected $fullname = '';
+
+    /**
+     * Email Address
+     *
+     * @access protected
+     * @var string
+     */
+    protected $email = '';
+
+    /**
      * User profile if the user already exists
      *
      * @access protected
@@ -34,10 +50,14 @@ class ReverseProxyUserProvider implements UserProviderInterface
      *
      * @access public
      * @param  string $username
+     * @param  string $fullname
+     * @param  string $email
      */
-    public function __construct($username, array $userProfile = array())
+    public function __construct($username, $fullname, $email, array $userProfile = array())
     {
         $this->username = $username;
+        $this->fullname = $fullname;
+        $this->email = $email;
         $this->userProfile = $userProfile;
     }
 
@@ -123,7 +143,7 @@ class ReverseProxyUserProvider implements UserProviderInterface
      */
     public function getName()
     {
-        return '';
+        return $this->fullname;
     }
 
     /**
@@ -134,7 +154,7 @@ class ReverseProxyUserProvider implements UserProviderInterface
      */
     public function getEmail()
     {
-        return REVERSE_PROXY_DEFAULT_DOMAIN !== '' ? $this->username.'@'.REVERSE_PROXY_DEFAULT_DOMAIN : '';
+        return $this->email;
     }
 
     /**

--- a/config.default.php
+++ b/config.default.php
@@ -183,6 +183,12 @@ define('REVERSE_PROXY_AUTH', false);
 // Header name to use for the username
 define('REVERSE_PROXY_USER_HEADER', 'REMOTE_USER');
 
+// Header name to use for the user full name
+define('REVERSE_PROXY_FULLNAME_HEADER', 'REMOTE_FULLNAME');
+
+// Header name to use for the user email address
+define('REVERSE_PROXY_EMAIL_HEADER', 'REMOTE_EMAIL');
+
 // Username of the admin, by default blank
 define('REVERSE_PROXY_DEFAULT_ADMIN', '');
 


### PR DESCRIPTION
As it was there was no way to get profile info from reverse proxy auth. I've added config elements for what the apache server should call the full name and the email. Then I've added Http/Request functions to get those values out. Then I've updated the ReverseProxyUserProvider class to take these new values in and return them.