### PR TITLE
Fix importing of automatic actions

### DIFF
--- a/app/Model/ActionParameterModel.php
+++ b/app/Model/ActionParameterModel.php
@@ -147,6 +147,8 @@ class ActionParameterModel extends Base
             case 'project_id':
                 return $value != $project_id ? $value : false;
             case 'category_id':
+                if ($value == 0)
+                    return 0;
                 return $this->categoryModel->getIdByName($project_id, $this->categoryModel->getNameById($value)) ?: false;
             case 'src_column_id':
             case 'dest_column_id':
@@ -156,6 +158,8 @@ class ActionParameterModel extends Base
                 return empty($column) ? false : $this->columnModel->getColumnIdByTitle($project_id, $column['title']) ?: false;
             case 'user_id':
             case 'owner_id':
+                if ($value == 0)
+                    return 0;
                 return $this->projectPermissionModel->isAssignable($project_id, $value) ? $value : false;
             case 'swimlane_id':
                 $column = $this->swimlaneModel->getById($value);

--- a/app/Model/ActionParameterModel.php
+++ b/app/Model/ActionParameterModel.php
@@ -147,8 +147,9 @@ class ActionParameterModel extends Base
             case 'project_id':
                 return $value != $project_id ? $value : false;
             case 'category_id':
-                if ($value == 0)
+                if ($value == 0) {
                     return 0;
+                }
                 return $this->categoryModel->getIdByName($project_id, $this->categoryModel->getNameById($value)) ?: false;
             case 'src_column_id':
             case 'dest_column_id':
@@ -158,8 +159,9 @@ class ActionParameterModel extends Base
                 return empty($column) ? false : $this->columnModel->getColumnIdByTitle($project_id, $column['title']) ?: false;
             case 'user_id':
             case 'owner_id':
-                if ($value == 0)
+                if ($value == 0) {
                     return 0;
+                }
                 return $this->projectPermissionModel->isAssignable($project_id, $value) ? $value : false;
             case 'swimlane_id':
                 $column = $this->swimlaneModel->getById($value);

--- a/tests/units/Model/ProjectDuplicationModelTest.php
+++ b/tests/units/Model/ProjectDuplicationModelTest.php
@@ -386,6 +386,13 @@ class ProjectDuplicationModelTest extends Base
             'params' => array('color_id' => 'blue', 'category_id' => 2),
         )));
 
+        $this->assertEquals(2, $actionModel->create(array(
+            'project_id' => 1,
+            'event_name' => TaskModel::EVENT_CREATE_UPDATE,
+            'action_name' => 'TaskAssignColorCategory',
+            'params' => array('color_id' => 'red', 'category_id' => 0),
+        )));
+ 
         $this->assertEquals(2, $projectDuplicationModel->duplicate(1));
 
         $actions = $actionModel->getAllByProject(2);
@@ -395,8 +402,56 @@ class ProjectDuplicationModelTest extends Base
         $this->assertNotEmpty($actions[0]['params']);
         $this->assertEquals('blue', $actions[0]['params']['color_id']);
         $this->assertEquals(5, $actions[0]['params']['category_id']);
+        
+        $this->assertEquals('TaskAssignColorCategory', $actions[1]['action_name']);
+        $this->assertNotEmpty($actions[1]['params']);
+        $this->assertEquals('red', $actions[1]['params']['color_id']);
+        $this->assertEquals(0, $actions[1]['params']['category_id']);
     }
 
