### PR TITLE
Redirect to board view of the current task after duplication

### DIFF
--- a/app/Controller/TaskDuplicationController.php
+++ b/app/Controller/TaskDuplicationController.php
@@ -87,7 +87,7 @@ class TaskDuplicationController extends BaseController
 
                 if ($task_id > 0) {
                     $this->flash->success(t('Task created successfully.'));
-                    return $this->response->redirect($this->helper->url->to('TaskViewController', 'show', array('project_id' => $values['project_id'], 'task_id' => $task_id)));
+                    return $this->response->redirect($this->helper->url->to('BoardViewController', 'show', array('project_id' => $task['project_id'])));
                 }
             }
 


### PR DESCRIPTION
Move to the board view following task duplication as per the request #3567

Board view was chosen to avoid possible confusion caused by redirecting to the original task instead.

User's familiar with the existing "duplicate to another project" feature may assume the redirect is still taking them to the duplicate in the "another" project. Therefore using the board view will clearly communicate that they're still in the same project and not the "another" project.

Redirecting to the board view will also give a nice user experience when then task is duplicated from a task on the board itself.

[x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
