### PR TITLE
Don't markdown project owner's name in tooltip

### DIFF
--- a/app/Helper/AppHelper.php
+++ b/app/Helper/AppHelper.php
@@ -17,6 +17,11 @@ class AppHelper extends Base
         return '<span class="tooltip"><i class="fa '.$icon.'"></i><script type="text/template"><div class="markdown">'.$this->helper->text->markdown($markdownText).'</div></script></span>';
     }
 
+    public function tooltipHTML($htmlText, $icon = 'fa-info-circle')
+    {
+        return '<span class="tooltip"><i class="fa '.$icon.'"></i><script type="text/template"><div class="markdown">'.$htmlText.'</div></script></span>';
+    }
+
     public function tooltipLink($label, $link)
     {
         return '<span class="tooltip" data-href="'.$link.'">'.$label.'</span>';

--- a/app/Helper/ProjectHeaderHelper.php
+++ b/app/Helper/ProjectHeaderHelper.php
@@ -67,14 +67,14 @@ class ProjectHeaderHelper extends Base
     public function getDescription(array &$project)
     {
         if ($project['owner_id'] > 0) {
-            $description = t('Project owner: ').'**'.$this->helper->text->e($project['owner_name'] ?: $project['owner_username']).'**'.PHP_EOL.PHP_EOL;
+            $description = t('Project owner: ').'<strong>'.$this->helper->text->e($project['owner_name'] ?: $project['owner_username']).'</strong>'.PHP_EOL.PHP_EOL;
 
             if (! empty($project['description'])) {
-                $description .= '***'.PHP_EOL.PHP_EOL;
-                $description .= $project['description'];
+                $description .= '<hr>'.PHP_EOL.PHP_EOL;
+                $description .= $this->helper->text->markdown($project['description']);
             }
         } else {
-            $description = $project['description'];
+            $description = $this->helper->text->markdown($project['description']);
         }
 
         return $description;

--- a/app/Template/header/title.php
+++ b/app/Template/header/title.php
@@ -10,6 +10,6 @@
         <?php endif ?>
     </span>
     <?php if (! empty($description)): ?>
-        <?= $this->app->tooltipMarkdown($description) ?>
+        <?= $this->app->tooltipHTML($description) ?>
     <?php endif ?>
 </h1>


### PR DESCRIPTION
[✓] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)

This change passes current unit tests. I added a `tooltipHTML` method to allow mixing markdown and plain HTML text.