### PR TITLE
color_id not required when updating a tag

### DIFF
--- a/app/Model/TagModel.php
+++ b/app/Model/TagModel.php
@@ -160,7 +160,7 @@ class TagModel extends Base
      * @param  string  $tag
      * @return bool
      */
-    public function update($tag_id, $tag, $color_id)
+    public function update($tag_id, $tag, $color_id = null)
     {
         return $this->db->table(self::TABLE)->eq('id', $tag_id)->update(array(
             'name' => $tag,


### PR DESCRIPTION
The parameter color_tag should be optional when updating a tag (Or the documentation should be changed).  Since color_id is optional when creating a tag, it is counter intuitive, that it is  needed when updating a tag.

https://docs.kanboard.org/en/latest/api/tags_procedures.html#updatetag