### PR TITLE
Auto link tasks created from a subtask

### DIFF
--- a/app/Model/SubtaskTaskConversionModel.php
+++ b/app/Model/SubtaskTaskConversionModel.php
@@ -35,6 +35,7 @@ class SubtaskTaskConversionModel extends Base
         ));
 
         if ($task_id !== false) {
+            $this->taskLinkModel->create($task_id, $subtask['task_id'], 6);
             $this->subtaskModel->remove($subtask_id);
         }
 


### PR DESCRIPTION
Automatically create links for tasks converted from a sub-task as per https://github.com/kanboard/kanboard/issues/3566#issuecomment-351725316

Links are created by default rather than having a checkbox for them to be created. This is so users may easily "undo" accidental creation (by removing the link) or forgetting to check the box (it's created by default). I feel this is the best fit for Kanboard's simplicity and efficiency philosophy.

[x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
