### PR TITLE
Add default filter per user

### DIFF
--- a/app/Controller/UserModificationController.php
+++ b/app/Controller/UserModificationController.php
@@ -54,6 +54,7 @@ class UserModificationController extends BaseController
                 'email' => isset($values['email']) ? $values['email'] : '',
                 'timezone' => isset($values['timezone']) ? $values['timezone'] : '',
                 'language' => isset($values['language']) ? $values['language'] : '',
+                'filter' => isset($values['filter']) ? $values['filter'] : '',
             );
         }
 

--- a/app/Core/User/UserSession.php
+++ b/app/Core/User/UserSession.php
@@ -223,7 +223,8 @@ class UserSession extends Base
     public function getFilters($projectID)
     {
         if (! session_exists('filters:'.$projectID)) {
-            return 'status:open';
+            // return 'status:open';
+            return session_get('user')['filter'];
         }
 
         return session_get('filters:'.$projectID);

--- a/app/Schema/Mysql.php
+++ b/app/Schema/Mysql.php
@@ -8,7 +8,12 @@ use PDO;
 use Kanboard\Core\Security\Token;
 use Kanboard\Core\Security\Role;
 
-const VERSION = 127;
+const VERSION = 128;
+
+function version_188(PDO $pdo)
+{
+    $pdo->exec('ALTER TABLE `users` ADD COLUMN `filter` VARCHAR(255) DEFAULT NULL');
+}
 
 function version_127(PDO $pdo)
 {

--- a/app/Schema/Postgres.php
+++ b/app/Schema/Postgres.php
@@ -8,7 +8,12 @@ use PDO;
 use Kanboard\Core\Security\Token;
 use Kanboard\Core\Security\Role;
 
-const VERSION = 106;
+const VERSION = 107;
+
+function version_107(PDO $pdo)
+{
+    $pdo->exec('ALTER TABLE "users" ADD COLUMN filter VARCHAR(255) DEFAULT NULL');
+}
 
 function version_106(PDO $pdo)
 {

--- a/app/Schema/Sql/mysql.sql
+++ b/app/Schema/Sql/mysql.sql
@@ -752,6 +752,7 @@ CREATE TABLE `users` (
   `is_active` tinyint(1) DEFAULT '1',
   `avatar_path` varchar(255) DEFAULT NULL,
   `api_access_token` varchar(255) DEFAULT NULL,
+  `filter` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `users_username_idx` (`username`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/app/Schema/Sql/postgres.sql
+++ b/app/Schema/Sql/postgres.sql
@@ -1299,7 +1299,8 @@ CREATE TABLE "users" (
     "role" character varying(25) DEFAULT 'app-user'::character varying NOT NULL,
     "is_active" boolean DEFAULT true,
     "avatar_path" character varying(255),
-    "api_access_token" character varying(255) DEFAULT NULL::character varying
+    "api_access_token" character varying(255) DEFAULT NULL::character varying,
+    "filter" character varying(255) DEFAULT NULL::character varying
 );
 
 

--- a/app/Schema/Sqlite.php
+++ b/app/Schema/Sqlite.php
@@ -8,7 +8,12 @@ use Kanboard\Core\Security\Token;
 use Kanboard\Core\Security\Role;
 use PDO;
 
-const VERSION = 117;
+const VERSION = 118;
+
+function version_118(PDO $pdo)
+{
+    $pdo->exec('ALTER TABLE users ADD COLUMN filter VARCHAR(255) DEFAULT NULL');
+}
 
 function version_117(PDO $pdo)
 {

--- a/app/Template/user_creation/show.php
+++ b/app/Template/user_creation/show.php
@@ -50,6 +50,9 @@
 
                 <?= $this->form->label(t('Language'), 'language') ?>
                 <?= $this->form->select('language', $languages, $values, $errors) ?>
+                
+                <?= $this->form->label(t('Filter'), 'filter') ?>
+                <?= $this->form->text('filter', $values, $errors) ?>
 
                 <?= $this->form->checkbox('notifications_enabled', t('Enable email notifications'), 1, isset($values['notifications_enabled']) && $values['notifications_enabled'] == 1 ? true : false) ?>
             </fieldset>

--- a/app/Template/user_modification/show.php
+++ b/app/Template/user_modification/show.php
@@ -26,7 +26,7 @@
         <?= $this->form->select('language', $languages, $values, $errors, array($this->user->hasAccess('UserModificationController', 'show/edit_language') ? '' : 'disabled')) ?>
         
         <?= $this->form->label(t('Filter'), 'filter') ?>
-        <?= $this->form->text('filter', $values, $errors, array($this->user->hasAccess('UserModificationController', 'show/edit_name') ? '' : 'readonly')) ?>
+        <?= $this->form->text('filter', $values, $errors, array($this->user->hasAccess('UserModificationController', 'show/edit_filter') ? '' : 'readonly')) ?>
     </fieldset>
 
     <?php if ($this->user->isAdmin()): ?>

--- a/app/Template/user_modification/show.php
+++ b/app/Template/user_modification/show.php
@@ -24,6 +24,9 @@
 
         <?= $this->form->label(t('Language'), 'language') ?>
         <?= $this->form->select('language', $languages, $values, $errors, array($this->user->hasAccess('UserModificationController', 'show/edit_language') ? '' : 'disabled')) ?>
+        
+        <?= $this->form->label(t('Filter'), 'filter') ?>
+        <?= $this->form->text('filter', $values, $errors, array($this->user->hasAccess('UserModificationController', 'show/edit_name') ? '' : 'readonly')) ?>
     </fieldset>
 
     <?php if ($this->user->isAdmin()): ?>

--- a/app/Template/user_view/show.php
+++ b/app/Template/user_view/show.php
@@ -33,6 +33,7 @@
 <ul class="panel">
     <li><?= t('Timezone:') ?> <strong><?= $this->text->in($user['timezone'], $timezones) ?></strong></li>
     <li><?= t('Language:') ?> <strong><?= $this->text->in($user['language'], $languages) ?></strong></li>
+    <li><?= t('Filter:') ?> <strong><?= $this->text->e($user['filter']) ?></strong></li>
     <li><?= t('Notifications:') ?> <strong><?= $user['notifications_enabled'] == 1 ? t('Enabled') : t('Disabled') ?></strong></li>
 </ul>
 


### PR DESCRIPTION
Each user can have a default filter rather than `status: open`.

This pull request is related to issues #1323, #2222, #3225, #3261 and #3413.