### PR TITLE
Missing translation for 'sign up'

### DIFF
--- a/app/Locale/bs_BA/translations.php
+++ b/app/Locale/bs_BA/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Šifra',
     'Administrator' => 'Administrator',
     'Sign in' => 'Prijava',
+	// 'Sign up' => '',
     'Users' => 'Korisnici',
     'Forbidden' => 'Zabranjeno',
     'Access Forbidden' => 'Pristup zabranjen',

--- a/app/Locale/ca_ES/translations.php
+++ b/app/Locale/ca_ES/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Contrasenya',
     'Administrator' => 'Administrador',
     'Sign in' => 'Accedeix',
+	// 'Sign up' => '',
     'Users' => 'Usuaris',
     'Forbidden' => 'Prohibit',
     'Access Forbidden' => 'Accés prohibit',

--- a/app/Locale/cs_CZ/translations.php
+++ b/app/Locale/cs_CZ/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Heslo',
     'Administrator' => 'Administrátor',
     'Sign in' => 'Přihlásit',
+	// 'Sign up' => '',
     'Users' => 'Uživatelé',
     'Forbidden' => 'Zakázat projekt',
     'Access Forbidden' => 'Přístup zakázán',

--- a/app/Locale/da_DK/translations.php
+++ b/app/Locale/da_DK/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Adgangskode',
     'Administrator' => 'Administrator',
     'Sign in' => 'Log ind',
+	// 'Sign up' => '',
     'Users' => 'Brugere',
     'Forbidden' => 'Forbudt',
     'Access Forbidden' => 'Adgang nægtet',

--- a/app/Locale/de_DE/translations.php
+++ b/app/Locale/de_DE/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Passwort',
     'Administrator' => 'Administrator',
     'Sign in' => 'Anmelden',
+    'Sign up' => 'Registrierung',
     'Users' => 'Benutzer',
     'Forbidden' => 'Verboten',
     'Access Forbidden' => 'Zugriff verboten',

--- a/app/Locale/el_GR/translations.php
+++ b/app/Locale/el_GR/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Κωδικός',
     'Administrator' => 'Διαχειριστής',
     'Sign in' => 'Είσοδος',
+	// 'Sign up' => '',
     'Users' => 'Χρήστες',
     'Forbidden' => 'Δεν επιτρέπεται η πρόσβαση',
     'Access Forbidden' => 'Δεν επιτρέπεται η πρόσβαση',

--- a/app/Locale/es_ES/translations.php
+++ b/app/Locale/es_ES/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Contraseña',
     'Administrator' => 'Administrador',
     'Sign in' => 'Iniciar sesión',
+	// 'Sign up' => '',
     'Users' => 'Usuarios',
     'Forbidden' => 'Acceso denegado',
     'Access Forbidden' => 'Acceso denegado',

--- a/app/Locale/fi_FI/translations.php
+++ b/app/Locale/fi_FI/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Salasana',
     'Administrator' => 'Ylläpitäjä',
     'Sign in' => 'Kirjaudu sisään',
+	// 'Sign up' => '',
     'Users' => 'Käyttäjät',
     'Forbidden' => 'Estetty',
     'Access Forbidden' => 'Pääsy estetty',

--- a/app/Locale/fr_FR/translations.php
+++ b/app/Locale/fr_FR/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Mot de passe',
     'Administrator' => 'Administrateur',
     'Sign in' => 'Connexion',
+	// 'Sign up' => '',
     'Users' => 'Utilisateurs',
     'Forbidden' => 'Accès interdit',
     'Access Forbidden' => 'Accès interdit',

--- a/app/Locale/hr_HR/translations.php
+++ b/app/Locale/hr_HR/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Lozinka',
     'Administrator' => 'Administrator',
     'Sign in' => 'Prijava',
+	// 'Sign up' => '',
     'Users' => 'Korisnik',
     'Forbidden' => 'Zabranjeno',
     'Access Forbidden' => 'Zabranjen prostup',

