### PR TITLE
Updates UrlHelper->dir() to use KANBOARD_URL if specified

### DIFF
--- a/app/Helper/UrlHelper.php
+++ b/app/Helper/UrlHelper.php
@@ -171,9 +171,13 @@ class UrlHelper extends Base
     public function dir()
     {
         if ($this->directory === '' && $this->request->getMethod() !== '') {
-            $this->directory = str_replace('\\', '/', dirname($this->request->getServerVariable('PHP_SELF')));
-            $this->directory = $this->directory !== '/' ? $this->directory.'/' : '/';
-            $this->directory = str_replace('//', '/', $this->directory);
+            if (strlen(KANBOARD_URL) > 0) {
+                $this->directory = parse_url(KANBOARD_URL, PHP_URL_PATH);
+            } else {
+                $this->directory = str_replace('\\', '/', dirname($this->request->getServerVariable('PHP_SELF')));
+                $this->directory = $this->directory !== '/' ? $this->directory.'/' : '/';
+                $this->directory = str_replace('//', '/', $this->directory);
+            }
         }
 
         return $this->directory;

--- a/app/Helper/UrlHelper.php
+++ b/app/Helper/UrlHelper.php
@@ -171,7 +171,7 @@ class UrlHelper extends Base
     public function dir()
     {
         if ($this->directory === '' && $this->request->getMethod() !== '') {
-            if (strlen(KANBOARD_URL) > 0) {
+            if (defined('KANBOARD_URL') && strlen(KANBOARD_URL) > 0) {
                 $this->directory = parse_url(KANBOARD_URL, PHP_URL_PATH);
             } else {
                 $this->directory = str_replace('\\', '/', dirname($this->request->getServerVariable('PHP_SELF')));


### PR DESCRIPTION
This resolves various redirection issues when hosted in a subdir, e.g.
https://example.com/kanboard/. See for example #4119 and #3534