### PR TITLE
Change order to connect API Before LDAP

### DIFF
--- a/app/ServiceProvider/AuthenticationProvider.php
+++ b/app/ServiceProvider/AuthenticationProvider.php
@@ -41,11 +41,11 @@ class AuthenticationProvider implements ServiceProviderInterface
             $container['authenticationManager']->register(new ReverseProxyAuth($container));
         }
 
+        $container['authenticationManager']->register(new ApiAccessTokenAuth($container));
+        
         if (LDAP_AUTH) {
             $container['authenticationManager']->register(new LdapAuth($container));
-        }
-
-        $container['authenticationManager']->register(new ApiAccessTokenAuth($container));
+        }     
 
         $container['projectAccessMap'] = $this->getProjectAccessMap();
         $container['applicationAccessMap'] = $this->getApplicationAccessMap();


### PR DESCRIPTION
Prevent double authentication with API Access token and ldaps server and also prevent temporary ban from ldap server when this one is enabled

Issues #4279 