### PR TITLE
translate time string in another template

### DIFF
--- a/app/Template/notification/subtask_create.php
+++ b/app/Template/notification/subtask_create.php
@@ -9,7 +9,7 @@
     <?php if (! empty($subtask['time_estimated'])): ?>
         <li>
             <?= t('Time tracking:') ?>
-            <strong><?= $this->text->e($subtask['time_estimated']).'h' ?></strong> <?= t('estimated') ?>
+            <?= t('%sh estimated', n($subtask['time_estimated'])) ?>
         </li>
     <?php endif ?>
 </ul>


### PR DESCRIPTION
[x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)

I wasn't to live test this change because I didn't find the precise location that this template is used. I tested the notifications for new subtasks, but the displayed text is different than the text in this template.