### PR TITLE
adding Netbeans project folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .project
 /.settings/
 .idea
+/nbproject/
 .DS_Store
 ehthumbs.db
 Icon?


### PR DESCRIPTION
The IntelliJ/PHPStorm and Eclipse project files/folders are already in .gitignore. I added the Netbeans project folder "nbproject" to .gitignore.