### PR TITLE
arm32v7 Dockerfile for RPi 3

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,0 +1,26 @@
+FROM arm32v7/alpine:3.9
+
+VOLUME /var/www/app/data
+VOLUME /var/www/app/plugins
+VOLUME /etc/nginx/ssl
+
+EXPOSE 80 443
+
+ARG VERSION
+
+RUN apk update && \
+    apk add openssl unzip nginx bash ca-certificates s6 curl ssmtp mailx php7 php7-phar php7-curl \
+    php7-fpm php7-json php7-zlib php7-xml php7-dom php7-ctype php7-opcache php7-zip php7-iconv \
+    php7-pdo php7-pdo_mysql php7-pdo_sqlite php7-pdo_pgsql php7-mbstring php7-session php7-bcmath \
+    php7-gd php7-mcrypt php7-openssl php7-sockets php7-posix php7-ldap php7-simplexml && \
+    rm -rf /var/cache/apk/* && \
+    rm -rf /var/www/localhost && \
+    rm -f /etc/php7/php-fpm.d/www.conf
+
+ADD . /var/www/app
+ADD docker/ /
+
+RUN rm -rf /var/www/app/docker && echo $VERSION > /version.txt
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD []


### PR DESCRIPTION
This PR introduces the Dockerfile.arm32v7, which is a complete copy of the original Dockerfile except for the first line (base image). 

The built image was tested on my pi with a Nginx-Reverse Proxy. You can find it [here](https://cloud.docker.com/repository/docker/alexanderkrause/kanboard).

https://github.com/kanboard/kanboard/issues/4175