### PR TITLE
add daily background job to cron under docker

### DIFF
--- a/docker/etc/crontabs/nginx
+++ b/docker/etc/crontabs/nginx
@@ -1,0 +1,1 @@
+0 8 * * * cd /var/www/app && ./cli cronjob >/dev/null 2>&1


### PR DESCRIPTION
:white_check_mark: I read the [contributor guidelines]

Under docker the daily background task doesn't seem to be set up.

If I run `./cli cronjob` manually all functionality kicks in fine.

I believe adding this file will fix it, but I'm not able to build and test a docker at present (I'm working on it...)

Another way to do this would have been to add the file to `/etc/periodic/daily`, but I believe it would then run as root and so might not be ideal.  Happy to change to this if that's preferred though.

Please review and if you agree merge it and I'll check the docker image on next build.