### PR TITLE
fixed memory leak in unit tests

### DIFF
--- a/tests/units/Base.php
+++ b/tests/units/Base.php
@@ -101,5 +101,6 @@ abstract class Base extends PHPUnit_Framework_TestCase
     public function tearDown()
     {
         $this->container['db']->closeConnection();
+        unset ($this->container);
     }
 }


### PR DESCRIPTION
There is a memory leak in the unit tests. Running the database tests is steadily increasing the used memory until the php process will be killed or mysql is crashing due to no memory (at least in the Vagrant VM-machine with 512 MB RAM).

Unsetting the DI-Container at the end of a test keeps the memory usage almost stable.

--

vagrant@vagrant-ubuntu-trusty-64:/var/www/html$ make test-sqlite
PHPUnit 4.8.26 by Sebastian Bergmann and contributors.

.............................................................   61 / 1078 (  5%)
.............................................................  122 / 1078 ( 11%)
.............................................................  183 / 1078 ( 16%)
.............................................................  244 / 1078 ( 22%)
.............................................................  305 / 1078 ( 28%)
.............................................................  366 / 1078 ( 33%)
.............................................................  427 / 1078 ( 39%)
.............................................................  488 / 1078 ( 45%)
.............................................................  549 / 1078 ( 50%)
.............................................................  610 / 1078 ( 56%)
.....................................Killed
make: *** [test-sqlite] Error 137
vagrant@vagrant-ubuntu-trusty-64:/var/www/html$

---

vagrant@vagrant-ubuntu-trusty-64:/var/www/html$ make test-mysql
PHPUnit 4.8.26 by Sebastian Bergmann and contributors.

.............................................................   61 / 1078 (  5%)
.............................................................  122 / 1078 ( 11%)
.............................................................  183 / 1078 ( 16%)
.............................................................  244 / 1078 ( 22%)
.............................................................  305 / 1078 ( 28%)
.............................................................  366 / 1078 ( 33%)
.............................................................  427 / 1078 ( 39%)
.............................................................  488 / 1078 ( 45%)
.............................................................  549 / 1078 ( 50%)
.............................................................  610 / 1078 ( 56%)
..................................E

Time: 7.72 minutes, Memory: 264.25MB

There was 1 error:

1) ConfigModelTest::testCRUDOperations
PDOException: SQLSTATE[HY000]: General error: 2006 MySQL server has gone away

/var/www/html/vendor/fguillot/picodb/lib/PicoDb/Driver/Mysql.php:111
/var/www/html/vendor/fguillot/picodb/lib/PicoDb/Schema.php:113
/var/www/html/vendor/fguillot/picodb/lib/PicoDb/Schema.php:78
/var/www/html/app/ServiceProvider/DatabaseProvider.php:93
/var/www/html/app/ServiceProvider/DatabaseProvider.php:31
/var/www/html/vendor/pimple/pimple/src/Pimple/Container.php:274
/var/www/html/tests/units/Base.php:48

FAILURES!
Tests: 645, Assertions: 83969, Errors: 1.
make: *** [test-mysql] Error 2
vagrant@vagrant-ubuntu-trusty-64:/var/www/html$
