### PR TITLE
Fix SubtaskRestrictionController modal misbehaviour on link

### DIFF
--- a/app/Helper/SubtaskHelper.php
+++ b/app/Helper/SubtaskHelper.php
@@ -32,7 +32,7 @@ class SubtaskHelper extends Base
     public function renderTitle(array $subtask)
     {
         if ($subtask['status'] == 0) {
-            $html = '<i class="fa fa-square-o fa-fw"></i>';
+            $html = '<i class="fa fa-square-o fa-fw ' . ($this->hasSubtaskInProgress() ? 'js-modal-confirm' : '') . '"></i>';
         } elseif ($subtask['status'] == 1) {
             $html = '<i class="fa fa-gears fa-fw"></i>';
         } else {


### PR DESCRIPTION
When the icon was clicked, the modal wasn't shown. Instead, its html content was open as the whole page.

Issue was reported on forum: https://kanboard.discourse.group/t/project-settings-allow-only-one-subtask-save-unvailable/649