--- a/app/Locale/hu_HU/translations.php
+++ b/app/Locale/hu_HU/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Jelszó',
     'Administrator' => 'Adminisztrátor',
     'Sign in' => 'Bejelentkezés',
+	// 'Sign up' => '',
     'Users' => 'Felhasználók',
     'Forbidden' => 'Tiltott',
     'Access Forbidden' => 'Hozzáférés megtagadva',

--- a/app/Locale/id_ID/translations.php
+++ b/app/Locale/id_ID/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Kata sandi',
     'Administrator' => 'Administrator',
     'Sign in' => 'Masuk',
+	// 'Sign up' => '',
     'Users' => 'Pengguna',
     'Forbidden' => 'Terlarang',
     'Access Forbidden' => 'Akses Dilarang',

--- a/app/Locale/it_IT/translations.php
+++ b/app/Locale/it_IT/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Password',
     'Administrator' => 'Amministratore',
     'Sign in' => 'Accedi',
+	// 'Sign up' => '',
     'Users' => 'Utenti',
     'Forbidden' => 'Vietato',
     'Access Forbidden' => 'Accesso vietato',

--- a/app/Locale/ja_JP/translations.php
+++ b/app/Locale/ja_JP/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'パスワード',
     'Administrator' => 'システム管理者',
     'Sign in' => 'ログイン',
+	// 'Sign up' => '',
     'Users' => 'ユーザー',
     'Forbidden' => 'アクセス拒否',
     'Access Forbidden' => 'アクセスが拒否されました',

--- a/app/Locale/ko_KR/translations.php
+++ b/app/Locale/ko_KR/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => '패스워드',
     'Administrator' => '관리자',
     'Sign in' => '로그인',
+	// 'Sign up' => '',
     'Users' => '사용자',
     'Forbidden' => '접근 거부',
     'Access Forbidden' => '접속이 거부되었습니다',

--- a/app/Locale/my_MY/translations.php
+++ b/app/Locale/my_MY/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Kata laluan',
     'Administrator' => 'Pentadbir',
     'Sign in' => 'Masuk',
+	// 'Sign up' => '',
     'Users' => 'Para Pengguna',
     'Forbidden' => 'Larangan',
     'Access Forbidden' => 'Akses Dilarang',

--- a/app/Locale/nb_NO/translations.php
+++ b/app/Locale/nb_NO/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Passord',
     'Administrator' => 'Administrator',
     'Sign in' => 'Logg inn',
+	// 'Sign up' => '',
     'Users' => 'Brukere',
     'Forbidden' => 'Ikke tillatt',
     'Access Forbidden' => 'Adgang ikke tillatt',

--- a/app/Locale/nl_NL/translations.php
+++ b/app/Locale/nl_NL/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Wachtwoord',
     'Administrator' => 'Administrator',
     'Sign in' => 'Inloggen',
+	// 'Sign up' => '',
     'Users' => 'Gebruikers',
     'Forbidden' => 'Geweigerd',
     'Access Forbidden' => 'Toegang geweigerd',

--- a/app/Locale/pl_PL/translations.php
+++ b/app/Locale/pl_PL/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Hasło',
     'Administrator' => 'Administrator',
     'Sign in' => 'Zaloguj',
+	// 'Sign up' => '',
     'Users' => 'Użytkownicy',
     'Forbidden' => 'Zabroniony',
     'Access Forbidden' => 'Dostęp zabroniony',

--- a/app/Locale/pt_BR/translations.php
+++ b/app/Locale/pt_BR/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Senha',
     'Administrator' => 'Administrador',
     'Sign in' => 'Entrar',
+	// 'Sign up' => '',
     'Users' => 'Usuários',
     'Forbidden' => 'Proibido',
     'Access Forbidden' => 'Acesso negado',

