### PR TITLE
Column task limits apply to sum of all swimlanes

### DIFF
--- a/app/Formatter/BoardSwimlaneFormatter.php
+++ b/app/Formatter/BoardSwimlaneFormatter.php
@@ -97,6 +97,13 @@ class BoardSwimlaneFormatter extends BaseFormatter implements FormatterInterface
             $this->calculateStatsByColumnAcrossSwimlanes($swimlane['columns']);
         }
 
+        foreach($this->swimlanes as &$swimlane) {
+            foreach($swimlane['columns'] as $columnIndex => &$column) {
+                $column['column_nb_tasks'] = $this->swimlanes[0]['columns'][$columnIndex]['column_nb_tasks'];
+                $column['column_nb_score'] = $this->swimlanes[0]['columns'][$columnIndex]['column_score'];
+            }
+        }
+
         return $this->swimlanes;
     }
 

--- a/app/Template/board/table_column.php
+++ b/app/Template/board/table_column.php
@@ -19,11 +19,10 @@
                 <?= $this->task->getNewBoardTaskButton($swimlane, $column) ?>
             <?php endif ?>
 
-            <?php if ($swimlane['nb_swimlanes'] > 1 && ! empty($column['column_nb_tasks'])): ?>
-                <span title="<?= t('Total number of tasks in this column across all swimlanes') ?>" class="board-column-header-task-count">
-                    (<span><?= $column['column_nb_tasks'] ?></span>)
-                </span>
-            <?php endif ?>
+
+            <span title="<?= t('Task count') ?>">
+                (<span id="task-number-column-<?= $column['id'] ?>"><?= $column['nb_tasks'] ?></span>)
+            </span>
 
             <span class="board-column-title">
                 <?php if ($not_editable): ?>
@@ -75,16 +74,17 @@
 
             </span>
 
-            <?php if ($column['task_limit']): ?>
-                <span title="<?= t('Task limit') ?>">
-                    (<span id="task-number-column-<?= $column['id'] ?>"><?= $column['nb_tasks'] ?></span>/<?= $this->text->e($column['task_limit']) ?>)
-                </span>
-            <?php else: ?>
-                <span title="<?= t('Task count') ?>" class="board-column-header-task-count">
-                    (<span id="task-number-column-<?= $column['id'] ?>"><?= $column['nb_tasks'] ?></span>)
-                </span>
-            <?php endif ?>
-	    <?= $this->hook->render('template:board:column:header', array('swimlane' => $swimlane, 'column' => $column)) ?> 
+            <?php if (! empty($column['column_nb_tasks'])): ?>
+            <span title="<?= t('Total number of tasks in this column across all swimlanes') ?>" class="board-column-header-task-count">
+                (
+                <span><?= $column['column_nb_tasks'] ?></span>
+                <?php if ($column['task_limit']): ?>
+                    /<span title="<?= t('Task limit') ?>"><?= $this->text->e($column['task_limit']) ?></span>
+                <?php endif ?>
+                )
+            </span>
+            <?php endif; ?>
+	    <?= $this->hook->render('template:board:column:header', array('swimlane' => $swimlane, 'column' => $column)) ?>
         </div>
 
     </th>

--- a/app/Template/board/table_tasks.php
+++ b/app/Template/board/table_tasks.php
@@ -3,7 +3,7 @@
     <?php foreach ($swimlane['columns'] as $column): ?>
         <td class="
             board-column-<?= $column['id'] ?>
-            <?= $column['task_limit'] > 0 && $column['nb_tasks'] > $column['task_limit'] ? 'board-task-list-limit' : '' ?>
+            <?= $column['task_limit'] > 0 && $column['column_nb_tasks'] > $column['task_limit'] ? 'board-task-list-limit' : '' ?>
             "
         >
 


### PR DESCRIPTION
Changed board column headings to show swimlane-column total in bold.
Also, board column total to be shown at end of column heading with limit across the sum of all swimlanes.

A column with a sum of tasks across all swimlanes over the column limit will highlight the whole column, not just a single column-lane.