### PR TITLE
Fixing LDAP authetication problem

### DIFF
--- a/app/Auth/LdapAuth.php
+++ b/app/Auth/LdapAuth.php
@@ -153,7 +153,7 @@ class LdapAuth extends Base implements PasswordAuthenticationProviderInterface
             case 'proxy':
                 return LDAP_PASSWORD;
             case 'user':
-                return $this->password;
+                return sprintf(LDAP_PASSWORD, $this->password);
             default:
                 return null;
         }


### PR DESCRIPTION
Fixing LDAP authentication problem, because it used the login LDAP user password with the config.php file LDAP user.