--- a/app/Locale/pt_PT/translations.php
+++ b/app/Locale/pt_PT/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Senha',
     'Administrator' => 'Administrador',
     'Sign in' => 'Entrar',
+	// 'Sign up' => '',
     'Users' => 'Utilizadores',
     'Forbidden' => 'Proibido',
     'Access Forbidden' => 'Acesso negado',

--- a/app/Locale/ro_RO/translations.php
+++ b/app/Locale/ro_RO/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Parolă',
     'Administrator' => 'Administrator',
     'Sign in' => 'Conectare',
+	// 'Sign up' => '',
     'Users' => 'Utilizatori',
     'Forbidden' => 'Interzis',
     'Access Forbidden' => 'Acces interzis',

--- a/app/Locale/ru_RU/translations.php
+++ b/app/Locale/ru_RU/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Пароль',
     'Administrator' => 'Администратор',
     'Sign in' => 'Войти',
+	// 'Sign up' => '',
     'Users' => 'Пользователи',
     'Forbidden' => 'Запрещено',
     'Access Forbidden' => 'Доступ запрещён',

--- a/app/Locale/sr_Latn_RS/translations.php
+++ b/app/Locale/sr_Latn_RS/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Lozinka',
     'Administrator' => 'Administrator',
     'Sign in' => 'Odjava',
+	// 'Sign up' => '',
     'Users' => 'Korisnik',
     'Forbidden' => 'Zabranjeno',
     'Access Forbidden' => 'Zabranjen prostup',

--- a/app/Locale/sv_SE/translations.php
+++ b/app/Locale/sv_SE/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Lösenord',
     'Administrator' => 'Administratör',
     'Sign in' => 'Logga in',
+	// 'Sign up' => '',
     'Users' => 'Användare',
     'Forbidden' => 'Ej tillåten',
     'Access Forbidden' => 'Ej tillåten',

--- a/app/Locale/th_TH/translations.php
+++ b/app/Locale/th_TH/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'รหัสผ่าน',
     'Administrator' => 'ผู้ดูแลระบบ',
     'Sign in' => 'เข้าสู่ระบบ',
+	// 'Sign up' => '',
     'Users' => 'ผู้ใช้',
     'Forbidden' => 'ไม่อนุญาต',
     'Access Forbidden' => 'ไม่อนุญาตให้เข้า',

--- a/app/Locale/tr_TR/translations.php
+++ b/app/Locale/tr_TR/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Şifre',
     'Administrator' => 'Yönetici',
     'Sign in' => 'Giriş yap',
+	// 'Sign up' => '',
     'Users' => 'Kullanıcılar',
     'Forbidden' => 'Yasak',
     'Access Forbidden' => 'Erişim yasak',

--- a/app/Locale/vi_VN/translations.php
+++ b/app/Locale/vi_VN/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => 'Mật khẩu',
     'Administrator' => 'Người quản lý',
     'Sign in' => 'Đăng nhập',
+	// 'Sign up' => '',
     'Users' => 'Người dùng',
     'Forbidden' => 'Forbidden',
     'Access Forbidden' => 'Truy cập bị cấm',

--- a/app/Locale/zh_CN/translations.php
+++ b/app/Locale/zh_CN/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => '密码',
     'Administrator' => '超级管理员',
     'Sign in' => '登录',
+	// 'Sign up' => '',
     'Users' => '用户',
     'Forbidden' => '禁止',
     'Access Forbidden' => '禁止进入',

--- a/app/Locale/zh_TW/translations.php
+++ b/app/Locale/zh_TW/translations.php
@@ -38,6 +38,7 @@ return array(
     'Password' => '密碼',
     'Administrator' => '管理者',
     'Sign in' => '登入',
+	// 'Sign up' => '',
     'Users' => '帳號',
     'Forbidden' => '禁止',
     'Access Forbidden' => '禁止進入',


### PR DESCRIPTION
This PR contains the text string "sign up" from the login screen. This values was not in the translation files. so i added them and give a translation for german.