### PR TITLE
Fix for #3466 - Uploading documents by drag and drop

### DIFF
--- a/assets/js/components/file-upload.js
+++ b/assets/js/components/file-upload.js
@@ -81,8 +81,8 @@ KB.component('file-upload', function (containerElement, options) {
         e.stopPropagation();
         e.preventDefault();
 
-        for(var i = 0, file; file = e.dataTransfer.files[i]; i++) {
-            files.push(file);
+        for (var i = 0; i < e.dataTransfer.files.length; i++) {
+            files.push(e.dataTransfer.files[i]);
         }
 
         showFiles();

--- a/assets/js/components/file-upload.js
+++ b/assets/js/components/file-upload.js
@@ -81,7 +81,10 @@ KB.component('file-upload', function (containerElement, options) {
         e.stopPropagation();
         e.preventDefault();
 
-        files = e.dataTransfer.files;
+        for(var i = 0, file; file = e.dataTransfer.files[i]; i++) {
+            files.push(file);
+        }
+
         showFiles();
     }
 
@@ -156,9 +159,20 @@ KB.component('file-upload', function (containerElement, options) {
             .attr('id', 'file-percentage-' + index)
             .text('(0%)')
             .build();
+        
+        var deleteElement = KB.dom('span')
+        		.attr('id', 'file-delete-' +index)
+        		.html('<i class="fa fa-trash fa-fw"></i>')
+        		.on('click', function(){
+        			files.splice(index,1);
+        			KB.find('#file-item-' + index).remove();
+        			showFiles();
+        		})
+        		.build();
 
         var itemElement = KB.dom('li')
             .attr('id', 'file-item-' + index)
+            .add(deleteElement)
             .add(progressElement)
             .text(' ' + files[index].name + ' ')
             .add(percentageElement);


### PR DESCRIPTION
Fix #3466

Add the possibility to add new files to the upload queue after first drag and drop

Add the possibility to remove files from queue also
