### PR TITLE
Avoid erroneous board refresh in case of network outage.

### DIFF
--- a/assets/js/components/session-check.js
+++ b/assets/js/components/session-check.js
@@ -3,7 +3,7 @@ KB.interval(60, function () {
     var loginUrl = KB.find('body').data('loginUrl');
 
     if (KB.find('.form-login') === null) {
-        KB.http.get(statusUrl).error(function () {
+        KB.http.get(statusUrl).authError(function () {
             window.location = loginUrl;
         });
     }


### PR DESCRIPTION
Previously, any error was treated as a reason to go to login page.
When being disconneted fron network (often story on laptop), this causes
task board to go away: first, it shows some sort of browser's
network error page, and then, after coming back online, moved to
projects overview page. This frustrates very much when you want to take
your laptop out of network and show opened page to someone else.

The idea is to split error HTTP callback to a few different ones. The "error" callback is kept and is called always for compatibility, thus no other existing code gets affected.

[X] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
