### PR TITLE
When forcing HTTPS, handle subfolder URLs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -26,7 +26,7 @@
     ############################
     
     # RewriteCond %{HTTPS} !=on 
-    # RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
+    # RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R,L]
 </IfModule>
 
 <IfModule pagespeed_module>


### PR DESCRIPTION
This fixes the redirection for Kanboard instances in subdirectories
(ex: /foo/bar/kanboard instead of the vhost's document root)

I have tested this on my own website and it worked for me. Hopefully it works fine for you too.

[x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
