### PR TITLE
Better notifications (subtask and task_overdue)

### DIFF
--- a/app/Console/TaskOverdueNotificationCommand.php
+++ b/app/Console/TaskOverdueNotificationCommand.php
@@ -180,7 +180,7 @@ class TaskOverdueNotificationCommand extends BaseCommand
         $this->userNotificationModel->sendUserNotification(
             $manager,
             TaskModel::EVENT_OVERDUE,
-            array('tasks' => $tasks, 'project_name' => $tasks[0]['project_name'])
+            array('tasks' => $tasks, 'project_name' => $tasks[0]['project_name'], 'project_id' => $tasks[0]['project_id'])
         );
     }
 

--- a/app/Template/notification/footer.php
+++ b/app/Template/notification/footer.php
@@ -2,6 +2,8 @@
 Kanboard
 
 <?php if ($this->app->config('application_url') != ''): ?>
-    - <?= $this->url->absoluteLink(t('view the task on Kanboard'), 'TaskViewController', 'show', array('task_id' => $task['id'], 'project_id' => $task['project_id'])) ?>
+    <?php if (isset($task['id'])): ?>
+        - <?= $this->url->absoluteLink(t('view the task on Kanboard'), 'TaskViewController', 'show', array('task_id' => $task['id'], 'project_id' => $task['project_id'])) ?>
+    <?php endif ?>
     - <?= $this->url->absoluteLink(t('view the board on Kanboard'), 'BoardViewController', 'show', array('project_id' => $task['project_id'])) ?>
 <?php endif ?>

--- a/app/Template/notification/subtask_create.php
+++ b/app/Template/notification/subtask_create.php
@@ -4,14 +4,14 @@
 
 <ul>
     <li><?= t('Title:') ?> <?= $this->text->e($subtask['title']) ?></li>
-    <li><?= t('Status:') ?> <?= $this->text->e($subtask['status_name']) ?></li>
+    <li><?= t('Status:') ?> <?= t($this->text->e($subtask['status_name'])) ?></li>
     <li><?= t('Assignee:') ?> <?= $this->text->e($subtask['name'] ?: $subtask['username'] ?: '?') ?></li>
-    <li>
-        <?= t('Time tracking:') ?>
-        <?php if (! empty($subtask['time_estimated'])): ?>
+    <?php if (! empty($subtask['time_estimated'])): ?>
+        <li>
+            <?= t('Time tracking:') ?>
             <strong><?= $this->text->e($subtask['time_estimated']).'h' ?></strong> <?= t('estimated') ?>
-        <?php endif ?>
-    </li>
+        </li>
+    <?php endif ?>
 </ul>
 
 <?= $this->render('notification/footer', array('task' => $task)) ?>

--- a/app/Template/notification/subtask_create.php
+++ b/app/Template/notification/subtask_create.php
@@ -4,7 +4,7 @@
 
 <ul>
     <li><?= t('Title:') ?> <?= $this->text->e($subtask['title']) ?></li>
-    <li><?= t('Status:') ?> <?= t($this->text->e($subtask['status_name'])) ?></li>
+    <li><?= t('Status:') ?> <?= t($subtask['status_name']) ?></li>
     <li><?= t('Assignee:') ?> <?= $this->text->e($subtask['name'] ?: $subtask['username'] ?: '?') ?></li>
     <?php if (! empty($subtask['time_estimated'])): ?>
         <li>

--- a/app/Template/notification/subtask_delete.php
+++ b/app/Template/notification/subtask_delete.php
@@ -4,7 +4,7 @@
 
 <ul>
     <li><?= t('Title:') ?> <?= $this->text->e($subtask['title']) ?></li>
-    <li><?= t('Status:') ?> <?= t($this->text->e($subtask['status_name'])) ?></li>
+    <li><?= t('Status:') ?> <?= t($subtask['status_name']) ?></li>
     <li><?= t('Assignee:') ?> <?= $this->text->e($subtask['name'] ?: $subtask['username'] ?: '?') ?></li>
 </ul>
 

--- a/app/Template/notification/subtask_delete.php
+++ b/app/Template/notification/subtask_delete.php
@@ -4,7 +4,7 @@
 
 <ul>
     <li><?= t('Title:') ?> <?= $this->text->e($subtask['title']) ?></li>
-    <li><?= t('Status:') ?> <?= $this->text->e($subtask['status_name']) ?></li>
+    <li><?= t('Status:') ?> <?= t($this->text->e($subtask['status_name'])) ?></li>
     <li><?= t('Assignee:') ?> <?= $this->text->e($subtask['name'] ?: $subtask['username'] ?: '?') ?></li>
 </ul>
 

--- a/app/Template/notification/subtask_update.php
+++ b/app/Template/notification/subtask_update.php
@@ -4,7 +4,7 @@
 
 <ul>
     <li><?= t('Title:') ?> <?= $this->text->e($subtask['title']) ?></li>
-    <li><?= t('Status:') ?> <?= t($this->text->e($subtask['status_name'])) ?></li>
+    <li><?= t('Status:') ?> <?= t($subtask['status_name']) ?></li>
     <li><?= t('Assignee:') ?> <?= $this->text->e($subtask['name'] ?: $subtask['username'] ?: '?') ?></li>
     <?php if (! empty($subtask['time_spent']) or ! empty($subtask['time_estimated'])): ?>
     <li>

--- a/app/Template/notification/subtask_update.php
+++ b/app/Template/notification/subtask_update.php
@@ -4,18 +4,19 @@
 
 <ul>
     <li><?= t('Title:') ?> <?= $this->text->e($subtask['title']) ?></li>