+    public function testCloneProjectWithActionTaskAssignSpecificUser()
+    {
+        $projectModel = new ProjectModel($this->container);
+        $actionModel = new ActionModel($this->container);
+        $userModel = new UserModel($this->container);
+        $projectDuplicationModel = new ProjectDuplicationModel($this->container);
+
+        $this->assertEquals(1, $projectModel->create(array('name' => 'P1')));
+
+        $this->assertEquals(1, $userModel->create(array('username' => 'user1')));
+        $this->assertEquals(2, $userModel->create(array('username' => 'user2')));
+        $this->assertEquals(3, $userModel->create(array('username' => 'user3')));
+
+        $this->assertEquals(1, $actionModel->create(array(
+            'project_id' => 1,
+            'event_name' => TaskModel::EVENT_CREATE_UPDATE,
+            'action_name' => 'TaskAssignSpecificUser',
+            'params' => array('column_id' => 1, 'user_id' => 2),
+        )));
+
+        $this->assertEquals(2, $actionModel->create(array(
+            'project_id' => 1,
+            'event_name' => TaskModel::EVENT_CREATE_UPDATE,
+            'action_name' => 'TaskAssignSpecificUser',
+            'params' => array('column_id' => 2, 'user_id' => 0),
+        )));
+        
+        $this->assertEquals(2, $projectDuplicationModel->duplicate(1));
+
+        $actions = $actionModel->getAllByProject(2);
+
+        $this->assertNotEmpty($actions);
+        $this->assertEquals('TaskAssignSpecificUser', $actions[0]['action_name']);
+        $this->assertNotEmpty($actions[0]['params']);
+        $this->assertEquals(1, $actions[0]['params']['column_id']);
+        $this->assertEquals(2, $actions[0]['params']['user_id']);
+
+        $this->assertEquals('TaskAssignSpecificUser', $actions[1]['action_name']);
+        $this->assertNotEmpty($actions[1]['params']);
+        $this->assertEquals(2, $actions[1]['params']['column_id']);
+        $this->assertEquals(0, $actions[1]['params']['user_id']);
+    }
+    
     public function testCloneProjectWithSwimlanes()
     {
         $projectModel = new ProjectModel($this->container);

--- a/tests/units/Model/ProjectDuplicationModelTest.php
+++ b/tests/units/Model/ProjectDuplicationModelTest.php
@@ -414,6 +414,7 @@ class ProjectDuplicationModelTest extends Base
         $projectModel = new ProjectModel($this->container);
         $actionModel = new ActionModel($this->container);
         $userModel = new UserModel($this->container);
+        $projectUserRoleModel = new ProjectUserRoleModel($this->container);
         $projectDuplicationModel = new ProjectDuplicationModel($this->container);
 
         $this->assertEquals(1, $projectModel->create(array('name' => 'P1')));

--- a/tests/units/Model/ProjectDuplicationModelTest.php
+++ b/tests/units/Model/ProjectDuplicationModelTest.php
@@ -422,6 +422,10 @@ class ProjectDuplicationModelTest extends Base
         $this->assertEquals(3, $userModel->create(array('username' => 'user2')));
         $this->assertEquals(4, $userModel->create(array('username' => 'user3')));
 
+        $this->assertTrue($projectUserRoleModel->addUser(1, 2, Role::PROJECT_VIEWER));
+        $this->assertTrue($projectUserRoleModel->addUser(1, 3, Role::PROJECT_VIEWER));
+        $this->assertTrue($projectUserRoleModel->addUser(1, 4, Role::PROJECT_VIEWER));
+
         $this->assertEquals(1, $actionModel->create(array(
             'project_id' => 1,
             'event_name' => TaskModel::EVENT_CREATE_UPDATE,

--- a/tests/units/Model/ProjectDuplicationModelTest.php
+++ b/tests/units/Model/ProjectDuplicationModelTest.php
@@ -418,15 +418,15 @@ class ProjectDuplicationModelTest extends Base
 
         $this->assertEquals(1, $projectModel->create(array('name' => 'P1')));
 
-        $this->assertEquals(1, $userModel->create(array('username' => 'user1')));
-        $this->assertEquals(2, $userModel->create(array('username' => 'user2')));
-        $this->assertEquals(3, $userModel->create(array('username' => 'user3')));
+        $this->assertEquals(2, $userModel->create(array('username' => 'user1')));
+        $this->assertEquals(3, $userModel->create(array('username' => 'user2')));
+        $this->assertEquals(4, $userModel->create(array('username' => 'user3')));
 
         $this->assertEquals(1, $actionModel->create(array(
             'project_id' => 1,
             'event_name' => TaskModel::EVENT_CREATE_UPDATE,
             'action_name' => 'TaskAssignSpecificUser',
-            'params' => array('column_id' => 1, 'user_id' => 2),
+            'params' => array('column_id' => 1, 'user_id' => 3),
         )));
 
         $this->assertEquals(2, $actionModel->create(array(
@@ -443,12 +443,12 @@ class ProjectDuplicationModelTest extends Base
         $this->assertNotEmpty($actions);
         $this->assertEquals('TaskAssignSpecificUser', $actions[0]['action_name']);
         $this->assertNotEmpty($actions[0]['params']);
-        $this->assertEquals(1, $actions[0]['params']['column_id']);
-        $this->assertEquals(2, $actions[0]['params']['user_id']);
+        $this->assertEquals(5, $actions[0]['params']['column_id']);
+        $this->assertEquals(3, $actions[0]['params']['user_id']);
 
         $this->assertEquals('TaskAssignSpecificUser', $actions[1]['action_name']);
         $this->assertNotEmpty($actions[1]['params']);
-        $this->assertEquals(2, $actions[1]['params']['column_id']);
+        $this->assertEquals(6, $actions[1]['params']['column_id']);
         $this->assertEquals(0, $actions[1]['params']['user_id']);
     }
     

--- a/tests/units/Model/ProjectDuplicationModelTest.php
+++ b/tests/units/Model/ProjectDuplicationModelTest.php
@@ -423,8 +423,8 @@ class ProjectDuplicationModelTest extends Base
         $this->assertEquals(3, $userModel->create(array('username' => 'user2')));
         $this->assertEquals(4, $userModel->create(array('username' => 'user3')));
 
-        $this->assertTrue($projectUserRoleModel->addUser(1, 2, Role::PROJECT_VIEWER));
-        $this->assertTrue($projectUserRoleModel->addUser(1, 3, Role::PROJECT_VIEWER));
+        $this->assertTrue($projectUserRoleModel->addUser(1, 2, Role::PROJECT_MANAGER));
+        $this->assertTrue($projectUserRoleModel->addUser(1, 3, Role::PROJECT_MEMBER));
         $this->assertTrue($projectUserRoleModel->addUser(1, 4, Role::PROJECT_VIEWER));
 
         $this->assertEquals(1, $actionModel->create(array(


### PR DESCRIPTION
Actions containing "unassigned" or "no category" parametes were not imported

Issue #3778 

[x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
