### PR TITLE
add bitcoin to the currency list

### DIFF
--- a/app/Model/CurrencyModel.php
+++ b/app/Model/CurrencyModel.php
@@ -49,6 +49,7 @@ class CurrencyModel extends Base
             'ARS' => t('ARS - Argentine Peso'),
             'COP' => t('COP - Colombian Peso'),
             'BRL' => t('BRL - Brazilian Real'),
+            'XBT' => t('XBT - bitcoin'),
         );
     }
 


### PR DESCRIPTION
bitcoin is referenced using its financial symbol XBT
description is with a lowercase b because its about the unit, not the trading system