### PR TITLE
Fixing typo in de_DE translation

### DIFF
--- a/app/Locale/de_DE/translations.php
+++ b/app/Locale/de_DE/translations.php
@@ -957,7 +957,7 @@ return array(
     'Created:' => 'Erstellt:',
     'Modified:' => 'Geändert:',
     'Completed:' => 'Abgeschlossen:',
-    'Started:' => 'Gestarted:',
+    'Started:' => 'Gestartet:',
     'Moved:' => 'Verschoben:',
     'Task #%d' => 'Aufgabe #%d',
     'Time format' => 'Zeitformat',


### PR DESCRIPTION
Gestarted -> Gestartet.