### PR TITLE
Use SET NAMES instead of charset for DB connection

### DIFF
--- a/libs/picodb/lib/PicoDb/Driver/Mysql.php
+++ b/libs/picodb/lib/PicoDb/Driver/Mysql.php
@@ -63,8 +63,7 @@ class Mysql extends Base
      */
     protected function buildDsn(array $settings)
     {
-        $charset = empty($settings['charset']) ? 'utf8' : $settings['charset'];
-        $dsn = 'mysql:host='.$settings['hostname'].';dbname='.$settings['database'].';charset='.$charset;
+        $dsn = 'mysql:host='.$settings['hostname'].';dbname='.$settings['database'];
 
         if (! empty($settings['port'])) {
             $dsn .= ';port='.$settings['port'];
@@ -82,8 +81,9 @@ class Mysql extends Base
      */
     protected function buildOptions(array $settings)
     {
+        $charset = empty($settings['charset']) ? 'utf8' : $settings['charset'];
         $options = array(
-            PDO::MYSQL_ATTR_INIT_COMMAND => 'SET sql_mode = STRICT_ALL_TABLES',
+            PDO::MYSQL_ATTR_INIT_COMMAND => 'SET sql_mode = STRICT_ALL_TABLES, NAMES ' . $charset,
         );
 
         if (! empty($settings['ssl_key'])) {


### PR DESCRIPTION
When using charset in buildDsn, not all variables are set on the server side. That leads to MySQL assuming latin1 charset and errors with Cyrillic, for example (I figured out the letter 'И', capital breaks the things).

[x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
