### PR TITLE
better whitespace handling by ./cli locale:compare

### DIFF
--- a/app/Console/LocaleComparatorCommand.php
+++ b/app/Console/LocaleComparatorCommand.php
@@ -63,11 +63,11 @@ class LocaleComparatorCommand extends BaseCommand
         $content = file_get_contents($filename);
         $strings = array();
 
-        if (preg_match_all('/\b[et]\((\'\K.*?\') *[\)\,]/', $content, $matches) && isset($matches[1])) {
+        if (preg_match_all('/\b[et]\s*\(\s*(\'\K.*?\')\s*[\)\,]/', $content, $matches) && isset($matches[1])) {
             $strings = $matches[1];
         }
 
-        if (preg_match_all('/\bdt\((\'\K.*?\') *[\)\,]/', $content, $matches) && isset($matches[1])) {
+        if (preg_match_all('/\bdt\s*\(\s*(\'\K.*?\')\s*[\)\,]/', $content, $matches) && isset($matches[1])) {
             $strings = array_merge($strings, $matches[1]);
         }
 


### PR DESCRIPTION
[x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)

This commit improves whitespace handling by `./cli locale:compare`. The command now finds more untranslated strings.

cf #3396.