### PR TITLE
Fix HTTP Basic Authentication for Apache/FastCGI/php-fpm setups

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,8 @@
+# Pass HTTP Authorization header via environment variable to PHP backend
+# to make HTTP Basic Authentication work for Apache/FastCGI/php-fpm
+# setups (required to authenticate over the API)
+SetEnvIf Authorization .+ HTTP_AUTHORIZATION=$0
+
 <IfModule mod_rewrite.c>
     Options -MultiViews
 

--- a/.htaccess
+++ b/.htaccess
@@ -1,7 +1,9 @@
 # Pass HTTP Authorization header via environment variable to PHP backend
 # to make HTTP Basic Authentication work for Apache/FastCGI/php-fpm
 # setups (required to authenticate over the API)
-SetEnvIf Authorization .+ HTTP_AUTHORIZATION=$0
+<IfModule mod_setenvif.c>
+    SetEnvIf Authorization .+ HTTP_AUTHORIZATION=$0
+</IfModule>
 
 <IfModule mod_rewrite.c>
     Options -MultiViews


### PR DESCRIPTION
Pass HTTP Authorization header via environment variable to PHP backend to make HTTP Basic Authentication work for Apache/FastCGI/php-fpm setups (required to authenticate over the API).

This should help mobile apps to work better with self-hosted Kanboard instances (and thus reduce negative feedback on the mobile app stores).

All credits go to the commenters of issue https://github.com/andresth/Kandroid/issues/22, I've just wrapped this up into a PR and made sure unit and integration tests pass.

See also:
https://github.com/andresth/Kandroid/issues/22#issuecomment-320719396
http://php.net/manual/bg/features.http-auth.php#114877
https://play.google.com/store/apps/details?id=eu.it_quality.kanboard&reviewId=Z3A6QU9xcFRPRVpkMGR6YjVfZk5sMUhONzdicl9XeGZfa1VYZFFDVWxNOVhPUmhhUG94eGNsY2hreWlmZHZxZnZrZVR4Mm9YbjNvNmRmY0MwcWdvT09SdlE