### PR TITLE
Add actions for handling swimlane changes

### DIFF
--- a/app/Action/TaskAssignCategorySwimlaneChange.php
+++ b/app/Action/TaskAssignCategorySwimlaneChange.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Kanboard\Action;
+
+use Kanboard\Model\TaskModel;
+
+/**
+ * Assign a category when the task is moved to a specific swimlane
+ *
+ * @package Kanboard\Action
+ * @author  @Interleaved
+ */
+class TaskAssignCategorySwimlaneChange extends Base
+{
+    /**
+     * Get automatic action description
+     *
+     * @access public
+     * @return string
+     */
+    public function getDescription()
+    {
+        return t('Assign a category when the task is moved to a specific swimlane');
+    }
+
+    /**
+     * Get the list of compatible events
+     *
+     * @access public
+     * @return array
+     */
+    public function getCompatibleEvents()
+    {
+        return array(
+            TaskModel::EVENT_CREATE,
+            TaskModel::EVENT_MOVE_SWIMLANE,
+        );
+    }
+
+    /**
+     * Get the required parameter for the action (defined by the user)
+     *
+     * @access public
+     * @return array
+     */
+    public function getActionRequiredParameters()
+    {
+        return array(
+            'swimlane_id' => t('Swimlane'),
+            'category_id' => t('Category'),
+        );
+    }
+
+    /**
+     * Get the required parameter for the event
+     *
+     * @access public
+     * @return string[]
+     */
+    public function getEventRequiredParameters()
+    {
+        return array(
+            'task_id',
+            'task' => array(
+                'project_id',
+                'swimlane_id',
+            )
+        );
+    }
+
+    /**
+     * Execute the action (set the task category)
+     *
+     * @access public
+     * @param  array   $data   Event data dictionary
+     * @return bool            True if the action was executed or false when not executed
+     */
+    public function doAction(array $data)
+    {
+        $values = array(
+            'id' => $data['task_id'],
+            'category_id' => $this->getParam('category_id'),
+        );
+
+        return $this->taskModificationModel->update($values, false);
+    }
+
+    /**
+     * Check if the event data meet the action condition
+     *
+     * @access public
+     * @param  array   $data   Event data dictionary
+     * @return bool
+     */
+    public function hasRequiredCondition(array $data)
+    {
+        return $data['task']['swimlane_id'] == $this->getParam('swimlane_id');
+    }
+}

--- a/app/Action/TaskMoveSwimlaneCategoryChange.php
+++ b/app/Action/TaskMoveSwimlaneCategoryChange.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Kanboard\Action;
+
+use Kanboard\Model\TaskModel;
+
+/**
+ * Move a task to another swimlane when the category is changed
+ *
+ * @package Kanboard\Action
+ * @author  @Interleaved
+ */
+class TaskMoveSwimlaneCategoryChange extends Base
+{
+    /**
+     * Get automatic action description
+     *
+     * @access public
+     * @return string
+     */
+    public function getDescription()
+    {
+        return t('Move the task to another swimlane when the category is changed');
+    }
+
+    /**
+     * Get the list of compatible events
+     *
+     * @access public
+     * @return array
+     */
+    public function getCompatibleEvents()
+    {
+        return array(
+            TaskModel::EVENT_UPDATE,
+        );
+    }
+
+    /**
+     * Get the required parameter for the action (defined by the user)
+     *
+     * @access public
+     * @return array
+     */
+    public function getActionRequiredParameters()
+    {
+        return array(
+            'dest_swimlane_id' => t('Destination swimlane'),
+            'category_id' => t('Category'),
+        );
+    }
+
+    /**
+     * Get the required parameter for the event
+     *
+     * @access public
+     * @return string[]
+     */
+    public function getEventRequiredParameters()
+    {
+        return array(
+            'task_id',
+            'task' => array(
+                'project_id',
+                'column_id',
+                'category_id',
+                'position',
+                'swimlane_id',
+            )
+        );
+    }
+
+    /**
+     * Execute the action (move the task to another swimlane)
+     *
+     * @access public
+     * @param  array   $data   Event data dictionary
+     * @return bool            True if the action was executed or false when not executed
+     */
+    public function doAction(array $data)
+    {
+        return $this->taskPositionModel->movePosition(
+            $data['task']['project_id'],
+            $data['task_id'],
+            $data['task']['column_id'],
+            $data['task']['position'],
+            $this->getParam('dest_swimlane_id'),
+            false
+        );
+    }
+
+    /**
+     * Check if the event data meet the action condition
+     *
+     * @access public
+     * @param  array   $data   Event data dictionary
+     * @return bool
+     */
+    public function hasRequiredCondition(array $data)
+    {
+        return $data['task']['swimlane_id'] != $this->getParam('dest_swimlane_id') && $data['task']['category_id'] == $this->getParam('category_id');
+    }
+}

--- a/app/ServiceProvider/ActionProvider.php
+++ b/app/ServiceProvider/ActionProvider.php
@@ -4,6 +4,7 @@ namespace Kanboard\ServiceProvider;
 
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
+use Kanboard\Action\TaskAssignCategorySwimlaneChange;
 use Kanboard\Action\TaskAssignColorOnDueDate;
 use Kanboard\Action\TaskAssignColorOnStartDate;
 use Kanboard\Action\TaskAssignColorPriority;
@@ -67,6 +68,7 @@ class ActionProvider implements ServiceProviderInterface
         $container['actionManager'] = new ActionManager($container);
         $container['actionManager']->register(new CommentCreation($container));
         $container['actionManager']->register(new CommentCreationMoveTaskColumn($container));
+        $container['actionManager']->register(new TaskAssignCategorySwimlaneChange($container));
         $container['actionManager']->register(new TaskAssignCategoryColor($container));
         $container['actionManager']->register(new TaskAssignCategoryLabel($container));
         $container['actionManager']->register(new TaskAssignCategoryLink($container));

--- a/app/ServiceProvider/ActionProvider.php
+++ b/app/ServiceProvider/ActionProvider.php
@@ -35,6 +35,7 @@ use Kanboard\Action\TaskMoveAnotherProject;
 use Kanboard\Action\TaskMoveColumnAssigned;
 use Kanboard\Action\TaskMoveColumnCategoryChange;
 use Kanboard\Action\TaskMoveColumnUnAssigned;
+use Kanboard\Action\TaskMoveSwimlaneCategoryChange;
 use Kanboard\Action\TaskOpen;
 use Kanboard\Action\TaskUpdateStartDate;
 use Kanboard\Action\TaskCloseNoActivity;
@@ -94,6 +95,7 @@ class ActionProvider implements ServiceProviderInterface
         $container['actionManager']->register(new TaskMoveColumnClosed($container));
         $container['actionManager']->register(new TaskMoveColumnNotMovedPeriod($container));
         $container['actionManager']->register(new TaskMoveColumnUnAssigned($container));
+        $container['actionManager']->register(new TaskMoveSwimlaneCategoryChange($container));
         $container['actionManager']->register(new TaskOpen($container));
         $container['actionManager']->register(new TaskUpdateStartDate($container));
         $container['actionManager']->register(new TaskAssignDueDateOnCreation($container));


### PR DESCRIPTION
- [x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)

Thanks so much for your awesome work!

I added two new actions
* The first **action allows defining a target swimlane based on a category change**. I use that action for organizing the swimlanes and to only change the category instead of changing both category and swimlane (it's like a category filter for swimlanes). Maybe it's also useful for others. The other way around changing the category based on the current swimlane would be useful too. Will work on that.
* The **second action is the opposite, change the category based on a swimlane change**.