### PR TITLE
Fixes issue #4359. Updating the regex for matching attachment external links and added unit tests

### DIFF
--- a/app/ExternalLink/AttachmentLinkProvider.php
+++ b/app/ExternalLink/AttachmentLinkProvider.php
@@ -74,7 +74,7 @@ class AttachmentLinkProvider extends BaseLinkProvider implements ExternalLinkPro
      */
     public function match()
     {
-        if (preg_match('/^https?:\/\/.*\.([^\/]+)$/', $this->userInput, $matches)) {
+        if (preg_match('/^https?:\/\/.*\/.*\.([^\/]+)$/', $this->userInput, $matches)) {
             return $this->isValidExtension($matches[1]);
         }
 

--- a/tests/units/ExternalLink/AttachmentLinkProviderTest.php
+++ b/tests/units/ExternalLink/AttachmentLinkProviderTest.php
@@ -40,6 +40,9 @@ class AttachmentLinkProviderTest extends Base
         $attachmentLinkProvider->setUserTextInput('  https://kanboard.org/folder/archive.tar ');
         $this->assertTrue($attachmentLinkProvider->match());
 
+        $attachmentLinkProvider->setUserTextInput('https://www.github.io/folder/archive.zip');
+        $this->assertFalse($attachmentLinkProvider->match());
+
         $attachmentLinkProvider->setUserTextInput('http:// invalid url');
         $this->assertFalse($attachmentLinkProvider->match());
 
@@ -53,6 +56,12 @@ class AttachmentLinkProviderTest extends Base
         $this->assertFalse($attachmentLinkProvider->match());
 
         $attachmentLinkProvider->setUserTextInput('https://kanboard.org/folder/document.do');
+        $this->assertFalse($attachmentLinkProvider->match());
+
+        $attachmentLinkProvider->setUserTextInput('https://www.github.io/folder/document.html');
+        $this->assertFalse($attachmentLinkProvider->match());
+
+        $attachmentLinkProvider->setUserTextInput('https://www.github.io');
         $this->assertFalse($attachmentLinkProvider->match());
     }
 

--- a/tests/units/ExternalLink/AttachmentLinkProviderTest.php
+++ b/tests/units/ExternalLink/AttachmentLinkProviderTest.php
@@ -41,7 +41,7 @@ class AttachmentLinkProviderTest extends Base
         $this->assertTrue($attachmentLinkProvider->match());
 
         $attachmentLinkProvider->setUserTextInput('https://www.github.io/folder/archive.zip');
-        $this->assertFalse($attachmentLinkProvider->match());
+        $this->assertTrue($attachmentLinkProvider->match());
 
         $attachmentLinkProvider->setUserTextInput('http:// invalid url');
         $this->assertFalse($attachmentLinkProvider->match());


### PR DESCRIPTION
Fix for #4359 

Updated the regular expression so that https://github.io will count as a web link and https://github.io/test.jpeg will count as an attachment. Also added a few lines to a unit test to ensure those types of links behave appropriately.

See #4359 for more comments on this solution.