### PR TITLE
Fix #3871.Incompatible plugins could not uninstall.

### DIFF
--- a/app/Controller/PluginController.php
+++ b/app/Controller/PluginController.php
@@ -96,7 +96,10 @@ class PluginController extends BaseController
     public function confirm()
     {
         $pluginId = $this->request->getStringParam('pluginId');
-        $plugins = $this->pluginLoader->getPlugins();
+        $plugins = array_merge(
+          $this->pluginLoader->getPlugins(),
+          $this->pluginLoader->getIncompatiblePlugins()
+        );
 
         $this->response->html($this->template->render('plugin/remove', array(
             'plugin_id' => $pluginId,


### PR DESCRIPTION
This is a fix for #3871 

The `PluginController confirm` function was using the given plugin ID to look up the plugin. When that fails, the confirmation popup doesn't appear. The `confirm` function was only loading up compatible plugins, so an incompatible plugin ID would not be found in the array, so it would fail and the popup would not show. 

To fix, I merged the compatible and incompatible plugin arrays so the lookup would not fail on incompatible plugins.