-    <li><?= t('Status:') ?> <?= $this->text->e($subtask['status_name']) ?></li>
+    <li><?= t('Status:') ?> <?= t($this->text->e($subtask['status_name'])) ?></li>
     <li><?= t('Assignee:') ?> <?= $this->text->e($subtask['name'] ?: $subtask['username'] ?: '?') ?></li>
+    <?php if (! empty($subtask['time_spent']) or ! empty($subtask['time_estimated'])): ?>
     <li>
         <?= t('Time tracking:') ?>
         <?php if (! empty($subtask['time_spent'])): ?>
             <strong><?= $this->text->e($subtask['time_spent']).'h' ?></strong> <?= t('spent') ?>
         <?php endif ?>
-
         <?php if (! empty($subtask['time_estimated'])): ?>
             <strong><?= $this->text->e($subtask['time_estimated']).'h' ?></strong> <?= t('estimated') ?>
         <?php endif ?>
     </li>
+    <?php endif ?>
 </ul>
 
 <?= $this->render('notification/footer', array('task' => $task)) ?>

--- a/app/Template/notification/task_internal_link_create_update.php
+++ b/app/Template/notification/task_internal_link_create_update.php
@@ -3,7 +3,7 @@
 <p>
     <?= e('This task is now linked to the task %s with the relation "%s"',
           $this->url->absoluteLink(t('#%d', $task_link['opposite_task_id']), 'TaskViewController', 'show', array('task_id' => $task_link['opposite_task_id'])),
-          t($this->text->e($task_link['label']))) ?>
+          t($task_link['label'])) ?>
 </p>
 
 <?= $this->render('notification/footer', array('task' => $task)) ?>

--- a/app/Template/notification/task_internal_link_create_update.php
+++ b/app/Template/notification/task_internal_link_create_update.php
@@ -3,7 +3,7 @@
 <p>
     <?= e('This task is now linked to the task %s with the relation "%s"',
           $this->url->absoluteLink(t('#%d', $task_link['opposite_task_id']), 'TaskViewController', 'show', array('task_id' => $task_link['opposite_task_id'])),
-          $this->text->e($task_link['label'])) ?>
+          t($this->text->e($task_link['label']))) ?>
 </p>
 
 <?= $this->render('notification/footer', array('task' => $task)) ?>

--- a/app/Template/notification/task_internal_link_delete.php
+++ b/app/Template/notification/task_internal_link_delete.php
@@ -2,7 +2,7 @@
 
 <p>
     <?= e('The link with the relation "%s" to the task %s has been removed',
-          t($this->text->e($task_link['label'])),
+          t($task_link['label']),
           $this->url->absoluteLink(t('#%d', $task_link['opposite_task_id']), 'TaskViewController', 'show', array('task_id' => $task_link['opposite_task_id']))) ?>
 </p>
 

--- a/app/Template/notification/task_internal_link_delete.php
+++ b/app/Template/notification/task_internal_link_delete.php
@@ -2,7 +2,7 @@
 
 <p>
     <?= e('The link with the relation "%s" to the task %s has been removed',
-          $this->text->e($task_link['label']),
+          t($this->text->e($task_link['label'])),
           $this->url->absoluteLink(t('#%d', $task_link['opposite_task_id']), 'TaskViewController', 'show', array('task_id' => $task_link['opposite_task_id']))) ?>
 </p>
 

--- a/app/Template/notification/task_overdue.php
+++ b/app/Template/notification/task_overdue.php
@@ -13,14 +13,20 @@
         <tr style="overflow: hidden; background: #fff; text-align: left; padding-top: .5em; padding-bottom: .5em; padding-left: 3px; padding-right: 3px;">
             <td style="border: 1px solid #eee;">#<?= $task['id'] ?></td>
             <td style="border: 1px solid #eee;">
-                <?php if (! empty($application_url)): ?>
+                <?php if ($this->app->config('application_url') != ''): ?>
                     <?= $this->url->absoluteLink($this->text->e($task['title']), 'TaskViewController', 'show', array('task_id' => $task['id'], 'project_id' => $task['project_id'])) ?>
                 <?php else: ?>
                     <?= $this->text->e($task['title']) ?>
                 <?php endif ?>
             </td>
             <td style="border: 1px solid #eee;"><?= $this->dt->datetime($task['date_due']) ?></td>
-            <td style="border: 1px solid #eee;"><?= $this->text->e($task['project_name']) ?></td>
+            <td style="border: 1px solid #eee;">
+                <?php if ($this->app->config('application_url') != ''): ?>
+                    <?= $this->url->absoluteLink($this->text->e($task['project_name']), 'BoardViewController', 'show', array('project_id' => $task['project_id'])) ?>
+                <?php else: ?>
+                    <?= $this->text->e($task['project_name']) ?>
+                <?php endif ?>
+            </td>
             <td style="border: 1px solid #eee;">
                 <?php if (! empty($task['assignee_username'])): ?>
                     <?= $this->text->e($task['assignee_name'] ?: $task['assignee_username']) ?>
@@ -29,3 +35,5 @@
         </tr>
     <?php endforeach ?>
 </table>
+
+<?= $this->render('notification/footer', array('task' => array('project_id' => $project_id))) ?>

--- a/app/Template/notification/task_overdue.php
+++ b/app/Template/notification/task_overdue.php
@@ -35,5 +35,3 @@
         </tr>
     <?php endforeach ?>
 </table>
-
-<?= $this->render('notification/footer', array('task' => array('project_id' => $project_id))) ?>


### PR DESCRIPTION
Should fix #3525 : 

- repairing links on task in the task_overdue notification
- add a footer in the task_overdue notification
- change notification footer to manage the case where we don't have a task id (task overdue notification)

Should fix #3818 :

- translate statuses in subtask creation and deletion notification
- don't show time management if not used

And more : 

- translate label of the link between tasks