### PR TITLE
Auto link duplicates

### DIFF
--- a/app/Model/TaskDuplicationModel.php
+++ b/app/Model/TaskDuplicationModel.php
@@ -57,6 +57,7 @@ class TaskDuplicationModel extends Base
 
         if ($new_task_id !== false) {
             $this->tagDuplicationModel->duplicateTaskTags($task_id, $new_task_id);
+            $this->taskLinkModel->create($new_task_id, $task_id, 4);
         }
 
         return $new_task_id;

--- a/app/Model/TaskProjectDuplicationModel.php
+++ b/app/Model/TaskProjectDuplicationModel.php
@@ -30,6 +30,7 @@ class TaskProjectDuplicationModel extends TaskDuplicationModel
 
         if ($new_task_id !== false) {
             $this->tagDuplicationModel->duplicateTaskTagsToAnotherProject($task_id, $new_task_id, $project_id);
+            $this->taskLinkModel->create($new_task_id, $task_id, 4);
         }
 
         return $new_task_id;


### PR DESCRIPTION
Automatically create links for duplicate tasks as per https://github.com/kanboard/kanboard/issues/3566#issue-276394254

Links are created by default rather than having a checkbox for them to be created. This is so users may easily "undo" accidental creation (by removing the link) or forgetting to check the box (it's created by default). I feel this is the best fit for Kanboard's simplicity and efficiency philosophy.

[x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
