### PR TITLE
Make tags global from project settings

### DIFF
--- a/app/Controller/ProjectTagController.php
+++ b/app/Controller/ProjectTagController.php
@@ -121,4 +121,30 @@ class ProjectTagController extends BaseController
 
         $this->response->redirect($this->helper->url->to('ProjectTagController', 'index', array('project_id' => $project['id'])));
     }
+
+    public function confirmMakeGlobalTag()
+    {
+        $project = $this->getProject();
+        $tag = $this->getProjectTag($project);
+
+        $this->response->html($this->template->render('project_tag/make_global', array(
+            'tag'     => $tag,
+            'project' => $project,
+        )));
+    }
+
+    public function makeGlobalTag(){
+        if ($this->userSession->isAdmin()) {
+            $project = $this->getProject();
+            $tag = $this->getProjectTag($project);
+            
+            if ($this->tagModel->update($tag['id'], $tag['name'], $tag['color_id'], 0)) {
+                $this->flash->success(t('Tag updated successfully.'));
+            } else {
+                $this->flash->failure(t('Unable to update this tag.'));
+            }
+
+            $this->response->redirect($this->helper->url->to('ProjectTagController', 'index', array('project_id' => $project['id'])));
+        }
+    }    
 }

--- a/app/Locale/de_DE/translations.php
+++ b/app/Locale/de_DE/translations.php
@@ -1411,4 +1411,6 @@ return array(
     'Task limits apply to each swimlane individually' => 'Aufgabenlimit gilt pro Swimlane',
     'Task limits are applied to each swimlane individually' => 'Aufgabenlimit gilt pro Swimlane',
     'Task limits are applied across swimlanes' => 'Aufgabenlimit gilt Swimlane übergreifend',
+    'Change to global tag' => 'Zu globalem Schlagwort machen',
+    'Do you really want to make the tag "%s" global?' => 'Das Schlagwort "%s" wirklich global machen?',
 );

--- a/app/Locale/fr_FR/translations.php
+++ b/app/Locale/fr_FR/translations.php
@@ -1411,4 +1411,6 @@ return array(
     'Task limits apply to each swimlane individually' => 'Les limites de tâches s\'appliquent à chaque swimlane individuellement',
     'Task limits are applied to each swimlane individually' => 'Les limites de tâches sont appliquées à chaque swimlane individuellement',
     'Task limits are applied across swimlanes' => 'Les limites de tâches sont appliquées entre les swimlanes',
+    // 'Change to global tag' => '',
+    // 'Do you really want to make the tag "%s" global?' => '',
 );

--- a/app/Model/TagModel.php
+++ b/app/Model/TagModel.php
@@ -160,12 +160,20 @@ class TagModel extends Base
      * @param  string  $tag
      * @return bool
      */
-    public function update($tag_id, $tag, $color_id = null)
+    public function update($tag_id, $tag, $color_id = null, $project_id = null)
     {
-        return $this->db->table(self::TABLE)->eq('id', $tag_id)->update(array(
-            'name' => $tag,
-            'color_id' => $color_id,
-        ));
+        if($project_id !== null){
+            return $this->db->table(self::TABLE)->eq('id', $tag_id)->update(array(
+                'name' => $tag,
+                'color_id' => $color_id,
+                'project_id' => $project_id
+            ));
+        } else {
+            return $this->db->table(self::TABLE)->eq('id', $tag_id)->update(array(
+                'name' => $tag,
+                'color_id' => $color_id
+            ));
+        }   
     }
 
     /**

--- a/app/Template/project_tag/index.php
+++ b/app/Template/project_tag/index.php
@@ -24,6 +24,11 @@
                             <li>
                                 <?= $this->modal->medium('edit', t('Edit'), 'ProjectTagController', 'edit', array('tag_id' => $tag['id'], 'project_id' => $project['id'])) ?>
                             </li>
+                            <?php if ($this->user->isAdmin()): ?>
+                            <li>
+                                <?= $this->modal->confirm('globe', t('Change to global tag'), 'ProjectTagController', 'confirmMakeGlobalTag', array('tag_id' => $tag['id'], 'project_id' => $project['id'])) ?>
+                            </li>
+                            <?php endif ?>
                             <li>
                                 <?= $this->modal->confirm('trash-o', t('Remove'), 'ProjectTagController', 'confirm', array('tag_id' => $tag['id'], 'project_id' => $project['id'])) ?>
                             </li>

--- a/app/Template/project_tag/make_global.php
+++ b/app/Template/project_tag/make_global.php
@@ -1,0 +1,15 @@
+<div class="page-header">
+    <h2><?= t('Change to global tag') ?></h2>
+</div>
+
+<div class="confirm">
+    <p class="alert alert-info">
+        <?= t('Do you really want to make the tag "%s" global?', $tag['name']) ?>
+    </p>
+
+    <?= $this->modal->confirmButtons(
+        'ProjectTagController',
+        'makeGlobalTag',
+        array('tag_id' => $tag['id'], 'project_id' => $project['id'])
+    ) ?>
+</div>


### PR DESCRIPTION
Function to allow administrators to convert project tag to global tag.

![image](https://user-images.githubusercontent.com/1961634/73962312-76386a80-490e-11ea-9cd0-0f8d5be1390c.png)

![image](https://user-images.githubusercontent.com/1961634/73962330-7df80f00-490e-11ea-8f1b-edf461d3dc47.png)
