### PR TITLE
Docker: Forbid access to the data directory

### DIFF
--- a/docker/etc/nginx/nginx.conf
+++ b/docker/etc/nginx/nginx.conf
@@ -44,6 +44,10 @@ http {
             include fastcgi_params;
         }
 
+        location ~ /data {
+            return 404;
+        }
+
         location ~* ^.+\.(log|sqlite)$ {
             return 404;
         }


### PR DESCRIPTION
Forbid direct access to the data directory, as [security advices in Administrator’s Guide](https://docs.kanboard.org/en/latest/admin_guide/security.html#general-advices) says.

