### PR TITLE
add ProjectMetaDataProcedure to JSONRPC api

### DIFF
--- a/app/Api/Procedure/ProjectMetaDataProcedure.php
+++ b/app/Api/Procedure/ProjectMetaDataProcedure.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Kanboard\Api\Procedure;
+
+use Kanboard\Api\Authorization\ProjectAuthorization;
+
+/**
+ * Class ProjectMetadataProcedure
+ *
+ * @package Kanboard\Api\Procedure
+ * @author  Frederic Guillot
+ */
+class ProjectMetadataProcedure extends BaseProcedure
+{
+    public function getProjectMetadata($project_id)
+    {
+        ProjectAuthorization::getInstance($this->container)->check($this->getClassName(), 'getProject', $project_id);
+        return (object) $this->projectMetadataModel->getAll($project_id);
+    }
+
+    public function getProjectMetadataByName($project_id, $name)
+    {
+        ProjectAuthorization::getInstance($this->container)->check($this->getClassName(), 'getProject', $project_id);
+        return $this->projectMetadataModel->get($project_id, $name);
+    }
+
+    public function saveProjectMetadata($project_id, array $values)
+    {
+        ProjectAuthorization::getInstance($this->container)->check($this->getClassName(), 'updateProject', $project_id);
+        return $this->projectMetadataModel->save($project_id, $values);
+    }
+
+    public function removeProjectMetadata($project_id, $name)
+    {
+        ProjectAuthorization::getInstance($this->container)->check($this->getClassName(), 'updateProject', $project_id);
+        return $this->projectMetadataModel->remove($project_id, $name);
+    }
+}

--- a/app/ServiceProvider/ApiProvider.php
+++ b/app/ServiceProvider/ApiProvider.php
@@ -10,6 +10,7 @@ use Kanboard\Api\Procedure\CategoryProcedure;
 use Kanboard\Api\Procedure\ColumnProcedure;
 use Kanboard\Api\Procedure\CommentProcedure;
 use Kanboard\Api\Procedure\ProjectFileProcedure;
+use Kanboard\Api\Procedure\ProjectMetadataProcedure;
 use Kanboard\Api\Procedure\TagProcedure;
 use Kanboard\Api\Procedure\TaskExternalLinkProcedure;
 use Kanboard\Api\Procedure\TaskFileProcedure;
@@ -66,6 +67,7 @@ class ApiProvider implements ServiceProviderInterface
             ->withObject(new LinkProcedure($container))
             ->withObject(new ProjectProcedure($container))
             ->withObject(new ProjectPermissionProcedure($container))
+            ->withObject(new ProjectMetadataProcedure($container))
             ->withObject(new SubtaskProcedure($container))
             ->withObject(new SubtaskTimeTrackingProcedure($container))
             ->withObject(new SwimlaneProcedure($container))


### PR DESCRIPTION
The JSONRPC API is lacking methods to manage the project's metadata.

So I adapted the code from `taskMetaDataProcedure` to `projectMetaDataProcedure` and registered it in the APIProvider. 

Saddly I wasn't able to run the PHPUnit tests on my new environment. I'll try again later.