### PR TITLE
Fix postgres schema version + move to separate lines

### DIFF
--- a/app/Schema/Sql/mysql.sql
+++ b/app/Schema/Sql/mysql.sql
@@ -807,4 +807,5 @@ UNLOCK TABLES;
 /*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
-INSERT INTO users (username, password, role) VALUES ('admin', '$2y$10$I5O18nLDOZ436DXzIRZal.ArrFe69gSMoegHDwV.8lChQHz6K4Kku', 'app-admin');INSERT INTO schema_version VALUES ('133');
+INSERT INTO users (username, password, role) VALUES ('admin', '$2y$10$I5O18nLDOZ436DXzIRZal.ArrFe69gSMoegHDwV.8lChQHz6K4Kku', 'app-admin');
+INSERT INTO schema_version VALUES ('133');

--- a/app/Schema/Sql/postgres.sql
+++ b/app/Schema/Sql/postgres.sql
@@ -2717,4 +2717,5 @@ SELECT pg_catalog.setval('links_id_seq', 11, true);
 -- PostgreSQL database dump complete
 --
 
-INSERT INTO users (username, password, role) VALUES ('admin', '$2y$10$eu5txjAlmBRZYmAcWjHAx.BSCIYL6RMTIyrIWG4eqWFtf62DCJPWy', 'app-admin');INSERT INTO schema_version VALUES ('108');
+INSERT INTO users (username, password, role) VALUES ('admin', '$2y$10$eu5txjAlmBRZYmAcWjHAx.BSCIYL6RMTIyrIWG4eqWFtf62DCJPWy', 'app-admin');
+INSERT INTO schema_version VALUES ('111');


### PR DESCRIPTION
This PR fixes *postgres.sql* schema version which wasn't updated when the schema has been changed in the past. Currently it leads to the following failure during fresh installation:
```
Internal Error: Unable to run SQL migrations: Running migration \Schema\version_109, Running migration \Schema\version_110, SQLSTATE[42701]: Duplicate column: 7 ERROR: column "color_id" of relation "project_has_categories" already exists (You may have to fix it manually)
```

It also puts the version number to a separate line, so it's not that easily overlooked in the future.

- [x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
