### PR TITLE
Allow 'No assignee' for external task on single user public boards

### DIFF
--- a/app/Controller/ExternalTaskCreationController.php
+++ b/app/Controller/ExternalTaskCreationController.php
@@ -67,7 +67,7 @@ class ExternalTaskCreationController extends BaseController
                 'errors' => $errors,
                 'template' => $taskProvider->getCreationFormTemplate(),
                 'columns_list' => $this->columnModel->getList($project['id']),
-                'users_list' => $this->projectUserRoleModel->getAssignableUsersList($project['id'], true, false, true),
+                'users_list' => $this->projectUserRoleModel->getAssignableUsersList($project['id'], true, false, $project['is_private'] == 1),
                 'categories_list' => $this->categoryModel->getList($project['id']),
                 'swimlanes_list' => $this->swimlaneModel->getList($project['id'], false, true),
             )));


### PR DESCRIPTION
'No assignee' option is already available in modification but not in
creation.
This patch fixes that by allowing the 'No assignee' option on external
task creation.

- [x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
