### PR TITLE
Fix #4341. Show all date formats in application settings, including iso

### DIFF
--- a/app/Controller/ConfigController.php
+++ b/app/Controller/ConfigController.php
@@ -69,7 +69,7 @@ class ConfigController extends BaseController
             'mail_transports' => $this->emailClient->getAvailableTransports(),
             'languages' => $this->languageModel->getLanguages(),
             'timezones' => $this->timezoneModel->getTimezones(),
-            'date_formats' => $this->dateParser->getAvailableFormats($this->dateParser->getDateFormats()),
+            'date_formats' => $this->dateParser->getAvailableFormats($this->dateParser->getDateFormats(true)),
             'time_formats' => $this->dateParser->getAvailableFormats($this->dateParser->getTimeFormats()),
             'title' => t('Settings').' &gt; '.t('Application settings'),
         )));


### PR DESCRIPTION
This is a fix for #4341. 
 
To allow the iso formats to be shown in application settings by default ("2019-11-16" and "2019_11_16"), I added true as a parameter here `'date_formats' => $this->dateParser->getAvailableFormats($this->dateParser->getDateFormats(true)),` in the config controller so it will pull in all described formats in the function getAvailableFormats:

```
public function getDateFormats($iso = false)
    {
        $formats = array(
            $this->getUserDateFormat(),
        );

        $isoFormats = array(
            'Y-m-d',
            'Y_m_d',
        );

        $userFormats = array(
            'm/d/Y',
            'd/m/Y',
            'Y/m/d',
            'd.m.Y',
        );

        if ($iso) {
            $formats = array_merge($formats, $isoFormats, $userFormats);
        } else {
            $formats = array_merge($formats, $userFormats);
        }

        return array_unique($formats);
    }
```

The other option would be to set the default param $iso in `getDateFormats` to true rather than false. I didn't do that here since it would be a global change to anything calling that function without a parameter, though nothing else is calling that function except the ConfigController. 

If you want to change the default parameter value instead, remember to update the DateParserTest.php accordingly.