### PR TITLE
Disable php_uname() warning

### DIFF
--- a/app/Template/config/about.php
+++ b/app/Template/config/about.php
@@ -37,7 +37,7 @@
         </li>
         <li>
             <?= t('OS version:') ?>
-            <strong><?= php_uname('s').' '.php_uname('r') ?></strong>
+            <strong><?= @php_uname('s').' '.@php_uname('r') ?></strong>
         </li>
         <li>
             <?= t('Database driver:') ?>


### PR DESCRIPTION
Hi,

This PR disabled the PHP warning produced on installations where `php_uname()` is disabled.

Thank you 👍 