### PR TITLE
Update link to Docker Volume documentation.

### DIFF
--- a/doc/en_US/docker.markdown
+++ b/doc/en_US/docker.markdown
@@ -56,7 +56,7 @@ You can attach 2 volumes to your container:
 - Data folder: `/var/www/app/data`
 - Plugins folder: `/var/www/app/plugins`
 
-Use the flag `-v` to mount a volume on the host machine like described in [official Docker documentation](https://docs.docker.com/engine/userguide/containers/dockervolumes/).
+Use the flag `-v` to mount a volume on the host machine like described in [official Docker documentation](https://docs.docker.com/storage/volumes/).
 
 There is also a `docker-compose.yml` file in the repository.
 

--- a/doc/es_ES/docker.markdown
+++ b/doc/es_ES/docker.markdown
@@ -70,7 +70,7 @@ Usted puede adjuntar dos volúmenes de su contenedor:
 - Complementos de carpeta: `/var/www/app/plugins`
 
 
-Use el indicador `-v` par montar un volumen en el ordenador central como se describe en [official Docker documentation](https://docs.docker.com/engine/userguide/containers/dockervolumes/).
+Use el indicador `-v` par montar un volumen en el ordenador central como se describe en [official Docker documentation](https://docs.docker.com/storage/volumes/).
 
 
 Actualizar contenedor

--- a/doc/ru_RU/docker.markdown
+++ b/doc/ru_RU/docker.markdown
@@ -89,7 +89,7 @@
 
 
 
-Используйте опцию `-v` для монтирования тома на удаленной машине как описано в [официальной документации Docker](https://docs.docker.com/engine/userguide/containers/dockervolumes/).
+Используйте опцию `-v` для монтирования тома на удаленной машине как описано в [официальной документации Docker](https://docs.docker.com/storage/volumes/).
 
 
 

--- a/doc/tr_TR/docker.markdown
+++ b/doc/tr_TR/docker.markdown
@@ -67,7 +67,7 @@ Kapsayıcınıza-konyetner 2 cilt bağlayabilirsiniz:
 - Veri klasörü: `/var/www/app/data`
 - Eklentiler-Plugins klasörü: `/var/www/app/plugins`
 
-[Resmi Docker belgeleri](https://docs.docker.com/engine/userguide/containers/dockervolumes/) 'da açıklandığı gibi, ana makineye bir hacim bağlamak için  `-v` parametresi-bayrağını kullanın.
+[Resmi Docker belgeleri](https://docs.docker.com/storage/volumes/) 'da açıklandığı gibi, ana makineye bir hacim bağlamak için  `-v` parametresi-bayrağını kullanın.
 
 Kapsayıcınızı-Konteyner Yükseltme
 ----------------------


### PR DESCRIPTION
In the docs, the link to docker volumes documentation is broken. 

This pull request updates the docs with the new link for all languages that mention it.
