### PR TITLE
change category icon (in favor for tag icon for tags)

### DIFF
--- a/app/Template/project_header/search.php
+++ b/app/Template/project_header/search.php
@@ -41,7 +41,7 @@
             <?php if (isset($categories_list) && ! empty($categories_list)): ?>
             <div class="input-addon-item">
                 <div class="dropdown">
-                    <a href="#" class="dropdown-menu dropdown-menu-link-icon" title="<?= t('Category filters') ?>"><i class="fa fa-tags fa-fw"></i><i class="fa fa-caret-down"></i></a>
+                    <a href="#" class="dropdown-menu dropdown-menu-link-icon" title="<?= t('Category filters') ?>"><i class="fa fa-folder-open fa-fw"></i><i class="fa fa-caret-down"></i></a>
                     <ul>
                         <li><a href="#" class="filter-helper" data-unique-filter="category:none"><?= t('No category') ?></a></li>
                         <?php foreach ($categories_list as $category): ?>


### PR DESCRIPTION
This PR proposes a new icon for category.
Currently the tag icon is used for categories, the tag icon should be used for tags instead.

See discussion in the forum https://kanboard.discourse.group/t/tag-filter-dropdown