### PR TITLE
make border around recently modified tasks more visible

### DIFF
--- a/assets/sass/_task_board.sass
+++ b/assets/sass/_task_board.sass
@@ -11,7 +11,7 @@
 
 div
   &.task-board-recent
-    border-width: 2px
+    border: 5px dashed
   &.task-board-status-closed
     user-select: none
     border: 1px dotted #555


### PR DESCRIPTION
The small 2px frame around recently changed tasks is barely visible, so i changed the css to make it thicker and dashed. 