### PR TITLE
Save images as PNG to allow transparency.

### DIFF
--- a/app/Controller/AvatarFileController.php
+++ b/app/Controller/AvatarFileController.php
@@ -69,7 +69,7 @@ class AvatarFileController extends BaseController
         $etag = md5($filename.$size);
 
         $this->response->withCache(365 * 86400, $etag);
-        $this->response->withContentType('image/jpeg');
+        $this->response->withContentType('image/png');
 
         if ($this->request->getHeader('If-None-Match') !== '"'.$etag.'"') {
             $this->response->send();

--- a/app/Controller/FileViewerController.php
+++ b/app/Controller/FileViewerController.php
@@ -116,7 +116,7 @@ class FileViewerController extends BaseController
         $etag = md5($filename);
 
         $this->response->withCache(5 * 86400, $etag);
-        $this->response->withContentType('image/jpeg');
+        $this->response->withContentType('image/png');
 
         if ($this->request->getHeader('If-None-Match') === '"'.$etag.'"') {
             $this->response->status(304);

--- a/app/Core/Thumbnail.php
+++ b/app/Core/Thumbnail.php
@@ -10,7 +10,7 @@ namespace Kanboard\Core;
  */
 class Thumbnail
 {
-    protected $quality = 95;
+    protected $compression = -1;
     protected $metadata = array();
     protected $srcImage;
     protected $dstImage;
@@ -124,6 +124,9 @@ class Thumbnail
             $this->dstImage = imagecreatetruecolor($width, $height);
         }
 
+        imagealphablending($this->dstImage, false);
+        imagesavealpha($this->dstImage, true);
+
         imagecopyresampled($this->dstImage, $this->srcImage, $dstX, $dstY, 0, 0, $dstWidth, $dstHeight, $srcWidth, $srcHeight);
 
         return $this;
@@ -138,7 +141,7 @@ class Thumbnail
      */
     public function toFile($filename)
     {
-        imagejpeg($this->dstImage, $filename, $this->quality);
+        imagepng($this->dstImage, $filename, $this->compression);
         imagedestroy($this->dstImage);
         imagedestroy($this->srcImage);
         return $this;
@@ -153,7 +156,7 @@ class Thumbnail
     public function toString()
     {
         ob_start();
-        imagejpeg($this->dstImage, null, $this->quality);
+        imagepng($this->dstImage, null, $this->compression);
         imagedestroy($this->dstImage);
         imagedestroy($this->srcImage);
         return ob_get_clean();
@@ -166,7 +169,7 @@ class Thumbnail
      */
     public function toOutput()
     {
-        imagejpeg($this->dstImage, null, $this->quality);
+        imagepng($this->dstImage, null, $this->compression);
         imagedestroy($this->dstImage);
         imagedestroy($this->srcImage);
     }


### PR DESCRIPTION
I have changed the file type of the generated thumbnail from jpeg to png. This change allows to display transparency in uploaded avatars or other images.