### PR TITLE
Clarified English text: logical 'and' not intended

### DIFF
--- a/app/Locale/bs_BA/translations.php
+++ b/app/Locale/bs_BA/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Sve zadatke',
     'Only for tasks assigned to me' => 'Samo za zadatke na kojima sam izvršilac',
     'Only for tasks created by me' => 'Samo za zadatke koje sam ja napravio',
-    'Only for tasks created by me and assigned to me' => 'Samo za zadatke koje sam ja napravio i na kojima sam izvršilac',
+    'Only for tasks created by me tasks and assigned to me' => 'Samo za zadatke koje sam ja napravio i na kojima sam izvršilac',
     '%%Y-%%m-%%d' => '%%Y-%%m-%%d',
     'Total for all columns' => 'Ukupno za sve kolone',
     'You need at least 2 days of data to show the chart.' => 'Da bi se prikazao ovaj grafik potrebni su podaci iz najmanje posljednja dva dana.',

--- a/app/Locale/ca_ES/translations.php
+++ b/app/Locale/ca_ES/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'totes les tasques',
     'Only for tasks assigned to me' => 'Només per a les tasques que se m\'ha s\'assignin',
     'Only for tasks created by me' => 'Només per a les tasques creades per mi',
-    'Only for tasks created by me and assigned to me' => 'Només per a tasques creades per mi i em assignin',
+    'Only for tasks created by me tasks and assigned to me' => 'Només per a tasques creades per mi i em assignin',
     // '%%Y-%%m-%%d' => '',
     'Total for all columns' => 'Total per a totes les columnes',
     'You need at least 2 days of data to show the chart.' => 'Es necessita com a mínim 2 dies de dades per mostrar el gràfic.',

--- a/app/Locale/cs_CZ/translations.php
+++ b/app/Locale/cs_CZ/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Všechny úkoly',
     'Only for tasks assigned to me' => 'pouze pro moje úkoly',
     'Only for tasks created by me' => 'pouze pro mnou vytvořené úkoly',
-    'Only for tasks created by me and assigned to me' => 'pouze pro mnou vytvořené a mě přiřazené úkoly',
+    'Only for tasks created by me tasks and assigned to me' => 'pouze pro mnou vytvořené a mě přiřazené úkoly',
     // '%%Y-%%m-%%d' => '',
     'Total for all columns' => 'S',
     'You need at least 2 days of data to show the chart.' => 'Potřebujete nejméně data ze dvou dnů pro zobrazení grafu',

--- a/app/Locale/da_DK/translations.php
+++ b/app/Locale/da_DK/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Alle opgaver',
     'Only for tasks assigned to me' => 'Kun tildelte opgaver',
     'Only for tasks created by me' => 'Kun opgaver oprettet af bruger',
-    'Only for tasks created by me and assigned to me' => 'Kun opgaver oprettet og tildelt bruger',
+    'Only for tasks created by me tasks and assigned to me' => 'Kun opgaver oprettet og tildelt bruger',
     '%%Y-%%m-%%d' => '%%Y-%%m-%%d',
     'Total for all columns' => 'Total for alle kolonner',
     'You need at least 2 days of data to show the chart.' => 'Der skal mindst 2 dages data for at vise diagram.',

--- a/app/Locale/de_DE/translations.php
+++ b/app/Locale/de_DE/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Alle Aufgaben',
     'Only for tasks assigned to me' => 'nur mir zugeordnete Aufgaben',
     'Only for tasks created by me' => 'nur von mir erstellte Aufgaben',
-    'Only for tasks created by me and assigned to me' => 'nur mir zugeordnete und von mir erstellte Aufgaben',
+    'Only for tasks created by me tasks and assigned to me' => 'nur mir zugeordnete und von mir erstellte Aufgaben',
     '%%Y-%%m-%%d' => '%%d.%%m.%%Y',
     'Total for all columns' => 'Gesamt für alle Spalten',
     'You need at least 2 days of data to show the chart.' => 'Es werden mindestens 2 Tage zur Darstellung benötigt',

