### PR TITLE
Fixes issue #4359. Updating the regex for matching attachment external links

### DIFF
--- a/app/ExternalLink/AttachmentLinkProvider.php
+++ b/app/ExternalLink/AttachmentLinkProvider.php
@@ -74,7 +74,7 @@ class AttachmentLinkProvider extends BaseLinkProvider implements ExternalLinkPro
      */
     public function match()
     {
-        if (preg_match('/^https?:\/\/.*/.*\.([^\/]+)$/', $this->userInput, $matches)) {
+        if (preg_match('/^https?:\/\/.*\/.*\.([^\/]+)$/', $this->userInput, $matches)) {
             return $this->isValidExtension($matches[1]);
         }
 

--- a/app/ExternalLink/AttachmentLinkProvider.php
+++ b/app/ExternalLink/AttachmentLinkProvider.php
@@ -74,7 +74,7 @@ class AttachmentLinkProvider extends BaseLinkProvider implements ExternalLinkPro
      */
     public function match()
     {
-        if (preg_match('/^https?:\/\/.*\.([^\/]+)$/', $this->userInput, $matches)) {
+        if (preg_match('/^https?:\/\/.*/.*\.([^\/]+)$/', $this->userInput, $matches)) {
             return $this->isValidExtension($matches[1]);
         }
 


### PR DESCRIPTION
Fix for #4359 . 

[Closed pull request](https://github.com/kanboard/kanboard/pull/4382)

Updated the regular expression so that https://github.io will count as a web link and https://github.io/test.jpeg will count as an attachment.

See #4359 for more comments on this solution.