### PR TITLE
Add "Create another link" checkbox for internal link creation

### DIFF
--- a/app/Locale/fr_FR/translations.php
+++ b/app/Locale/fr_FR/translations.php
@@ -1338,4 +1338,5 @@ return array(
     'This task was sent by email to "%s" with subject "%s".' => 'Cette tâche a été envoyée par courrier électronique à « %s » avec le sujet « %s ».',
     'Predefined Email Subjects' => 'Sujets de courrier électronique prédéfinis',
     'Write one subject by line.' => 'Écrivez un sujet par ligne.',
+    'Create another link' => 'Créer un autre lien',
 );

--- a/app/Template/task_internal_link/create.php
+++ b/app/Template/task_internal_link/create.php
@@ -25,5 +25,7 @@
         ),
         'autocomplete') ?>
 
+    <?= $this->form->checkbox('another_tasklink', t('Create another link'), 1, isset($values['another_tasklink']) && $values['another_tasklink'] == 1) ?>
+
     <?= $this->modal->submitButtons() ?>
 </form>


### PR DESCRIPTION
Add "Create another link" checkbox for internal link creation as in sub-task creation.

This is really useful when you have one task which is "blocking" / "is a milestone of" / "relates to" several other tasks.

I check the implementation for sub-task and tried to mimic as far as possible. This is why I also introduced a "controller:tasklink:form:default" hook (which is not the main goal of this PR).

Thanks!
