### PR TITLE
fix config overrides in docker

### DIFF
--- a/app/common.php
+++ b/app/common.php
@@ -15,13 +15,13 @@ if ($dbUrlParser->isEnvironmentVariableDefined()) {
     define('DB_NAME', $dbSettings['database']);
 }
 
-$config_file = implode(DIRECTORY_SEPARATOR, array(__DIR__, '..', 'config.php'));
+$config_file = implode(DIRECTORY_SEPARATOR, array(__DIR__, '..', 'data', 'config.php'));
 
 if (file_exists($config_file)) {
     require $config_file;
 }
 
-$config_file = implode(DIRECTORY_SEPARATOR, array(__DIR__, '..', 'data', 'config.php'));
+$config_file = implode(DIRECTORY_SEPARATOR, array(__DIR__, '..', 'config.php'));
 
 if (file_exists($config_file)) {
     require $config_file;


### PR DESCRIPTION
[:white_check_mark:] I read the [contributor guidelines]

My previous PR #3884 did not do the job for config in docker as the `/var/www/app/config.php` loads first.

The attached `/var/www/app/data/config.php` must be loaded first, then `/var/www/app/config.php` (and then `/var/www/app/app/constants.php`).

This PR changes the order so the attached config loads before the builtin one.
