### PR TITLE
make it possibe to configer reply-to, authorname, in send

### DIFF
--- a/app/Core/Mail/Client.php
+++ b/app/Core/Mail/Client.php
@@ -44,7 +44,7 @@ class Client extends Base
      * @param  string  $html
      * @return Client
      */
-    public function send($recipientEmail, $recipientName, $subject, $html, $authorName=null, $authorEmail=null)
+    public function send($recipientEmail, $recipientName, $subject, $html, $authorName = null, $authorEmail = null)
     {
         if (! empty($recipientEmail)) {
             $this->queueManager->push(EmailJob::getInstance($this->container)->withParams(
@@ -52,8 +52,8 @@ class Client extends Base
                 $recipientName,
                 $subject,
                 $html,
-                (is_null ($authorName) ? $this->getAuthorName() : $authorName),
-                (is_null ($authorEmail)? $this->getAuthorEmail(): $authorEmail)
+                is_null($authorName) ? $this->getAuthorName() : $authorName,
+                is_null($authorEmail) ? $this->getAuthorEmail() : $authorEmail
             ));
         }
 

--- a/app/Core/Mail/Client.php
+++ b/app/Core/Mail/Client.php
@@ -44,7 +44,7 @@ class Client extends Base
      * @param  string  $html
      * @return Client
      */
-    public function send($recipientEmail, $recipientName, $subject, $html)
+    public function send($recipientEmail, $recipientName, $subject, $html, $authorName=null, $authorEmail=null)
     {
         if (! empty($recipientEmail)) {
             $this->queueManager->push(EmailJob::getInstance($this->container)->withParams(
@@ -52,8 +52,8 @@ class Client extends Base
                 $recipientName,
                 $subject,
                 $html,
-                $this->getAuthorName(),
-                $this->getAuthorEmail()
+                (is_null ($authorName) ? $this->getAuthorName() : $authorName),
+                (is_null ($authorEmail)? $this->getAuthorEmail(): $authorEmail)
             ));
         }
 


### PR DESCRIPTION
Hi, I am working on a plug-in for kanboard to extend mail functionality. 
To make kanboard usable for us ([at computing](www.atcomputing.nl)) system for remote support.  Our plug-in would work better if you could optional  configure reply-to, author name, in send function.

this patch keeps the original behaviour of send function. but if  you can supply it with extra arguments, to make it more configurable.
  
We could do without this patch. But we hope you like it, Comments our welcome.  
