### PR TITLE
Add option to clone filters on project duplication

### DIFF
--- a/app/Model/ProjectDuplicationModel.php
+++ b/app/Model/ProjectDuplicationModel.php
@@ -28,6 +28,7 @@ class ProjectDuplicationModel extends Base
             'projectPermissionModel',
             'actionModel',
             'tagDuplicationModel',
+            'customFilterModel',
             'projectMetadataModel',
             'projectTaskDuplicationModel',
         );
@@ -50,6 +51,7 @@ class ProjectDuplicationModel extends Base
             'actionModel',
             'swimlaneModel',
             'tagDuplicationModel',
+            'customFilterModel',
             'projectMetadataModel',
             'projectTaskDuplicationModel',
         );

--- a/app/Model/SwimlaneModel.php
+++ b/app/Model/SwimlaneModel.php
@@ -443,7 +443,7 @@ class SwimlaneModel extends Base
                     'name'        => $swimlane['name'],
                     'description' => $swimlane['description'],
                     'position'    => $swimlane['position'],
-                    'is_active'   => $swimlane['is_active'],
+                    'is_active'   => $swimlane['is_active'] ? self::ACTIVE : self::INACTIVE, // Avoid SQL error with Postgres
                     'project_id'  => $projectDstId,
                 );
 

--- a/app/Template/project_creation/create.php
+++ b/app/Template/project_creation/create.php
@@ -30,6 +30,7 @@
             <?= $this->form->checkbox('categoryModel', t('Categories'), 1, true) ?>
             <?= $this->form->checkbox('tagDuplicationModel', t('Tags'), 1, true) ?>
             <?= $this->form->checkbox('actionModel', t('Actions'), 1, true) ?>
+            <?= $this->form->checkbox('customFilterModel', t('Custom filters'), 1, true) ?>
             <?= $this->form->checkbox('projectMetadataModel', t('Metadata'), 1, false) ?>
             <?= $this->form->checkbox('projectTaskDuplicationModel', t('Tasks'), 1, false) ?>
         </div>

--- a/app/Template/project_creation/create.php
+++ b/app/Template/project_creation/create.php
@@ -30,6 +30,7 @@
             <?= $this->form->checkbox('categoryModel', t('Categories'), 1, true) ?>
             <?= $this->form->checkbox('tagDuplicationModel', t('Tags'), 1, true) ?>
             <?= $this->form->checkbox('actionModel', t('Actions'), 1, true) ?>
+            <?= $this->form->checkbox('projectMetadataModel', t('Metadata'), 1, false) ?>
             <?= $this->form->checkbox('projectTaskDuplicationModel', t('Tasks'), 1, false) ?>
         </div>
 

--- a/app/Template/project_view/duplicate.php
+++ b/app/Template/project_view/duplicate.php
@@ -18,6 +18,7 @@
         <?= $this->form->checkbox('categoryModel', t('Categories'), 1, true) ?>
         <?= $this->form->checkbox('tagDuplicationModel', t('Tags'), 1, true) ?>
         <?= $this->form->checkbox('actionModel', t('Actions'), 1, true) ?>
+        <?= $this->form->checkbox('customFilterModel', t('Custom filters'), 1, true) ?>
         <?= $this->form->checkbox('projectMetadataModel', t('Metadata'), 1, false) ?>
         <?= $this->form->checkbox('projectTaskDuplicationModel', t('Tasks'), 1, false) ?>
 

--- a/tests/units/Model/CustomFilterTest.php
+++ b/tests/units/Model/CustomFilterTest.php
@@ -16,6 +16,7 @@ class CustomFilterTest extends Base
         $this->assertEquals(1, $p->create(array('name' => 'UnitTest')));
         $this->assertEquals(1, $cf->create(array('name' => 'My filter 1', 'filter' => 'status:open color:blue', 'project_id' => 1, 'user_id' => 1)));
         $this->assertEquals(2, $cf->create(array('name' => 'My filter 2', 'filter' => 'status:open color:red', 'project_id' => 1, 'user_id' => 1, 'is_shared' => 1)));
+        $this->assertEquals(3, $cf->create(array('name' => 'My filter 3', 'filter' => 'status:open color:green', 'project_id' => 1, 'user_id' => 1, 'append' => 1)));
 
         $filter = $cf->getById(1);
         $this->assertNotEmpty($filter);
@@ -24,6 +25,7 @@ class CustomFilterTest extends Base
         $this->assertEquals(1, $filter['project_id']);
         $this->assertEquals(1, $filter['user_id']);
         $this->assertEquals(0, $filter['is_shared']);
+        $this->assertEquals(0, $filter['append']);
 
         $filter = $cf->getById(2);
         $this->assertNotEmpty($filter);
@@ -32,6 +34,16 @@ class CustomFilterTest extends Base
         $this->assertEquals(1, $filter['project_id']);
         $this->assertEquals(1, $filter['user_id']);
         $this->assertEquals(1, $filter['is_shared']);
+        $this->assertEquals(0, $filter['append']);
+
+        $filter = $cf->getById(3);
+        $this->assertNotEmpty($filter);
+        $this->assertEquals('My filter 3', $filter['name']);
+        $this->assertEquals('status:open color:green', $filter['filter']);
+        $this->assertEquals(1, $filter['project_id']);
+        $this->assertEquals(1, $filter['user_id']);
+        $this->assertEquals(0, $filter['is_shared']);
+        $this->assertEquals(1, $filter['append']);
     }
 
     public function testModification()

--- a/tests/units/Model/ProjectDuplicationModelTest.php
+++ b/tests/units/Model/ProjectDuplicationModelTest.php
@@ -540,6 +540,9 @@ class ProjectDuplicationModelTest extends Base
         $this->assertEquals(2, $taskCreationModel->create(array('title' => 'T2', 'project_id' => 1, 'column_id' => 2, 'owner_id' => 1)));
         $this->assertEquals(3, $taskCreationModel->create(array('title' => 'T3', 'project_id' => 1, 'column_id' => 3, 'owner_id' => 1)));
 
+        // make the first swimlane inactive (keep positions)
+        $this->assertTrue($swimlaneModel->disable(1, 1));
+
         $this->assertEquals(2, $projectDuplicationModel->duplicate(1, array('projectPermissionModel', 'swimlaneModel', 'projectTaskDuplicationModel')));
 
         // Check if Swimlanes have been duplicated
@@ -547,12 +550,16 @@ class ProjectDuplicationModelTest extends Base
         $this->assertCount(4, $swimlanes);
         $this->assertEquals(5, $swimlanes[0]['id']);
         $this->assertEquals('Default swimlane', $swimlanes[0]['name']);
+        $this->assertEquals(0, $swimlanes[0]['is_active']);
         $this->assertEquals(6, $swimlanes[1]['id']);
         $this->assertEquals('S1', $swimlanes[1]['name']);
+        $this->assertEquals(1, $swimlanes[1]['is_active']);
         $this->assertEquals(7, $swimlanes[2]['id']);
         $this->assertEquals('S2', $swimlanes[2]['name']);
+        $this->assertEquals(1, $swimlanes[2]['is_active']);
         $this->assertEquals(8, $swimlanes[3]['id']);
         $this->assertEquals('S3', $swimlanes[3]['name']);
+        $this->assertEquals(1, $swimlanes[3]['is_active']);
 
         // Check if Tasks have been duplicated
         $tasks = $taskFinderModel->getAll(2);


### PR DESCRIPTION
Also:
- Fixes project "create from" option, it was missing one option
- Adds a test case to Custom filters tests (custom field with append option)