### PR TITLE
Escape table name 'groups' because groups is a reserved word

### DIFF
--- a/app/Schema/Mysql.php
+++ b/app/Schema/Mysql.php
@@ -507,7 +507,7 @@ function version_96(PDO $pdo)
             `group_id` INT NOT NULL,
             `project_id` INT NOT NULL,
             `role` VARCHAR(25) NOT NULL,
-            FOREIGN KEY(group_id) REFERENCES groups(id) ON DELETE CASCADE,
+            FOREIGN KEY(group_id) REFERENCES `groups`(id) ON DELETE CASCADE,
             FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE,
             UNIQUE(group_id, project_id)
         ) ENGINE=InnoDB CHARSET=utf8
@@ -535,7 +535,7 @@ function version_96(PDO $pdo)
 function version_95(PDO $pdo)
 {
     $pdo->exec("
-        CREATE TABLE groups (
+        CREATE TABLE `groups` (
             id INT NOT NULL AUTO_INCREMENT,
             external_id VARCHAR(255) DEFAULT '',
             name VARCHAR(100) NOT NULL UNIQUE,
@@ -547,7 +547,7 @@ function version_95(PDO $pdo)
         CREATE TABLE group_has_users (
             group_id INT NOT NULL,
             user_id INT NOT NULL,
-            FOREIGN KEY(group_id) REFERENCES groups(id) ON DELETE CASCADE,
+            FOREIGN KEY(group_id) REFERENCES `groups`(id) ON DELETE CASCADE,
             FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE,
             UNIQUE(group_id, user_id)
         ) ENGINE=InnoDB CHARSET=utf8

--- a/app/Validator/GroupValidator.php
+++ b/app/Validator/GroupValidator.php
@@ -63,7 +63,7 @@ class GroupValidator extends BaseValidator
         return array(
             new Validators\Required('name', t('The name is required')),
             new Validators\MaxLength('name', t('The maximum length is %d characters', 191), 191),
-            new Validators\Unique('name', t('The name must be unique'), $this->db->getConnection(), GroupModel::TABLE, 'id'),
+            new Validators\Unique('name', t('The name must be unique'), $this->db->getConnection(), $this->db->escapeIdentifier(GroupModel::TABLE), $this->db->escapeIdentifier('id')),
             new Validators\MaxLength('external_id', t('The maximum length is %d characters', 255), 255),
             new Validators\Integer('id', t('This value must be an integer')),
         );


### PR DESCRIPTION
As of [MySql 8.0.2](https://dev.mysql.com/doc/refman/8.0/en/keywords.html)

[*] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
