### PR TITLE
Fix postgres explicit schema name usage

### DIFF
--- a/app/Schema/Sql/postgres.sql
+++ b/app/Schema/Sql/postgres.sql
@@ -2747,5 +2747,5 @@ SELECT pg_catalog.setval('public.links_id_seq', 11, true);
 -- PostgreSQL database dump complete
 --
 
-INSERT INTO users (username, password, role) VALUES ('admin', '$2y$10$GzDCeQl/GdH.pCZfz4fWdO3qmayutRCmxEIY9U9t1k9q9F89VNDCm', 'app-admin');
-INSERT INTO schema_version VALUES ('111');
+INSERT INTO public.users (username, password, role) VALUES ('admin', '$2y$10$GzDCeQl/GdH.pCZfz4fWdO3qmayutRCmxEIY9U9t1k9q9F89VNDCm', 'app-admin');
+INSERT INTO public.schema_version VALUES ('111');


### PR DESCRIPTION
Hi,

This PR aims to unify the explicit usage of postgres schema name in SQL queries.

Specifically, the dump created in f070ad87d6ff33b5fb18fa13463955d93cf08a4d on postgres 10.5 uses `public` schema for the dumped structure and removes `SET search_path = "public", pg_catalog;`. This causes the last 2 SQL queries for default admin password and schema version added by Makefile to fail as no schema is specified for them.

Makefile part is reworked using a variable populated by calling `php -r "echo password_hash('admin', PASSWORD_DEFAULT);"`, which allowed to remove all the quotes escaping and hopefully makes the SQL queries on subsequent lines a bit more readable.

Lastly, I have removed the redundant `-x -O` from `pg_dump` command added in the same commit mentioned above, as `-x` is equivalent to `--no-privileges` and `-O` is alias to `--no-owner` both of which were already present in the command parameters. (https://www.postgresql.org/docs/10/app-pgdump.html for reference)