### PR TITLE
Added some top level domains to the AttachmentLinkProvider match function

### DIFF
--- a/app/ExternalLink/AttachmentLinkProvider.php
+++ b/app/ExternalLink/AttachmentLinkProvider.php
@@ -29,6 +29,12 @@ class AttachmentLinkProvider extends BaseLinkProvider implements ExternalLinkPro
         'asp',
         'aspx',
         'cgi',
+        'com',
+        'net',
+        'io',
+        'org',
+        'edu',
+        'gov',
     );
 
     /**


### PR DESCRIPTION
Fix for #4359 

Added some top level domains to the match function of the AttachmentLinkProvider so that .com, .net, .edu, .org, .io, and .gov are marked as web links not attachments. This will prevent links like https://www.github.io from being marked as attachments instead of web links. See my comment in the issue this fixes for more details.