### PR TITLE
Fix assignable users on a group with a custom role

### DIFF
--- a/app/Model/ProjectGroupRoleModel.php
+++ b/app/Model/ProjectGroupRoleModel.php
@@ -114,7 +114,7 @@ class ProjectGroupRoleModel extends Base
             ->join(self::TABLE, 'group_id', 'group_id', GroupMemberModel::TABLE)
             ->eq(self::TABLE.'.project_id', $project_id)
             ->eq(UserModel::TABLE.'.is_active', 1)
-            ->in(self::TABLE.'.role', array(Role::PROJECT_MANAGER, Role::PROJECT_MEMBER))
+            ->neq(self::TABLE.'.role', Role::PROJECT_VIEWER)
             ->asc(UserModel::TABLE.'.username')
             ->findAll();
     }


### PR DESCRIPTION
Groups custom roles are now handled the same ways users custom roles are.

Fixes #4114 
[x] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
