### PR TITLE
Added extra values to subtask converted to task

### DIFF
--- a/app/Model/SubtaskTaskConversionModel.php
+++ b/app/Model/SubtaskTaskConversionModel.php
@@ -31,6 +31,9 @@ class SubtaskTaskConversionModel extends Base
             'time_estimated' => $subtask['time_estimated'],
             'time_spent' => $subtask['time_spent'],
             'owner_id' => $subtask['user_id'],
+            'swimlane_id' => $parent_task['swimlane_id'],
+            'priority' => $parent_task['priority'],
+            'column_id' => $parent_task['column_id'],
             'category_id' => $parent_task['category_id']
         ));
 


### PR DESCRIPTION
I noticed that when you convert a sub task into a task the priority of the main task is not automatically assigned. Furthermore, the new task is put in the default swimlane's first column.

I think it makes more sense to inherit those values as that was where I first looked for my new task. This change just adds that 3 lines of code into the conversion. 

[X] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
