### PR TITLE
Copy category on new task when create a task from sub-task

### DIFF
--- a/app/Model/SubtaskTaskConversionModel.php
+++ b/app/Model/SubtaskTaskConversionModel.php
@@ -23,6 +23,7 @@ class SubtaskTaskConversionModel extends Base
     public function convertToTask($project_id, $subtask_id)
     {
         $subtask = $this->subtaskModel->getById($subtask_id);
+        $parent_task = $this->taskFinderModel->getById($subtask['task_id']);
 
         $task_id = $this->taskCreationModel->create(array(
             'project_id' => $project_id,
@@ -30,6 +31,7 @@ class SubtaskTaskConversionModel extends Base
             'time_estimated' => $subtask['time_estimated'],
             'time_spent' => $subtask['time_spent'],
             'owner_id' => $subtask['user_id'],
+            'category_id' => $parent_task['category_id']
         ));
 
         if ($task_id !== false) {


### PR DESCRIPTION
This implemented a solution to the issue #3596. This just copies the category of the parent task of a subtask when converting the subtask to task.