### PR TITLE
Add ordering comments by id along with creation

### DIFF
--- a/app/Model/CommentModel.php
+++ b/app/Model/CommentModel.php
@@ -71,6 +71,7 @@ class CommentModel extends Base
             )
             ->join(UserModel::TABLE, 'id', 'user_id')
             ->orderBy(self::TABLE.'.date_creation', $sorting)
+            ->orderBy(self::TABLE.'.id', $sorting)
             ->eq(self::TABLE.'.task_id', $task_id)
             ->findAll();
     }


### PR DESCRIPTION
Order comments correctly when they are added on the same second.
When comments are added on same second, the database does not return them on cronological order.
Added order by id with same ordering as date_creation so the creation order is respected when date_creation is equal.

- [x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
