### PR TITLE
implement removal of all tasks from a column

### DIFF
--- a/app/Controller/BoardPopoverController.php
+++ b/app/Controller/BoardPopoverController.php
@@ -44,4 +44,39 @@ class BoardPopoverController extends BaseController
         $this->flash->success(t('All tasks of the column "%s" and the swimlane "%s" have been closed successfully.', $this->columnModel->getColumnTitleById($values['column_id']), $this->swimlaneModel->getNameById($values['swimlane_id'])));
         $this->response->redirect($this->helper->url->to('BoardViewController', 'show', array('project_id' => $project['id'])));
     }
+
+    /**
+     * Confirmation before removing (deleting) all column tasks
+     *
+     * @access public
+     */
+    public function confirmRemoveColumnTasks()
+    {
+        $project = $this->getProject();
+        $column_id = $this->request->getIntegerParam('column_id');
+        $swimlane_id = $this->request->getIntegerParam('swimlane_id');
+
+        $this->response->html($this->template->render('board_popover/remove_all_tasks_column', array(
+            'project' => $project,
+            'nb_tasks' => $this->taskFinderModel->countByColumnAndSwimlaneId($project['id'], $column_id, $swimlane_id),
+            'column' => $this->columnModel->getColumnTitleById($column_id),
+            'swimlane' => $this->swimlaneModel->getNameById($swimlane_id),
+            'values' => array('column_id' => $column_id, 'swimlane_id' => $swimlane_id),
+        )));
+    }
+
+    /**
+     * Remove (delete) all tasks in a column
+     *
+     * @access public
+     */
+    public function removeColumnTasks()
+    {
+        $project = $this->getProject();
+        $values = $this->request->getValues();
+
+        $this->taskStatusModel->closeTasksBySwimlaneAndColumn($values['swimlane_id'], $values['column_id']);
+        $this->flash->success(t('All tasks of the column "%s" and the swimlane "%s" have been removed successfully.', $this->columnModel->getColumnTitleById($values['column_id']), $this->swimlaneModel->getNameById($values['swimlane_id'])));
+        $this->response->redirect($this->helper->url->to('BoardViewController', 'show', array('project_id' => $project['id'])));
+    }
 }

--- a/app/Model/TaskStatusModel.php
+++ b/app/Model/TaskStatusModel.php
@@ -141,4 +141,26 @@ class TaskStatusModel extends Base
                     ->eq('is_active', $status)
                     ->exists();
     }
+
+    /**
+     * Remove (delete) all tasks within a column/swimlane
+     *
+     * @access public
+     * @param  integer $swimlane_id
+     * @param  integer $column_id
+     */
+    public function removeTasksBySwimlaneAndColumn($swimlane_id, $column_id)
+    {
+        $task_ids = $this->db
+            ->table(TaskModel::TABLE)
+            ->eq('swimlane_id', $swimlane_id)
+            ->eq('column_id', $column_id)
+            ->eq(TaskModel::TABLE.'.is_active', TaskModel::STATUS_OPEN)
+            ->findAllByColumn('id');
+
+        foreach ($task_ids as $task_id) {
+            $this->subtaskStatusModel->remove($task_id);
+        }
+    }
+
 }

--- a/app/Template/board/table_column.php
+++ b/app/Template/board/table_column.php
@@ -48,6 +48,9 @@
                                 <li>
                                     <?= $this->modal->confirm('close', t('Close all tasks of this column'), 'BoardPopoverController', 'confirmCloseColumnTasks', array('project_id' => $column['project_id'], 'column_id' => $column['id'], 'swimlane_id' => $swimlane['id'])) ?>
                                 </li>
+                                <li>
+                                    <?= $this->modal->confirm('trash', t('Remove all tasks of this column'), 'BoardPopoverController', 'confirmRemoveColumnTasks', array('project_id' => $column['project_id'], 'column_id' => $column['id'], 'swimlane_id' => $swimlane['id'])) ?>
+                                </li>
                             <?php endif ?>
 
                             <?= $this->hook->render('template:board:column:dropdown', array('swimlane' => $swimlane, 'column' => $column)) ?>

--- a/app/Template/board_popover/remove_all_tasks_column.php
+++ b/app/Template/board_popover/remove_all_tasks_column.php
@@ -1,0 +1,18 @@
+<div class="page-header">
+    <h2><?= t('Do you really want to remove all tasks of this column?') ?></h2>
+</div>
+<form method="post" action="<?= $this->url->href('BoardPopoverController', 'removeColumnTasks', array('project_id' => $project['id'])) ?>">
+    <?= $this->form->csrf() ?>
+    <?= $this->form->hidden('column_id', $values) ?>
+    <?= $this->form->hidden('swimlane_id', $values) ?>
+
+    <p class="alert"><?= t('%d task(s) in the column "%s" and the swimlane "%s" will be permanently removed.', $nb_tasks, $column, $swimlane) ?><br/>
+		<span style="font-weight: bold;"><?= t('NOTE: This action can not be undone!') ?></div>
+
+</p>
+
+    <?= $this->modal->submitButtons(array(
+        'submitLabel' => t('Yes'),
+        'color' => 'red',
+    )) ?>
+</form>


### PR DESCRIPTION
This compliments the Close All function available in columns with a Remove All.

Our use case for this is as follows:

 * each sprint we create a new project for that sprint
 * that project board duplicates the previous sprint's board (thereby carrying over all the unfinished tasks)
 * we then delete all the tasks in the done column from the new project

We started doing this manually one task at a time .. then I moved to using an SQL statement in the database directly (!!) .. and today I had a few minutes before our sprint kickoff meeting and so I implemented this feature to save my fingers in the future :) .. and hopefully it can be pulled upstream as well!

Cheers, and thanks for a great project I've been using for many years now.
