### PR TITLE
fix config overrides in docker

### DIFF
--- a/docker/var/www/app/config.php
+++ b/docker/var/www/app/config.php
@@ -1,4 +1,4 @@
 <?php
 
-define('ENABLE_URL_REWRITE', true);
-define('LOG_DRIVER', 'system');
+defined('ENABLE_URL_REWRITE') or define('ENABLE_URL_REWRITE', true);
+defined('LOG_DRIVER') or define('LOG_DRIVER', 'system');


### PR DESCRIPTION
[x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)

When using docker and an attached /var/www/app/data/config.php, if values for LOG_DRIVER or ENABLE_URL_REWRITE are specified, errors of the following form occur:

`2018/05/25 16:29:30 [error] 15#15: *4 FastCGI sent in stderr: "PHP message: PHP Notice:  Constant LOG_DRIVER already defined in /var/www/app/data/config.php on line 14`

and the values set in the attached config appear to be overwritten by those in the default config.
