### PR TITLE
Clarify the comment about MAIL_SMTP_ENCRYPTION

### DIFF
--- a/config.default.php
+++ b/config.default.php
@@ -52,7 +52,7 @@ define('MAIL_SMTP_HOSTNAME', '');
 define('MAIL_SMTP_PORT', 25);
 define('MAIL_SMTP_USERNAME', '');
 define('MAIL_SMTP_PASSWORD', '');
-define('MAIL_SMTP_ENCRYPTION', null); // Valid values are "null", "ssl" or "tls"
+define('MAIL_SMTP_ENCRYPTION', null); // Valid values are null (not a string "null"), "ssl" or "tls"
 
 // Sendmail command to use when the transport is "sendmail"
 define('MAIL_SENDMAIL_COMMAND', '/usr/sbin/sendmail -bs');


### PR DESCRIPTION
The comment can be somewhat misleading for people not familiar with PHP (including me).

I have set the value as follows by mistake: (Before this, I had changed the value from the default)

```
define('MAIL_SMTP_ENCRYPTION', 'null');
```

and got the following error when sending a mail from Kanboard:

```
[error] Connection could not be established with host smtp [Unable to find the socket transport "null" - did you forget to enable it when you configured PHP? #22072]
```
