### PR TITLE
Add LDAP nested groups processing for users

### DIFF
--- a/app/Core/Ldap/User.php
+++ b/app/Core/Ldap/User.php
@@ -78,15 +78,12 @@ class User
     }
 
     /**
-     * Get user groupIds (DN)
-     *
-     * 1) If configured, use memberUid and posixGroup
-     * 2) Otherwise, use memberOf
+     * Fill the 3rd param with all memberships of the 2nd param
      *
      * @access protected
-     * @param  Entry   $entry
-     * @param  string  $username
-     * @return string[]
+     * @param  Entry     $entry
+     * @param  string    $member
+     * @param  string[]  $groupsAll
      */
     protected function getGroupsRecursive(Entry $entry, $member, &$groupsAll)
     {
@@ -103,6 +100,17 @@ class User
         }
     }
 
+    /**
+     * Get user groupIds (DN)
+     *
+     * 1) If configured, use memberUid and posixGroup
+     * 2) Otherwise, use memberOf
+     *
+     * @access protected
+     * @param  Entry   $entry
+     * @param  string  $username
+     * @return string[]
+     */
     protected function getGroups(Entry $entry, $username)
     {
         $groupIds = array();

--- a/config.default.php
+++ b/config.default.php
@@ -177,11 +177,14 @@ define('LDAP_GROUP_BASE_DN', '');
 
 // LDAP group filter
 // Example for ActiveDirectory: (&(objectClass=group)(sAMAccountName=%s*))
+// Example for OpenLDAP (nested groups): (&(objectClass=groupOfNames)(cn=*%s*))
+// Example for OpenLDAP (posix groups):  (&(objectClass=posixGroup)(cn=*%s*))
 define('LDAP_GROUP_FILTER', '');
 
 // LDAP user group filter
 // If this filter is configured, Kanboard will search user groups in LDAP_GROUP_BASE_DN with this filter
-// Example for OpenLDAP: (&(objectClass=posixGroup)(memberUid=%s))
+// Example for OpenLDAP (memberUid: username): (&(objectClass=posixGroup)(memberUid=%s))
+// Example for OpenLDAP (member: uid=userDn,ou=accounts,dc=local): (&(objectClass=groupOfNames)(member=%s))
 define('LDAP_GROUP_USER_FILTER', '');
 
 // LDAP attribute for the group name


### PR DESCRIPTION
Provide recusive processing of groups member of groups, only when
LDAP_GROUP_USER_FILTER is provided.

Example: Group1( Group2( User ) )

With only direct membership proessing, user is only member of Group2
With recursion, User will be member of Group2 and Group1 too.

Discuss on https://kanboard.discourse.group/t/ldap-nested-groups/319