### PR TITLE
fix custom roles duplication

### DIFF
--- a/app/Model/ColumnMoveRestrictionModel.php
+++ b/app/Model/ColumnMoveRestrictionModel.php
@@ -159,8 +159,8 @@ class ColumnMoveRestrictionModel extends Base
             $result = $this->db->table(self::TABLE)->persist(array(
                 'project_id' => $project_dst_id,
                 'role_id' => $role_dst_id,
-                'src_column_id' => $row['src_column_id'],
-                'dst_column_id' => $row['dst_column_id'],
+                'src_column_id' => $src_column_id,
+                'dst_column_id' => $dst_column_id,
                 'only_assigned' => (int) $row['only_assigned'],
             ));
             


### PR DESCRIPTION
- [x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)

fixed the custom roles duplication.   
The source_column_id and destination_column_id are searched into the correct project: the newly created one