### PR TITLE
Defer javascript files by default

### DIFF
--- a/app/Helper/AssetHelper.php
+++ b/app/Helper/AssetHelper.php
@@ -21,7 +21,7 @@ class AssetHelper extends Base
      */
     public function js($filename, $async = false)
     {
-        return '<script '.($async ? 'async' : '').' type="text/javascript" src="'.$this->helper->url->dir().$filename.'?'.filemtime($filename).'"></script>';
+        return '<script '.($async ? 'async' : '').' defer type="text/javascript" src="'.$this->helper->url->dir().$filename.'?'.filemtime($filename).'"></script>';
     }
 
     /**


### PR DESCRIPTION
Prevent scripts blocking browser HTML parsing by using the `defer` attribute. The modern method instead of moving scripts to the end of the body tag as suggested in kanboard/kanboard#3829

Without either `defer` or `async` [JavaScript files will block parsing of the HTML](https://developers.google.com/speed/docs/insights/BlockingJS#deferJS) until the script has been downloaded and executed.

`async` will still [take preference over `defer`](https://flaviocopes.com/javascript-async-defer/#async-and-defer) if used, and older browsers which do not support it will fallback to `defer`.

Older browsers should degrade gracefully and ["should still load correctly on the 20% of browsers that do not support these attributes while speeding up the other 80%."](https://stackoverflow.com/a/24070373)

[x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
