### PR TITLE
Hide one task count when there is only one swimlane

### DIFF
--- a/app/Template/board/table_column.php
+++ b/app/Template/board/table_column.php
@@ -19,7 +19,7 @@
                 <?= $this->task->getNewBoardTaskButton($swimlane, $column) ?>
             <?php endif ?>
 
-            <?php if ($column['nb_tasks'] > 0): ?>
+            <?php if ($swimlane['nb_swimlanes'] > 1 && $column['nb_tasks'] > 0): ?>
             <span title="<?= t('Task count') ?>">
                 (<span id="task-number-column-<?= $column['id'] ?>"><?= $column['nb_tasks'] ?></span>)
             </span>


### PR DESCRIPTION
Don't show two task counts per column when there is only one swimlane. 
Fixes #4208