### PR TITLE
Set the correct swimlane/column ID when moving a task via its dialog.

### DIFF
--- a/app/Template/task_move_position/show.php
+++ b/app/Template/task_move_position/show.php
@@ -7,6 +7,7 @@
 <?= $this->app->component('task-move-position', array(
     'saveUrl' => $this->url->href('TaskMovePositionController', 'save', array('task_id' => $task['id'], 'project_id' => $task['project_id'])),
     'board' => $board,
+    'task' => $task,
     'swimlaneLabel' => t('Swimlane'),
     'columnLabel' => t('Column'),
     'positionLabel' => t('Position'),

--- a/assets/js/components/task-move-position.js
+++ b/assets/js/components/task-move-position.js
@@ -85,7 +85,11 @@ KB.component('task-move-position', function (containerElement, options) {
         var swimlanes = [];
 
         options.board.forEach(function(swimlane) {
-            swimlanes.push({'value': swimlane.id, 'text': swimlane.name});
+            var option = {'value': swimlane.id, 'text': swimlane.name};
+            if(swimlane.id == options.task.swimlane_id) {
+                option.selected = "";
+            }
+            swimlanes.push(option);
         });
 
         return KB.dom('select')
@@ -102,7 +106,11 @@ KB.component('task-move-position', function (containerElement, options) {
         options.board.forEach(function(swimlane) {
             if (swimlaneId === swimlane.id) {
                 swimlane.columns.forEach(function(column) {
-                    columns.push({'value': column.id, 'text': column.title});
+                    var option = {'value': column.id, 'text': column.title};
+                    if(column.id == options.task.column_id) {
+                        option.selected = "";
+                    }
+                    columns.push(option);
                 });
             }
         });


### PR DESCRIPTION
Fixes https://github.com/kanboard/kanboard/issues/3114.