### PR TITLE
added missing php5-ldap extension to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 
 $script = <<SCRIPT
 apt-get update
-apt-get install -y apache2 php5 php5-sqlite php5-mysql php5-pgsql php5-gd curl unzip php5-curl && \
+apt-get install -y apache2 php5 php5-sqlite php5-mysql php5-pgsql php5-gd curl unzip php5-curl php5-ldap && \
 apt-get clean && \
 echo "ServerName localhost" >> /etc/apache2/apache2.conf && \
 sed -ri 's/AllowOverride None/AllowOverride All/g' /etc/apache2/apache2.conf && \


### PR DESCRIPTION
The php5-ldap extension was missing in the Vagrantfile so the PHPUnit-Tests are failing:

vagrant@vagrant-ubuntu-trusty-64:/var/www/html$ make test-sqlite
PHPUnit 4.8.26 by Sebastian Bergmann and contributors.

.............................................................   61 / 1078 (  5%)
.............................................................  122 / 1078 ( 11%)
.............................................................  183 / 1078 ( 16%)
...................................................E

Time: 25.95 seconds, Memory: 124.25MB

There was 1 error:

1) Kanboard\Core\Ldap\ClientTest::testConnectSuccess
Kanboard\Core\Ldap\ClientException: LDAP: The PHP LDAP extension is required

/var/www/html/app/Core/Ldap/Client.php:84
/var/www/html/tests/units/Core/Ldap/ClientTest.php:88

FAILURES!
Tests: 235, Assertions: 1133, Errors: 1.
make: *** [test-sqlite] Error 2
vagrant@vagrant-ubuntu-trusty-64:/var/www/html$

