### PR TITLE
Exclude task links and user mentions from nesting 

### DIFF
--- a/app/Core/Markdown.php
+++ b/app/Core/Markdown.php
@@ -145,4 +145,17 @@ class Markdown extends Parsedown
             array('task_id' => $task_id)
         );
     }
+
+    /**
+     * Exclude from nesting task links and user mentions for links
+     *
+     * @param array $Excerpt
+     * @return array|null
+     */
+    protected function inlineLink($Excerpt)
+    {
+        $Inline = parent::inlineLink($Excerpt);
+        array_push($Inline['element']['nonNestables'], 'TaskLink', 'UserLink');
+        return $Inline;
+    }
 }

--- a/tests/units/Helper/TextHelperTest.php
+++ b/tests/units/Helper/TextHelperTest.php
@@ -50,6 +50,13 @@ class TextHelperTest extends Base
                 'Check that: http://stackoverflow.com/questions/1732348/regex-match-open-tags-except-xhtml-self-contained-tags/1732454#1732454'
             )
         );
+
+        $this->assertEquals(
+            '<p><a href="http://localhost">item #123 is here</a></p>',
+            $textHelper->markdown(
+                '[item #123 is here](http://localhost)'
+            )
+        );
     }
 
     public function testMarkdownUserLink()
@@ -100,6 +107,13 @@ class TextHelperTest extends Base
         );
 
         $this->assertEquals('<p>Text @admin @notfound</p>', $textHelper->markdown('Text @admin @notfound', true));
+
+        $this->assertEquals(
+            '<p><a href="http://localhost">mention @admin at localhost</a></p>',
+            $textHelper->markdown(
+                '[mention @admin at localhost](http://localhost)'
+            )
+        );
     }
 
     public function testFormatBytes()


### PR DESCRIPTION
Currently markdown `[#123](https://google.com)` will give us
```
<a href="https://google.com">
<a href="/?controller=TaskViewController&amp;action=show&amp;task_id=123">#123</a>
</a>
```
As a result we will get link to task `#123`, not to the `google.com`

PR fixes this behavior by excluding task links and user mentions from nesting within links.

[x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
