### PR TITLE
Correcting dass - das error

### DIFF
--- a/app/Locale/de_DE/translations.php
+++ b/app/Locale/de_DE/translations.php
@@ -1347,7 +1347,7 @@ return array(
     'Template removed successfully.' => 'Vorlage erfolgreich gelöscht.',
     'Unable to remove this template.' => 'Löschen der Vorlage nicht möglich.',
     'Template for the task description' => 'Vorlage für die Aufgabenbeschreibung',
-    'The start date is greater than the end date' => 'Das Startdatum ist größer als dass Enddatum',
+    'The start date is greater than the end date' => 'Das Startdatum ist größer als das Enddatum',
     'Tags must be separated by a comma' => 'Schlagworte müssen per Komma getrennt werden',
     'Only the task title is required' => 'Nur der Aufgaben-Titel wird benötigt',
     'Creator Username' => 'Ersteller Benutzername',


### PR DESCRIPTION
das Enddatum
not "dass" used as conjunction

[x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
