### PR TITLE
Increase size of the "users.language" column

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+Unreleased
+----------
+
+Bug fixes:
+
+* Fix the "users.language" column size
+
 Version 1.2.4 (May 16, 2018)
 ----------------------------
 

--- a/app/Schema/Mysql.php
+++ b/app/Schema/Mysql.php
@@ -8,7 +8,12 @@ use PDO;
 use Kanboard\Core\Security\Token;
 use Kanboard\Core\Security\Role;
 
-const VERSION = 130;
+const VERSION = 131;
+
+function version_131(PDO $pdo)
+{
+    $pdo->exec("ALTER TABLE `users` MODIFY `language` VARCHAR(11) DEFAULT NULL");
+}
 
 /*
 

--- a/app/Schema/Postgres.php
+++ b/app/Schema/Postgres.php
@@ -8,7 +8,12 @@ use PDO;
 use Kanboard\Core\Security\Token;
 use Kanboard\Core\Security\Role;
 
-const VERSION = 108;
+const VERSION = 109;
+
+function version_109(PDO $pdo)
+{
+    $pdo->exec('ALTER TABLE "users" ALTER COLUMN "language" TYPE VARCHAR(11)');
+}
 
 function version_108(PDO $pdo)
 {


### PR DESCRIPTION
The current schema definition for the language column in the users table
is limited to 5 characters, while the longest currently available
language code in Kanboard is 10 characters long - sr_Latn_RS. This
limitation prevents switching to Serbian as the application interface
language.

As per the currently available ISO 639 language codes this column should
be at least 11 characters in size. Examples of language codes of 11
characters in size are en-US-POSIX and shi_Latn_MA.

References:

 - http://www.localeplanet.com/icu/iso639.html

[x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)

This PR addresses #3877