### PR TITLE
 migrate HttpClient to cURL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk update && \
     apk add openssl unzip nginx bash ca-certificates s6 curl ssmtp mailx php7 php7-phar php7-curl \
     php7-fpm php7-json php7-zlib php7-xml php7-dom php7-ctype php7-opcache php7-zip php7-iconv \
     php7-pdo php7-pdo_mysql php7-pdo_sqlite php7-pdo_pgsql php7-mbstring php7-session php7-bcmath \
-    php7-gd php7-mcrypt php7-openssl php7-sockets php7-posix php7-ldap php7-simplexml && \
+    php7-gd php7-mcrypt php7-openssl php7-sockets php7-posix php7-ldap php7-simplexml php7-curl && \
     rm -rf /var/cache/apk/* && \
     rm -rf /var/www/localhost && \
     rm -f /etc/php7/php-fpm.d/www.conf

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -12,7 +12,7 @@ RUN apk update && \
     apk add openssl unzip nginx bash ca-certificates s6 curl ssmtp mailx php7 php7-phar php7-curl \
     php7-fpm php7-json php7-zlib php7-xml php7-dom php7-ctype php7-opcache php7-zip php7-iconv \
     php7-pdo php7-pdo_mysql php7-pdo_sqlite php7-pdo_pgsql php7-mbstring php7-session php7-bcmath \
-    php7-gd php7-mcrypt php7-openssl php7-sockets php7-posix php7-ldap php7-simplexml && \
+    php7-gd php7-mcrypt php7-openssl php7-sockets php7-posix php7-ldap php7-simplexml php7-curl && \
     rm -rf /var/cache/apk/* && \
     rm -rf /var/www/localhost && \
     rm -f /etc/php7/php-fpm.d/www.conf

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -12,7 +12,7 @@ RUN apk update && \
     apk add openssl unzip nginx bash ca-certificates s6 curl ssmtp mailx php7 php7-phar php7-curl \
     php7-fpm php7-json php7-zlib php7-xml php7-dom php7-ctype php7-opcache php7-zip php7-iconv \
     php7-pdo php7-pdo_mysql php7-pdo_sqlite php7-pdo_pgsql php7-mbstring php7-session php7-bcmath \
-    php7-gd php7-mcrypt php7-openssl php7-sockets php7-posix php7-ldap php7-simplexml && \
+    php7-gd php7-mcrypt php7-openssl php7-sockets php7-posix php7-ldap php7-simplexml php7-curl && \
     rm -rf /var/cache/apk/* && \
     rm -rf /var/www/localhost && \
     rm -f /etc/php7/php-fpm.d/www.conf

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -12,7 +12,7 @@ RUN apk update && \
     apk add openssl unzip nginx bash ca-certificates s6 curl ssmtp mailx php7 php7-phar php7-curl \
     php7-fpm php7-json php7-zlib php7-xml php7-dom php7-ctype php7-opcache php7-zip php7-iconv \
     php7-pdo php7-pdo_mysql php7-pdo_sqlite php7-pdo_pgsql php7-mbstring php7-session php7-bcmath \
-    php7-gd php7-mcrypt php7-openssl php7-sockets php7-posix php7-ldap php7-simplexml && \
+    php7-gd php7-mcrypt php7-openssl php7-sockets php7-posix php7-ldap php7-simplexml php7-curl && \
     rm -rf /var/cache/apk/* && \
     rm -rf /var/www/localhost && \
     rm -f /etc/php7/php-fpm.d/www.conf

--- a/app/Core/Http/Client.php
+++ b/app/Core/Http/Client.php
@@ -144,7 +144,7 @@ class Client extends Base
      */
     public function doRequest($method, $url, $content, array $headers, $raiseForErrors = false)
     {
-	$content = '';
+	$requestBody = '';
 
         if (!empty($url)) {
 		if (function_exists('curl_version')) {
@@ -152,17 +152,17 @@ class Client extends Base
 			{
 				$this->logger->debug('HttpClient::doRequest: cURL detected');
 			}
-			$content = $this->doRequestWithCurl($method, $url, $content, $headers, $raiseForErrors);
+			$requestBody = $this->doRequestWithCurl($method, $url, $content, $headers, $raiseForErrors);
 		} else {
 			if (DEBUG)
 			{
 				$this->logger->debug('HttpClient::doRequest: using socket');
 			}
-			$content = $this->doRequestWithSocket($method, $url, $content, $headers, $raiseForErrors);
+			$requestBody = $this->doRequestWithSocket($method, $url, $content, $headers, $raiseForErrors);
 		}
 	}
 
-	return $content;
+	return $requestBody;
     }
 
     /**

--- a/app/Template/config/about.php
+++ b/app/Template/config/about.php
@@ -36,6 +36,10 @@
             <strong><?= PHP_SAPI ?></strong>
         </li>
         <li>
+            <?= t('HttpClient:') ?>
+            <strong><?= Kanboard\Core\Http\Client::backend() ?></strong>
+        </li>
+        <li>
             <?= t('OS version:') ?>
             <strong><?= @php_uname('s').' '.@php_uname('r') ?></strong>
         </li>

--- a/app/constants.php
+++ b/app/constants.php
@@ -148,6 +148,7 @@ defined('HTTP_PROXY_HOSTNAME') or define('HTTP_PROXY_HOSTNAME', '');
 defined('HTTP_PROXY_PORT') or define('HTTP_PROXY_PORT', '3128');
 defined('HTTP_PROXY_USERNAME') or define('HTTP_PROXY_USERNAME', '');
 defined('HTTP_PROXY_PASSWORD') or define('HTTP_PROXY_PASSWORD', '');
+defined('HTTP_PROXY_EXCLUDE') or define('HTTP_PROXY_EXCLUDE', 'localhost');
 defined('HTTP_VERIFY_SSL_CERTIFICATE') or define('HTTP_VERIFY_SSL_CERTIFICATE', true);
 
 defined('TOTP_ISSUER') or define('TOTP_ISSUER', 'Kanboard');

--- a/config.default.php
+++ b/config.default.php
@@ -241,6 +241,7 @@ define('HTTP_PROXY_HOSTNAME', '');
 define('HTTP_PROXY_PORT', '3128');
 define('HTTP_PROXY_USERNAME', '');
 define('HTTP_PROXY_PASSWORD', '');
+define('HTTP_PROXY_EXCLUDE', 'localhost');
 
 // Set to false to allow self-signed certificates
 define('HTTP_VERIFY_SSL_CERTIFICATE', true);


### PR DESCRIPTION
Do not require to enable allow_url_fopen anymore
Allow to exclude hosts from being proxyfied
Requires php-curl