### PR TITLE
ignore vendor folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ data/cache
 !docker/kanboard/config.php
 node_modules
 bower_components
+vendor


### PR DESCRIPTION
For development purposes, this folder could be ignored. Since all
contents of this folder is generated from `composer.json`. Corollaries to
this are how `node_modules` and `bower_components` are ignored.