--- a/app/Locale/el_GR/translations.php
+++ b/app/Locale/el_GR/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Όλες οι εργασίες',
     'Only for tasks assigned to me' => 'Μόνο σε εργασίες που μου έχουν ανατεθεί',
     'Only for tasks created by me' => 'Μόνο σε εργασίες που έχουν δημιουργηθεί από εμένα',
-    'Only for tasks created by me and assigned to me' => 'Μόνο σε εργασίες που έχουν δημιουργηθεί από εμένα και μου έχουν ανατεθεί',
+    'Only for tasks created by me tasks and assigned to me' => 'Μόνο σε εργασίες που έχουν δημιουργηθεί από εμένα και μου έχουν ανατεθεί',
     '%%Y-%%m-%%d' => '%%d/%%m/%%Y',
     'Total for all columns' => 'Σύνολο για όλες τις στήλες',
     'You need at least 2 days of data to show the chart.' => 'Έχετε τουλάχιστον 2 ημέρες δεδομένων για να εμφανιστούν στο διάγραμμα.',

--- a/app/Locale/es_ES/translations.php
+++ b/app/Locale/es_ES/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Todas las tareas',
     'Only for tasks assigned to me' => 'Sólo para tareas asignadas a mí',
     'Only for tasks created by me' => 'Sólo para tareas creadas por mí',
-    'Only for tasks created by me and assigned to me' => 'Sólo para las tareas creadas por mí y asignadas a mí',
+    'Only for tasks created by me tasks and assigned to me' => 'Sólo para las tareas creadas por mí y asignadas a mí',
     '%%Y-%%m-%%d' => '%%Y-%%m-%%d',
     'Total for all columns' => 'Total para todas las columnas',
     'You need at least 2 days of data to show the chart.' => 'Necesita al menos 2 días de datos para mostrar el gráfico.',

