### PR TITLE
Allow extending of exports

### DIFF
--- a/app/Template/export/header.php
+++ b/app/Template/export/header.php
@@ -13,5 +13,6 @@
         <li <?= $this->app->checkMenuSelection('ExportController', 'summary') ?>>
             <?= $this->modal->replaceLink(t('Daily project summary'), 'ExportController', 'summary', array('project_id' => $project['id'])) ?>
         </li>
+        <?= $this->hook->render('template:export:header', array('project_id' => $project['id'])) ?>
     </ul>
 </div>


### PR DESCRIPTION
This PR adds new template hook `template:export:header` to allow plugins to add new exports in the UI.