### PR TITLE
SetEnv usage should be guarded

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -8,7 +8,11 @@
 <IfModule mod_rewrite.c>
     Options -MultiViews
 
-    SetEnv HTTP_MOD_REWRITE On
+
+    <IfModule mod_env.c>
+        SetEnv HTTP_MOD_REWRITE On
+    </IfModule>
+    
 
     # Uncomment this line depending of your Apache configuration
     # RewriteBase /


### PR DESCRIPTION
mod_env may not be present on a system in which case browser will get 500 Internal Server Error.

The error in apache logs say "Invalid command 'SetEnv', perhaps misspelled or defined by a module not included in the server configuration".

Tested on my setup at kanboard.ekvastra.in.

I read the [contributor guidelines] before submitting this pull request.
