### PR TITLE
Add SSL functionality to docker install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,14 @@ FROM alpine:3.7
 
 VOLUME /var/www/app/data
 VOLUME /var/www/app/plugins
+VOLUME /etc/nginx/ssl
+EXPOSE 80 443
 
-EXPOSE 80
 
 ARG VERSION
 
 RUN apk update && \
-    apk add unzip nginx bash ca-certificates s6 curl ssmtp mailx php7 php7-phar php7-curl \
+    apk add openssl unzip nginx bash ca-certificates s6 curl ssmtp mailx php7 php7-phar php7-curl \
     php7-fpm php7-json php7-zlib php7-xml php7-dom php7-ctype php7-opcache php7-zip php7-iconv \
     php7-pdo php7-pdo_mysql php7-pdo_sqlite php7-pdo_pgsql php7-mbstring php7-session \
     php7-gd php7-mcrypt php7-openssl php7-sockets php7-posix php7-ldap php7-simplexml && \
@@ -25,6 +26,9 @@ RUN cd /tmp \
     && rm -rf /tmp/kanboard-* /tmp/*.zip
 
 ADD docker/ /
+
+
+
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD []

--- a/docker/etc/nginx/nginx.conf
+++ b/docker/etc/nginx/nginx.conf
@@ -20,6 +20,9 @@ http {
 
     server {
         listen       80;
+        listen       443 ssl;
+        ssl_certificate /etc/nginx/ssl/kanboard.crt;
+        ssl_certificate_key /etc/nginx/ssl/kanboard.key;
         server_name  localhost;
         index        index.php;
         root         /var/www/app;

--- a/docker/usr/local/bin/entrypoint.sh
+++ b/docker/usr/local/bin/entrypoint.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+#generate a new self signed SSL certificate when none is provided in the volume
+if [ ! -f /etc/nginx/ssl/kanboard.key  ] || [ ! -f /etc/nginx/ssl/kanboard.crt ]
+then
+    openssl req -x509 -nodes -newkey rsa:2048 -keyout /etc/nginx/ssl/kanboard.key -out /etc/nginx/ssl/kanboard.crt -subj "/C=GB/ST=London/L=London/O=Self Signed/OU=IT Department/CN=kanboard.org"
+fi
+
 chown -R nginx:nginx /var/www/app/data
 chown -R nginx:nginx /var/www/app/plugins
 


### PR DESCRIPTION
[x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)

### Getting HTTPS request to work with a docker deployment
I've recently changed to a deployment with docker and was looking for a SSL solution (e.g. treat https requests). I've added my solution in this pull request so feel free to reuse/modify the solution if it is deemed practical. These are relatively small changes and basically just add the option of using ssl to the docker image, plain http still works as well. Users may opt for adding their own ssl certificates, but otherwise a self-signed version is generated.

### Modifications
To get this working I've added a few changes to the docker files.

Dockerfile:
* Install openssl to the docker image (only needed for generation of self signed certificates)
* Expose port 80 (http) and 443 (https)
* Add a dedicated volume to store ssl certificates  (/etc/nginx/ssl)

docker/etc/nginx/nginx.conf:
* Allow both http (port 80) and https (port 443) in nginx.conf and set paths to certificates (kanboard.crt and kanboard.key)

docker/usr/local/bin/entrypoint.sh 
* add a  check which generates self signed ssl certificates when not provided explicitly

### Suggestion for documentation change
If deemed useful, the above probably needs a few modifications in the [documentation](https://docs.kanboard.org/en/latest/admin_guide/docker.html):
* Add note on the additional ssl volume
* add a dedicated command for running the SSL version e.g. `docker run -d --name kanboard -p 443:443 -t kanboard/kanboard:latest`

In any case: A big thank you for this awesome software!

Roelof