### PR TITLE
Make PLUGINS_DIR absolute, this is the common requirement in Kanboard.

### DIFF
--- a/config.default.php
+++ b/config.default.php
@@ -2,6 +2,8 @@
 
 /*******************************************************************/
 /* Rename this file to config.php if you want to change the values */
+/*                                                                 */
+/* Make sure all paths are absolute by using __DIR__ where needed  */
 /*******************************************************************/
 
 // Data folder (must be writeable by the web server user and absolute)
@@ -17,7 +19,7 @@ define('LOG_DRIVER', 'system');
 define('LOG_FILE', DATA_DIR.DIRECTORY_SEPARATOR.'debug.log');
 
 // Plugins directory
-define('PLUGINS_DIR', 'plugins');
+define('PLUGINS_DIR', __DIR__.DIRECTORY_SEPARATOR.'plugins');
 
 // Plugins directory URL
 define('PLUGIN_API_URL', 'https://kanboard.org/plugins.json');


### PR DESCRIPTION
Also add comment telling users to use absolute paths to avoid someone
else failing the same way as I did.

[X] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