--- a/app/Locale/fi_FI/translations.php
+++ b/app/Locale/fi_FI/translations.php
@@ -648,7 +648,7 @@ return array(
     // 'All tasks' => '',
     // 'Only for tasks assigned to me' => '',
     // 'Only for tasks created by me' => '',
-    // 'Only for tasks created by me and assigned to me' => '',
+    // 'Only for tasks created by me tasks and assigned to me' => '',
     // '%%Y-%%m-%%d' => '',
     // 'Total for all columns' => '',
     // 'You need at least 2 days of data to show the chart.' => '',

--- a/app/Locale/fr_FR/translations.php
+++ b/app/Locale/fr_FR/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Toutes les Tâches',
     'Only for tasks assigned to me' => 'Seulement les tâches qui me sont assignées',
     'Only for tasks created by me' => 'Seulement les tâches que j\'ai créées',
-    'Only for tasks created by me and assigned to me' => 'Seulement les tâches créées par moi-même et celles qui me sont assignées',
+    'Only for tasks created by me tasks and assigned to me' => 'Seulement les tâches créées par moi-même et celles qui me sont assignées',
     '%%Y-%%m-%%d' => '%%d/%%m/%%Y',
     'Total for all columns' => 'Total pour toutes les colonnes',
     'You need at least 2 days of data to show the chart.' => 'Vous avez besoin d\'au minimum 2 jours de données pour afficher le graphique.',

--- a/app/Locale/hr_HR/translations.php
+++ b/app/Locale/hr_HR/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Sve zadatke',
     'Only for tasks assigned to me' => 'Samo zadatke koji su mi dodijeljeni',
     'Only for tasks created by me' => 'Samo zadatke koje sam kreirao',
-    'Only for tasks created by me and assigned to me' => 'Samo zadatke koji su mi dodijeljeni i koje sam kreirao',
+    'Only for tasks created by me tasks and assigned to me' => 'Samo zadatke koji su mi dodijeljeni i koje sam kreirao',
     // '%%Y-%%m-%%d' => '',
     // 'Total for all columns' => '',
     // 'You need at least 2 days of data to show the chart.' => '',

--- a/app/Locale/hu_HU/translations.php
+++ b/app/Locale/hu_HU/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Összes feladat',
     'Only for tasks assigned to me' => 'Csak a hozzám rendelt feladatok',
     'Only for tasks created by me' => 'Csak az általam létrehozott feladatok',
-    'Only for tasks created by me and assigned to me' => 'Csak az általam létrehozott és a hozzám rendelt feladatok',
+    'Only for tasks created by me tasks and assigned to me' => 'Csak az általam létrehozott és a hozzám rendelt feladatok',
     '%%Y-%%m-%%d' => '%%Y-%%m-%%d',
     'Total for all columns' => 'Az összes oszlop összege',
     'You need at least 2 days of data to show the chart.' => 'Legalább 2 nap adatára van szükség a diagram megjelenítéséhez.',

--- a/app/Locale/id_ID/translations.php
+++ b/app/Locale/id_ID/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Semua tugas',
     'Only for tasks assigned to me' => 'Hanya untuk tugas yang ditugaskan ke saya',
     'Only for tasks created by me' => 'Hanya untuk tugas yang dibuat oleh saya',
-    'Only for tasks created by me and assigned to me' => 'Hanya untuk tugas yang dibuat oleh saya dan ditugaskan ke saya',
+    'Only for tasks created by me tasks and assigned to me' => 'Hanya untuk tugas yang dibuat oleh saya dan ditugaskan ke saya',
     '%%Y-%%m-%%d' => '%%d/%%m/%%Y',
     'Total for all columns' => 'Total untuk semua kolom',
     'You need at least 2 days of data to show the chart.' => 'Anda memerlukan setidaknya 2 hari dari data yang menunjukkan grafik.',

--- a/app/Locale/it_IT/translations.php
+++ b/app/Locale/it_IT/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Tutti i task',
     'Only for tasks assigned to me' => 'Solo per i task assegnati a me',
     'Only for tasks created by me' => 'Solo per i task creati da me',
-    'Only for tasks created by me and assigned to me' => 'Solo per i task creati da me e assegnati a me',
+    'Only for tasks created by me tasks and assigned to me' => 'Solo per i task creati da me e assegnati a me',
     // '%%Y-%%m-%%d' => '',
     'Total for all columns' => 'Totale per tutte le colonne',
     'You need at least 2 days of data to show the chart.' => 'Hai bisogno di almeno 2 giorni di dati per mostrare il grafico.',

--- a/app/Locale/ja_JP/translations.php
+++ b/app/Locale/ja_JP/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'すべてのタスク',
     'Only for tasks assigned to me' => '自分のタスクのみ',
     'Only for tasks created by me' => '自分が作成したタスクのみ',
-    'Only for tasks created by me and assigned to me' => '自分が作成した自分のタスクのみ',
+    'Only for tasks created by me tasks and assigned to me' => '自分が作成した自分のタスクのみ',
     // '%%Y-%%m-%%d' => '',
     'Total for all columns' => 'すべてのカラムの合計',
     'You need at least 2 days of data to show the chart.' => 'グラフを表示するには最低2日間のデータが必要です',

--- a/app/Locale/ko_KR/translations.php
+++ b/app/Locale/ko_KR/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => '모든 할일',
     'Only for tasks assigned to me' => '내가 담당자인 일',
     'Only for tasks created by me' => '내가 만든 일',
-    'Only for tasks created by me and assigned to me' => '내가 만들었거나 내가 담당자인 일',
+    'Only for tasks created by me tasks and assigned to me' => '내가 만들었거나 내가 담당자인 일',
     '%%Y-%%m-%%d' => '%%Y-%%m-%%d',
     'Total for all columns' => '모든 컬럼',
     'You need at least 2 days of data to show the chart.' => '차트를 보기 위하여 최소 2일의 데이터가 필요합니다',

--- a/app/Locale/my_MY/translations.php
+++ b/app/Locale/my_MY/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Semua tugas',
     'Only for tasks assigned to me' => 'Hanya untuk tugas yang ditugaskan ke saya',
     'Only for tasks created by me' => 'Hanya untuk tugas yang dibuat oleh saya',
-    'Only for tasks created by me and assigned to me' => 'Hanya untuk tugas yang dibuat oleh saya dan ditugaskan ke saya',
+    'Only for tasks created by me tasks and assigned to me' => 'Hanya untuk tugas yang dibuat oleh saya dan ditugaskan ke saya',
     '%%Y-%%m-%%d' => '%%d/%%m/%%Y',
     'Total for all columns' => 'Total untuk semua kolom',
     'You need at least 2 days of data to show the chart.' => 'Anda memerlukan setidaknya 2 hari dari data yang menunjukkan grafik.',

--- a/app/Locale/nb_NO/translations.php
+++ b/app/Locale/nb_NO/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Alle oppgaver',
     'Only for tasks assigned to me' => 'Kun oppgaver som er tildelt meg',
     'Only for tasks created by me' => 'Kun oppgaver som er opprettet av meg',
-    'Only for tasks created by me and assigned to me' => 'Kun oppgaver som er opprettet av meg og tildelt meg',
+    'Only for tasks created by me tasks and assigned to me' => 'Kun oppgaver som er opprettet av meg og tildelt meg',
     // '%%Y-%%m-%%d' => '',
     'Total for all columns' => 'Totalt for alle kolonner',
     // 'You need at least 2 days of data to show the chart.' => '',

--- a/app/Locale/nl_NL/translations.php
+++ b/app/Locale/nl_NL/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Alle taken',
     // 'Only for tasks assigned to me' => '',
     // 'Only for tasks created by me' => '',
-    // 'Only for tasks created by me and assigned to me' => '',
+    // 'Only for tasks created by me tasks and assigned to me' => '',
     '%%Y-%%m-%%d' => '%%d-%%m-%%Y',
     // 'Total for all columns' => '',
     // 'You need at least 2 days of data to show the chart.' => '',

--- a/app/Locale/pl_PL/translations.php
+++ b/app/Locale/pl_PL/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Wszystkich zadań',
     'Only for tasks assigned to me' => 'Tylko zadań przypisanych do mnie',
     'Only for tasks created by me' => 'Tylko zadań utworzonych przeze mnie',
-    'Only for tasks created by me and assigned to me' => 'Tylko zadań przypisanych lub utworzonych przeze mnie',
+    'Only for tasks created by me tasks and assigned to me' => 'Tylko zadań przypisanych lub utworzonych przeze mnie',
     // '%%Y-%%m-%%d' => '',
     'Total for all columns' => 'Ogółem dla wszystkich kolumn',
     'You need at least 2 days of data to show the chart.' => 'Potrzebujesz przynajmniej 2 dni by wyświetlić wykres',

--- a/app/Locale/pt_BR/translations.php
+++ b/app/Locale/pt_BR/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Todas as tarefas',
     'Only for tasks assigned to me' => 'Somente as tarefas atribuídas a mim',
     'Only for tasks created by me' => 'Apenas as tarefas que eu criei',
-    'Only for tasks created by me and assigned to me' => 'Apenas as tarefas que eu criei e aquelas atribuídas a mim',
+    'Only for tasks created by me tasks and assigned to me' => 'Apenas as tarefas que eu criei e aquelas atribuídas a mim',
     '%%Y-%%m-%%d' => '%%d/%%m/%%Y',
     'Total for all columns' => 'Total para todas as colunas',
     'You need at least 2 days of data to show the chart.' => 'Você precisa de pelo menos 2 dias de dados para visualizar o gráfico.',

--- a/app/Locale/pt_PT/translations.php
+++ b/app/Locale/pt_PT/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Todas as tarefas',
     'Only for tasks assigned to me' => 'Somente as tarefas atribuídas a mim',
     'Only for tasks created by me' => 'Apenas as tarefas que eu criei',
-    'Only for tasks created by me and assigned to me' => 'Apenas as tarefas que eu criei e aquelas atribuídas a mim',
+    'Only for tasks created by me tasks and assigned to me' => 'Apenas as tarefas que eu criei e aquelas atribuídas a mim',
     '%%Y-%%m-%%d' => '%%d/%%m/%%Y',
     'Total for all columns' => 'Total para todas as colunas',
     'You need at least 2 days of data to show the chart.' => 'Precisa de pelo menos 2 dias de dados para visualizar o gráfico.',

--- a/app/Locale/ro_RO/translations.php
+++ b/app/Locale/ro_RO/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Toate Sarcinile',
     'Only for tasks assigned to me' => 'Numai sarcinile atribuite mie',
     'Only for tasks created by me' => 'Numai sarcinile create de mine',
-    'Only for tasks created by me and assigned to me' => 'Numai sarcinile create de mine si atribuite mie.',
+    'Only for tasks created by me tasks and assigned to me' => 'Numai sarcinile create de mine si atribuite mie.',
     '%%Y-%%m-%%d' => '%%d/%%m/%%Y',
     'Total for all columns' => 'Totalul tuturor coloanelor',
     'You need at least 2 days of data to show the chart.' => 'Ai nevoie de cel putin 2 zile de date pentru afișarea graficului.',

--- a/app/Locale/ru_RU/translations.php
+++ b/app/Locale/ru_RU/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Все задачи',
     'Only for tasks assigned to me' => 'Только для задач, назначенных мне',
     'Only for tasks created by me' => 'Только для задач, созданных мной',
-    'Only for tasks created by me and assigned to me' => 'Только для задач, созданных мной и назначенных мне',
+    'Only for tasks created by me tasks and assigned to me' => 'Только для задач, созданных мной и назначенных мне',
     '%%Y-%%m-%%d' => '%%Y-%%m-%%d',
     'Total for all columns' => 'Суммарно для всех колонок',
     'You need at least 2 days of data to show the chart.' => 'Для отображения диаграммы нужно по крайней мере 2 дня.',

--- a/app/Locale/sr_Latn_RS/translations.php
+++ b/app/Locale/sr_Latn_RS/translations.php
@@ -648,7 +648,7 @@ return array(
     // 'All tasks' => '',
     // 'Only for tasks assigned to me' => '',
     // 'Only for tasks created by me' => '',
-    // 'Only for tasks created by me and assigned to me' => '',
+    // 'Only for tasks created by me tasks and assigned to me' => '',
     // '%%Y-%%m-%%d' => '',
     // 'Total for all columns' => '',
     // 'You need at least 2 days of data to show the chart.' => '',

--- a/app/Locale/sv_SE/translations.php
+++ b/app/Locale/sv_SE/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Alla uppgifter',
     'Only for tasks assigned to me' => 'Bara för uppgifter tilldelade mig',
     'Only for tasks created by me' => 'Bara för uppgifter skapade av mig',
-    'Only for tasks created by me and assigned to me' => 'Bara för uppgifter skapade av mig och tilldelade till mig',
+    'Only for tasks created by me tasks and assigned to me' => 'Bara för uppgifter skapade av mig och tilldelade till mig',
     '%%Y-%%m-%%d' => '%%Y-%%m-%%d',
     'Total for all columns' => 'Totalt för alla kolumner',
     'You need at least 2 days of data to show the chart.' => 'Du behöver minst två dagars data för att visa diagrammet.',

--- a/app/Locale/th_TH/translations.php
+++ b/app/Locale/th_TH/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'ทุกงาน',
     'Only for tasks assigned to me' => 'เฉพาะงานที่ฉันรับผิดชอบ',
     'Only for tasks created by me' => 'เฉพาะงานที่ฉันสร้าง',
-    'Only for tasks created by me and assigned to me' => 'เฉพาะงานที่ฉันสร้างและฉันรับผิดชอบ',
+    'Only for tasks created by me tasks and assigned to me' => 'เฉพาะงานที่ฉันสร้างและฉันรับผิดชอบ',
     // '%%Y-%%m-%%d' => '',
     'Total for all columns' => 'จำนวนคอลัมน์ทั้งหมด',
     'You need at least 2 days of data to show the chart.' => 'คุณต้องการอย่างน้อย 2 วันในการแสดงแผนภูมิ',

--- a/app/Locale/tr_TR/translations.php
+++ b/app/Locale/tr_TR/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Tüm görevler',
     'Only for tasks assigned to me' => 'Yalnızca bana atanmış görevler için',
     'Only for tasks created by me' => 'Yalnızca benim oluşturduğum görevler için',
-    'Only for tasks created by me and assigned to me' => 'Yalnızca benim oluşturduğum ve bana atanmış görevler için',
+    'Only for tasks created by me tasks and assigned to me' => 'Yalnızca benim oluşturduğum ve bana atanmış görevler için',
     '%%Y-%%m-%%d' => '%%Y-%%m-%%d',
     'Total for all columns' => 'Tüm sütunlar için toplam',
     'You need at least 2 days of data to show the chart.' => 'Grafiği göstermek için en az iki günlük veriye ihtiyaç var.',

--- a/app/Locale/vi_VN/translations.php
+++ b/app/Locale/vi_VN/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => 'Tất cả các nhiệm vụ',
     'Only for tasks assigned to me' => 'Chỉ đối với những nhiệm vụ được giao cho tôi',
     'Only for tasks created by me' => 'Chỉ cho những công việc do tôi tạo ra',
-    'Only for tasks created by me and assigned to me' => 'Chỉ cho những công việc mà tôi tạo ra và được giao cho tôi',
+    'Only for tasks created by me tasks and assigned to me' => 'Chỉ cho những công việc mà tôi tạo ra và được giao cho tôi',
     '%%Y-%%m-%%d' => '%%Y - %%m - %%d',
     'Total for all columns' => 'Tổng cho tất cả các cột',
     'You need at least 2 days of data to show the chart.' => 'Bạn cần ít nhất 2 ngày dữ liệu để hiển thị biểu đồ.',

--- a/app/Locale/zh_CN/translations.php
+++ b/app/Locale/zh_CN/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => '所有任务',
     'Only for tasks assigned to me' => '所有指派给我的任务',
     'Only for tasks created by me' => '所有我创建的任务',
-    'Only for tasks created by me and assigned to me' => '所有我创建的并且指派给我的任务',
+    'Only for tasks created by me tasks and assigned to me' => '所有我创建的并且指派给我的任务',
     '%%Y-%%m-%%d' => '%%Y-%%m-%%d',
     'Total for all columns' => '所有栏目下的',
     'You need at least 2 days of data to show the chart.' => '当前柱状图至少需要2天的数据。',

--- a/app/Locale/zh_TW/translations.php
+++ b/app/Locale/zh_TW/translations.php
@@ -648,7 +648,7 @@ return array(
     'All tasks' => '所有任務',
     'Only for tasks assigned to me' => '所有指派给我的任務',
     'Only for tasks created by me' => '所有我建立的任務',
-    'Only for tasks created by me and assigned to me' => '所有我建立的並且指派给我的任務',
+    'Only for tasks created by me tasks and assigned to me' => '所有我建立的並且指派给我的任務',
     // '%%Y-%%m-%%d' => '',
     'Total for all columns' => '所有欄位下的',
     'You need at least 2 days of data to show the chart.' => '目前柱狀圖至少需要2天的資料。',

--- a/app/Model/UserNotificationFilterModel.php
+++ b/app/Model/UserNotificationFilterModel.php
@@ -41,7 +41,7 @@ class UserNotificationFilterModel extends Base
             self::FILTER_NONE => t('All tasks'),
             self::FILTER_ASSIGNEE => t('Only for tasks assigned to me'),
             self::FILTER_CREATOR => t('Only for tasks created by me'),
-            self::FILTER_BOTH => t('Only for tasks created by me and assigned to me'),
+            self::FILTER_BOTH => t('Only for tasks created by me and tasks assigned to me'),
         );
     }
 


### PR DESCRIPTION
See issue #3817

I also updated translation texts so they will fall back to the old translated strings.

[x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)