### PR TITLE
Fix errors when setting duplicate default columns or categories

### DIFF
--- a/app/Model/BoardModel.php
+++ b/app/Model/BoardModel.php
@@ -31,20 +31,16 @@ class BoardModel extends Base
      */
     public function getUserColumns()
     {
-        $column_names = explode(',', $this->configModel->get('board_columns', implode(',', $this->getDefaultColumns())));
+        $column_names = array_unique(explode_csv_field($this->configModel->get('board_columns', implode(',', $this->getDefaultColumns()))));
         $columns = array();
 
         foreach ($column_names as $column_name) {
-            $column_name = trim($column_name);
-
-            if (! empty($column_name)) {
-                $columns[] = array(
-                    'title' => $column_name,
-                    'task_limit' => 0,
-                    'description' => '',
-                    'hide_in_dashboard' => 0,
-                );
-            }
+            $columns[] = array(
+                'title' => $column_name,
+                'task_limit' => 0,
+                'description' => '',
+                'hide_in_dashboard' => 0,
+            );
         }
 
         return $columns;

--- a/app/Model/CategoryModel.php
+++ b/app/Model/CategoryModel.php
@@ -137,17 +137,13 @@ class CategoryModel extends Base
     public function createDefaultCategories($project_id)
     {
         $results = array();
-        $categories = explode(',', $this->configModel->get('project_categories'));
+        $categories = array_unique(explode_csv_field($this->configModel->get('project_categories')));
 
         foreach ($categories as $category) {
-            $category = trim($category);
-
-            if (! empty($category)) {
-                $results[] = $this->db->table(self::TABLE)->insert(array(
-                    'project_id' => $project_id,
-                    'name' => $category,
-                ));
-            }
+            $results[] = $this->db->table(self::TABLE)->insert(array(
+                'project_id' => $project_id,
+                'name' => $category,
+            ));
         }
 
         return in_array(false, $results, true);

--- a/tests/units/Model/BoardTest.php
+++ b/tests/units/Model/BoardTest.php
@@ -26,8 +26,8 @@ class BoardTest extends Base
         $this->assertEquals('Work in progress', $columns[3]);
         $this->assertEquals('Done', $columns[4]);
 
-        // Custom columns: spaces should be trimed and no empty columns
-        $input = '   column #1  , column #2, ';
+        // Custom columns: spaces should be trimed, no empty columns and no duplicates
+        $input = '   column #1  , column #2,column #1 ,column #3  , ';
 
         $this->assertTrue($c->save(array('board_columns' => $input)));
         $this->container['memoryCache']->flush();
@@ -37,8 +37,9 @@ class BoardTest extends Base
         $columns = $columnModel->getList(2);
 
         $this->assertTrue(is_array($columns));
-        $this->assertEquals(2, count($columns));
+        $this->assertEquals(3, count($columns));
         $this->assertEquals('column #1', $columns[5]);
         $this->assertEquals('column #2', $columns[6]);
+        $this->assertEquals('column #3', $columns[7]);
     }
 }

--- a/tests/units/Model/CategoryModelTest.php
+++ b/tests/units/Model/CategoryModelTest.php
@@ -156,7 +156,8 @@ class CategoryModelTest extends Base
         $categoryModel = new CategoryModel($this->container);
         $configModel = new ConfigModel($this->container);
 
-        $this->assertTrue($configModel->save(array('project_categories' => 'C1, C2, C3')));
+        // Custom categories: spaces should be trimed, no empty and no duplicates
+        $this->assertTrue($configModel->save(array('project_categories' => 'C1, C2, C2 , C3, C1,  ')));
         $this->assertEquals(1, $projectModel->create(array('name' => 'Project #1')));
         $this->assertTrue($categoryModel->createDefaultCategories(1));
 


### PR DESCRIPTION
It was impossible to create a new project if a user sets the default columns or default categories with duplicated values.
Improved unit tests to cover more cases