### PR TITLE
Per-project and per-swimlane task limits

### DIFF
--- a/app/Controller/BaseController.php
+++ b/app/Controller/BaseController.php
@@ -127,7 +127,7 @@ abstract class BaseController extends Base
     protected function getProject($project_id = 0)
     {
         $project_id = $this->request->getIntegerParam('project_id', $project_id);
-        $project = $this->projectModel->getByIdWithOwner($project_id);
+        $project = $this->projectModel->getByIdWithOwnerAndTaskCount($project_id);
 
         if (empty($project)) {
             throw new PageNotFoundException();

--- a/app/Controller/ProjectCreationController.php
+++ b/app/Controller/ProjectCreationController.php
@@ -97,7 +97,8 @@ class ProjectCreationController extends BaseController
             'name' => $values['name'],
             'is_private' => $values['is_private'],
             'identifier' => $values['identifier'],
-            'per_swimlane_task_limits' => $values['per_swimlane_task_limits'],
+            'per_swimlane_task_limits' => array_key_exists('per_swimlane_task_limits', $values) ? $values['per_swimlane_task_limits'] : 0,
+            'task_limit' => $values['task_limit'],
         );
 
         return $this->projectModel->create($project, $this->userSession->getId(), true);

--- a/app/Controller/SwimlaneController.php
+++ b/app/Controller/SwimlaneController.php
@@ -63,7 +63,7 @@ class SwimlaneController extends BaseController
         list($valid, $errors) = $this->swimlaneValidator->validateCreation($values);
 
         if ($valid) {
-            if ($this->swimlaneModel->create($project['id'], $values['name'], $values['description']) !== false) {
+            if ($this->swimlaneModel->create($project['id'], $values['name'], $values['description'], $values['task_limit']) !== false) {
                 $this->flash->success(t('Your swimlane have been created successfully.'));
                 $this->response->redirect($this->helper->url->to('SwimlaneController', 'index', array('project_id' => $project['id'])), true);
                 return;

--- a/app/Model/ProjectDuplicationModel.php
+++ b/app/Model/ProjectDuplicationModel.php
@@ -160,6 +160,7 @@ class ProjectDuplicationModel extends Base
             'priority_start' => $project['priority_start'],
             'priority_end' => $project['priority_end'],
             'per_swimlane_task_limits' => empty($project['per_swimlane_task_limits']) ? 0 : 1,
+            'task_limit' => $project['task_limit'],
             'identifier' => $identifier,
         );
 

--- a/app/Model/ProjectModel.php
+++ b/app/Model/ProjectModel.php
@@ -89,7 +89,7 @@ class ProjectModel extends Base
     public function getByIdWithOwnerAndTaskCount($project_id)
     {
         return $this->db->table(self::TABLE)
-            ->columns(self::TABLE.'.*', UserModel::TABLE.'.username AS owner_username', UserModel::TABLE.'.name AS owner_name', 'SUM('.TaskModel::TABLE.'.is_active) AS nb_active_tasks')
+            ->columns(self::TABLE.'.*', UserModel::TABLE.'.username AS owner_username', UserModel::TABLE.'.name AS owner_name', 'SUM(CAST('.TaskModel::TABLE.'.is_active AS INTEGER)) AS nb_active_tasks')
             ->eq(self::TABLE.'.id', $project_id)
             ->join(UserModel::TABLE, 'id', 'owner_id')
             ->join(TaskModel::TABLE, 'project_id', 'id')

--- a/app/Model/ProjectModel.php
+++ b/app/Model/ProjectModel.php
@@ -390,7 +390,7 @@ class ProjectModel extends Base
             $values['identifier'] = strtoupper($values['identifier']);
         }
 
-        $this->helper->model->convertIntegerFields($values, array('priority_default', 'priority_start', 'priority_end'));
+        $this->helper->model->convertIntegerFields($values, array('priority_default', 'priority_start', 'priority_end', 'task_limit'));
 
         if (! $this->db->table(self::TABLE)->save($values)) {
             $this->db->cancelTransaction();

--- a/app/Model/ProjectModel.php
+++ b/app/Model/ProjectModel.php
@@ -80,6 +80,24 @@ class ProjectModel extends Base
     }
 
     /**
+     * Get a project by id with owner name and task count
+     *
+     * @access public
+     * @param  integer   $project_id    Project id
+     * @return array
+     */
+    public function getByIdWithOwnerAndTaskCount($project_id)
+    {
+        return $this->db->table(self::TABLE)
+            ->columns(self::TABLE.'.*', UserModel::TABLE.'.username AS owner_username', UserModel::TABLE.'.name AS owner_name', 'SUM('.TaskModel::TABLE.'.is_active) AS nb_active_tasks')
+            ->eq(self::TABLE.'.id', $project_id)
+            ->join(UserModel::TABLE, 'id', 'owner_id')
+            ->join(TaskModel::TABLE, 'project_id', 'id')
+            ->groupBy(self::TABLE.'.id', UserModel::TABLE.'.username', UserModel::TABLE.'.name')
+            ->findOne();
+    }
+
+    /**
      * Get a project by the name
      *
      * @access public
@@ -459,7 +477,7 @@ class ProjectModel extends Base
 
         $values['per_swimlane_task_limits'] = empty($values['per_swimlane_task_limits']) ? 0 : 1;
 
-        $this->helper->model->convertIntegerFields($values, array('priority_default', 'priority_start', 'priority_end'));
+        $this->helper->model->convertIntegerFields($values, array('priority_default', 'priority_start', 'priority_end', 'task_limit'));
 
         return $this->exists($values['id']) &&
                $this->db->table(self::TABLE)->eq('id', $values['id'])->save($values);
@@ -567,5 +585,20 @@ class ProjectModel extends Base
                     ->table(self::TABLE)
                     ->eq('id', $project_id)
                     ->save(array('is_public' => 0, 'token' => ''));
+    }
+
+    /**
+     * Return the task count for a project
+     *
+     * @access public
+     * @param  integer    $project_id   Project id
+     * @return integer
+     */
+    public function taskCount($project_id)
+    {
+        return $this->db->table(self::TABLE)
+            ->eq('id', $project_id)->exists()
+            ->join(ColumnModel::TABLE, 'id', 'project_id')
+            ->count();
     }
 }

--- a/app/Model/SwimlaneModel.php
+++ b/app/Model/SwimlaneModel.php
@@ -178,7 +178,7 @@ class SwimlaneModel extends Base
         );
 
         $swimlanes = $this->db->table(self::TABLE)
-            ->columns('id', 'name', 'description', 'project_id', 'position', 'is_active')
+            ->columns('id', 'name', 'description', 'project_id', 'position', 'is_active', 'task_limit')
             ->subquery("SELECT COUNT(*) FROM ".TaskModel::TABLE." WHERE swimlane_id=".self::TABLE.".id AND is_active='1'", 'nb_open_tasks')
             ->subquery("SELECT COUNT(*) FROM ".TaskModel::TABLE." WHERE swimlane_id=".self::TABLE.".id AND is_active='0'", 'nb_closed_tasks')
             ->eq('project_id', $project_id)
@@ -231,7 +231,7 @@ class SwimlaneModel extends Base
      * @param  string  $description
      * @return bool|int
      */
-    public function create($projectId, $name, $description = '')
+    public function create($projectId, $name, $description = '', $task_limit = 0)
     {
         if (! $this->projectModel->exists($projectId)) {
             return 0;
@@ -243,6 +243,7 @@ class SwimlaneModel extends Base
             'description' => $description,
             'position'    => $this->getLastPosition($projectId),
             'is_active'   => 1,
+            'task_limit'  => $task_limit,
         ));
     }
 

--- a/app/Schema/Mysql.php
+++ b/app/Schema/Mysql.php
@@ -8,7 +8,12 @@ use PDO;
 use Kanboard\Core\Security\Token;
 use Kanboard\Core\Security\Role;
 
-const VERSION = 135;
+const VERSION = 136;
+
+function version_136(PDO $pdo)
+{
+    $pdo->exec('ALTER TABLE `swimlanes` ADD COLUMN `task_limit` INT DEFAULT 0');
+}
 
 function version_135(PDO $pdo)
 {

--- a/app/Schema/Mysql.php
+++ b/app/Schema/Mysql.php
@@ -8,7 +8,12 @@ use PDO;
 use Kanboard\Core\Security\Token;
 use Kanboard\Core\Security\Role;
 
-const VERSION = 134;
+const VERSION = 135;
+
+function version_135(PDO $pdo)
+{
+    $pdo->exec('ALTER TABLE `projects` ADD COLUMN `task_limit` INT DEFAULT 0');
+}
 
 function version_134(PDO $pdo)
 {

--- a/app/Schema/Postgres.php
+++ b/app/Schema/Postgres.php
@@ -8,7 +8,12 @@ use PDO;
 use Kanboard\Core\Security\Token;
 use Kanboard\Core\Security\Role;
 
-const VERSION = 113;
+const VERSION = 114;
+
+function version_114(PDO $pdo)
+{
+    $pdo->exec('ALTER TABLE "swimlanes" ADD COLUMN task_limit INTEGER DEFAULT 0');
+}
 
 function version_113(PDO $pdo)
 {

--- a/app/Schema/Postgres.php
+++ b/app/Schema/Postgres.php
@@ -8,7 +8,12 @@ use PDO;
 use Kanboard\Core\Security\Token;
 use Kanboard\Core\Security\Role;
 
-const VERSION = 112;
+const VERSION = 113;
+
+function version_113(PDO $pdo)
+{
+    $pdo->exec('ALTER TABLE "projects" ADD COLUMN task_limit INTEGER DEFAULT 0');
+}
 
 function version_112(PDO $pdo)
 {

--- a/app/Schema/Sqlite.php
+++ b/app/Schema/Sqlite.php
@@ -8,7 +8,12 @@ use Kanboard\Core\Security\Token;
 use Kanboard\Core\Security\Role;
 use PDO;
 
-const VERSION = 122;
+const VERSION = 123;
+
+function version_123(PDO $pdo)
+{
+    $pdo->exec('ALTER TABLE swimlanes ADD COLUMN task_limit INTEGER DEFAULT 0');
+}
 
 function version_122(PDO $pdo)
 {

--- a/app/Schema/Sqlite.php
+++ b/app/Schema/Sqlite.php
@@ -8,7 +8,12 @@ use Kanboard\Core\Security\Token;
 use Kanboard\Core\Security\Role;
 use PDO;
 
-const VERSION = 121;
+const VERSION = 122;
+
+function version_122(PDO $pdo)
+{
+    $pdo->exec('ALTER TABLE projects ADD COLUMN task_limit INTEGER DEFAULT 0');
+}
 
 function version_121(PDO $pdo)
 {

--- a/app/Template/board/table_container.php
+++ b/app/Template/board/table_container.php
@@ -1,4 +1,5 @@
-<div id="board-container">
+<div id="board-container"
+     class="<?= ($project['task_limit'] && $project['nb_active_tasks'] > $project['task_limit']) ? 'board-task-list-limit' : '' ?>">
     <?php if (empty($swimlanes) || empty($swimlanes[0]['nb_columns'])): ?>
         <p class="alert alert-error"><?= t('There is no column or swimlane activated in your project!') ?></p>
     <?php else: ?>

--- a/app/Template/board/table_swimlane.php
+++ b/app/Template/board/table_swimlane.php
@@ -15,7 +15,11 @@
         <?php endif ?>
 
         <span title="<?= t('Task count') ?>" class="board-column-header-task-count swimlane-task-count-<?= $swimlane['id'] ?>">
-            (<?= $swimlane['nb_tasks'] ?>)
+            <?php if ($swimlane['task_limit']): ?>
+                (<?= $swimlane['nb_tasks'] ?>/<?= $swimlane['task_limit'] ?>)
+            <?php else: ?>
+                (<?= $swimlane['nb_tasks'] ?>)
+            <?php endif ?>
         </span>
     </th>
 </tr>

--- a/app/Template/board/table_tasks.php
+++ b/app/Template/board/table_tasks.php
@@ -1,5 +1,5 @@
 <!-- task row -->
-<tr class="board-swimlane board-swimlane-tasks-<?= $swimlane['id'] ?>">
+<tr class="board-swimlane board-swimlane-tasks-<?= $swimlane['id'] ?><?= $swimlane['task_limit'] && $swimlane['nb_tasks'] > $swimlane['task_limit'] ? ' board-task-list-limit' : '' ?>">
     <?php foreach ($swimlane['columns'] as $column): ?>
         <td class="
             board-column-<?= $column['id'] ?>

--- a/app/Template/header/title.php
+++ b/app/Template/header/title.php
@@ -7,6 +7,9 @@
             <?= $this->url->link($this->text->e($project['name']), 'BoardViewController', 'show', array('project_id' => $project['id'])) ?>
         <?php else: ?>
             <?= $this->text->e($title) ?>
+            <?php if (! empty($project) && $project['task_limit'] && array_key_exists('nb_active_tasks', $project)): ?>
+              (<span><?= $project['nb_active_tasks'] ?></span> / <span title="<?= t('Task limit') ?>"><?= $this->text->e($project['task_limit']) ?></span>)
+            <?php endif ?>
         <?php endif ?>
     </span>
     <?php if (! empty($description)): ?>

--- a/app/Template/header/title.php
+++ b/app/Template/header/title.php
@@ -8,7 +8,7 @@
         <?php else: ?>
             <?= $this->text->e($title) ?>
             <?php if (! empty($project) && $project['task_limit'] && array_key_exists('nb_active_tasks', $project)): ?>
-              (<span><?= $project['nb_active_tasks'] ?></span> / <span title="<?= t('Task limit') ?>"><?= $this->text->e($project['task_limit']) ?></span>)
+              (<span><?= intval($project['nb_active_tasks']) ?></span> / <span title="<?= t('Task limit') ?>"><?= $this->text->e($project['task_limit']) ?></span>)
             <?php endif ?>
         <?php endif ?>
     </span>

--- a/app/Template/project_creation/create.php
+++ b/app/Template/project_creation/create.php
@@ -14,7 +14,10 @@
         <?= $this->form->text('identifier', $values, $errors, array('autofocus')) ?>
         <p class="form-help"><?= t('The project identifier is optional and must be alphanumeric, example: MYPROJECT.') ?></p>
 
-        <?= $this->form->checkbox('per_swimlane_task_limits', t('Task limits apply to each swimlane individually'), 1, false) ?>
+        <?= $this->form->checkbox('per_swimlane_task_limits', t('Column task limits apply to each swimlane individually'), 1, false) ?>
+
+        <?= $this->form->label(t('Task limit'), 'task_limit') ?>
+        <?= $this->form->number('task_limit', $values, $errors) ?>
 
         <?php if (count($projects_list) > 1): ?>
             <?= $this->form->label(t('Create from another project'), 'src_project_id') ?>

--- a/app/Template/project_edit/show.php
+++ b/app/Template/project_edit/show.php
@@ -28,6 +28,9 @@
         <?= $this->form->textEditor('description', $values, $errors, array('tabindex' => 4)) ?>
 
         <?= $this->form->checkbox('per_swimlane_task_limits', t('Task limits apply to each swimlane individually'), 1, $project['per_swimlane_task_limits'] == 1, '', array('tabindex' => 5)) ?>
+
+        <?= $this->form->label(t('Task limit'), 'task_limit') ?>
+        <?= $this->form->number('task_limit', $values, $errors, array('tabindex' => 6)) ?>
     </fieldset>
 
     <fieldset>
@@ -42,29 +45,29 @@
 
         <div class="form-inline">
             <?= $this->form->label(t('Project owner'), 'owner_id') ?>
-            <?= $this->form->select('owner_id', $owners, $values, $errors, array('tabindex="6"')) ?>
+            <?= $this->form->select('owner_id', $owners, $values, $errors, array('tabindex="7"')) ?>
         </div>
     </fieldset>
 
     <fieldset>
         <legend><?= t('Dates') ?></legend>
 
-        <?= $this->form->date(t('Start date'), 'start_date', $values, $errors, array('tabindex="7"')) ?>
-        <?= $this->form->date(t('End date'), 'end_date', $values, $errors, array('tabindex="8"')) ?>
+        <?= $this->form->date(t('Start date'), 'start_date', $values, $errors, array('tabindex="8"')) ?>
+        <?= $this->form->date(t('End date'), 'end_date', $values, $errors, array('tabindex="9"')) ?>
     </fieldset>
 
     <fieldset>
         <legend><?= t('Priorities') ?></legend>
 
         <?= $this->form->label(t('Default priority'), 'priority_default') ?>
-        <?= $this->form->number('priority_default', $values, $errors, array('tabindex="9"')) ?>
+        <?= $this->form->number('priority_default', $values, $errors, array('tabindex="10"')) ?>
 
         <?= $this->form->label(t('Lowest priority'), 'priority_start') ?>
-        <?= $this->form->number('priority_start', $values, $errors, array('tabindex="10"')) ?>
+        <?= $this->form->number('priority_start', $values, $errors, array('tabindex="11"')) ?>
 
         <?= $this->form->label(t('Highest priority'), 'priority_end') ?>
-        <?= $this->form->number('priority_end', $values, $errors, array('tabindex="11"')) ?>
+        <?= $this->form->number('priority_end', $values, $errors, array('tabindex="12"')) ?>
     </fieldset>
 
-    <?= $this->modal->submitButtons(array('tabindex' => 12)) ?>
+    <?= $this->modal->submitButtons(array('tabindex' => 13)) ?>
 </form>

--- a/app/Template/project_view/show.php
+++ b/app/Template/project_view/show.php
@@ -33,10 +33,12 @@
     <?php endif ?>
 
     <?php if ($project['per_swimlane_task_limits']): ?>
-        <li><?= t('Task limits are applied to each swimlane individually') ?></li>
+        <li><?= t('Column task limits are applied to each swimlane individually') ?></li>
     <?php else: ?>
-        <li><?= t('Task limits are applied across swimlanes') ?></li>
+        <li><?= t('Column task limits are applied across swimlanes') ?></li>
     <?php endif ?>
+
+    <li><?= t('Task limit: ') ?><?= $project['task_limit'] ? $project['task_limit'] : '∞' ?></li>
 </ul>
 
 <?php if (! empty($project['description'])): ?>

--- a/app/Template/swimlane/create.php
+++ b/app/Template/swimlane/create.php
@@ -10,5 +10,8 @@
     <?= $this->form->label(t('Description'), 'description') ?>
     <?= $this->form->textEditor('description', $values, $errors, array('tabindex' => 2)) ?>
 
+    <?= $this->form->label(t('Task limit'), 'task_limit') ?>
+    <?= $this->form->number('task_limit', $values, $errors, array('tabindex' => 3)) ?>
+
     <?= $this->modal->submitButtons() ?>
 </form>

--- a/app/Template/swimlane/edit.php
+++ b/app/Template/swimlane/edit.php
@@ -11,5 +11,8 @@
     <?= $this->form->label(t('Description'), 'description') ?>
     <?= $this->form->textEditor('description', $values, $errors, array('tabindex' => 2)) ?>
 
+    <?= $this->form->label(t('Task limit'), 'task_limit') ?>
+    <?= $this->form->number('task_limit', $values, $errors, array('tabindex' => 3)) ?>
+
     <?= $this->modal->submitButtons() ?>
 </form>

--- a/app/Template/swimlane/table.php
+++ b/app/Template/swimlane/table.php
@@ -4,6 +4,7 @@
     <thead>
         <tr>
             <th><?= t('Name') ?></th>
+            <th class="column-15"><?= t('Task limit') ?></th>
             <th class="column-15"><?= t('Open tasks') ?></th>
             <th class="column-15"><?= t('Closed tasks') ?></th>
         </tr>
@@ -42,6 +43,9 @@
                 <?php if (! empty($swimlane['description'])): ?>
                     <?= $this->app->tooltipMarkdown($swimlane['description']) ?>
                 <?php endif ?>
+            </td>
+            <td>
+                <?= $swimlane['task_limit'] > 0 ? $swimlane['task_limit'] : '∞' ?>
             </td>
             <td>
                 <?= $swimlane['nb_open_tasks'] ?>

--- a/tests/units/Model/ProjectModelTest.php
+++ b/tests/units/Model/ProjectModelTest.php
@@ -479,24 +479,29 @@ class ProjectModelTest extends Base
     {
         $projectModel = new ProjectModel($this->container);
         $userModel = new UserModel($this->container);
+        $taskCreationModel = new TaskCreationModel($this->container);
 
         $this->assertEquals(2, $userModel->create(array('username' => 'user1', 'name' => 'Me')));
         $this->assertEquals(1, $projectModel->create(array('name' => 'My project 1'), 2));
         $this->assertEquals(2, $projectModel->create(array('name' => 'My project 2')));
+        $this->assertEquals(1, $taskCreationModel->create(array('title' => 'Task #1', 'project_id' => 1)));
+        $this->assertEquals(2, $taskCreationModel->create(array('title' => 'Task #2', 'project_id' => 1)));
 
-        $project = $projectModel->getByIdWithOwner(1);
+        $project = $projectModel->getByIdWithOwnerAndTaskCount(1);
         $this->assertNotEmpty($project);
         $this->assertSame('My project 1', $project['name']);
         $this->assertSame('Me', $project['owner_name']);
         $this->assertSame('user1', $project['owner_username']);
         $this->assertEquals(2, $project['owner_id']);
+        $this->assertEquals(2, $project['nb_active_tasks']);
 
-        $project = $projectModel->getByIdWithOwner(2);
+        $project = $projectModel->getByIdWithOwnerAndTaskCount(2);
         $this->assertNotEmpty($project);
         $this->assertSame('My project 2', $project['name']);
         $this->assertEquals('', $project['owner_name']);
         $this->assertEquals('', $project['owner_username']);
         $this->assertEquals(0, $project['owner_id']);
+        $this->assertEquals(0, $project['nb_active_tasks']);
     }
 
     public function testGetList()

--- a/tests/units/Model/ProjectModelTest.php
+++ b/tests/units/Model/ProjectModelTest.php
@@ -44,6 +44,7 @@ class ProjectModelTest extends Base
         $this->assertEquals(0, $project['is_public']);
         $this->assertEquals(0, $project['is_private']);
         $this->assertEquals(0, $project['per_swimlane_task_limits']);
+        $this->assertEquals(0, $project['task_limit']);
         $this->assertEquals(time(), $project['last_modified'], '', 1);
         $this->assertEmpty($project['token']);
         $this->assertEmpty($project['start_date']);
@@ -63,6 +64,17 @@ class ProjectModelTest extends Base
         $this->assertEquals(2, $projectModel->create(array('name' => 'UnitTest'), 0));
         $project = $projectModel->getById(2);
         $this->assertEquals(0, $project['owner_id']);
+    }
+
+    public function testCreationWithTaskLimit()
+    {
+        $projectModel = new ProjectModel($this->container);
+
+        $this->assertEquals(1, $projectModel->create(array('name' => 'UnitTest', 'task_limit' => 3)));
+
+        $project = $projectModel->getById(1);
+        $this->assertNotEmpty($project);
+        $this->assertEquals(3, $project['task_limit']);
     }
 
     public function testProjectDate()
@@ -213,6 +225,20 @@ class ProjectModelTest extends Base
 
         $project = $projectModel->getById(1);
         $this->assertEquals(1, $project['per_swimlane_task_limits']);
+    }
+
+    public function testUpdateTaskLimit()
+    {
+        $projectModel = new ProjectModel($this->container);
+        $this->assertEquals(1, $projectModel->create(array('name' => 'UnitTest')));
+
+        $project = $projectModel->getById(1);
+        $this->assertEquals(0, $project['task_limit']);
+
+        $this->assertTrue($projectModel->update(array('id'=> 1, 'task_limit' => 1)));
+
+        $project = $projectModel->getById(1);
+        $this->assertEquals(1, $project['task_limit']);
     }
 
     public function testGetAllIds()

--- a/tests/units/Model/ProjectModelTest.php
+++ b/tests/units/Model/ProjectModelTest.php
@@ -174,6 +174,14 @@ class ProjectModelTest extends Base
         $this->assertEmpty($categories);
     }
 
+    public function testCreationWithBlankTaskLimit()
+    {
+        $projectModel = new ProjectModel($this->container);
+        $this->assertEquals(1, $projectModel->create(array('name' => 'UnitTest1', 'task_limit' => '')));
+        $project = $projectModel->getById(1);
+        $this->assertEquals(0, $project['task_limit']);
+    }
+
     public function testUpdateLastModifiedDate()
     {
         $projectModel = new ProjectModel($this->container);

--- a/tests/units/Model/SwimlaneModelTest.php
+++ b/tests/units/Model/SwimlaneModelTest.php
@@ -14,13 +14,15 @@ class SwimlaneModelTest extends Base
         $swimlaneModel = new SwimlaneModel($this->container);
 
         $this->assertEquals(1, $projectModel->create(array('name' => 'UnitTest')));
-        $this->assertEquals(2, $swimlaneModel->create(1, 'Swimlane #1'));
+        $this->assertEquals(2, $swimlaneModel->create(1, 'Swimlane #1', '', 1));
 
         $swimlanes = $swimlaneModel->getAll(1);
         $this->assertNotEmpty($swimlanes);
         $this->assertEquals(2, count($swimlanes));
         $this->assertEquals('Default swimlane', $swimlanes[0]['name']);
         $this->assertEquals('Swimlane #1', $swimlanes[1]['name']);
+        $this->assertEquals(0, $swimlanes[0]['task_limit']);
+        $this->assertEquals(1, $swimlanes[1]['task_limit']);
 
         $this->assertEquals(2, $swimlaneModel->getIdByName(1, 'Swimlane #1'));
         $this->assertEquals(0, $swimlaneModel->getIdByName(2, 'Swimlane #2'));
@@ -85,10 +87,11 @@ class SwimlaneModelTest extends Base
         $this->assertEquals(1, $projectModel->create(array('name' => 'UnitTest')));
         $this->assertEquals(2, $swimlaneModel->create(1, 'Swimlane #1'));
 
-        $this->assertTrue($swimlaneModel->update(2, array('name' => 'foobar')));
+        $this->assertTrue($swimlaneModel->update(2, array('name' => 'foobar', 'task_limit' => 1)));
 
         $swimlane = $swimlaneModel->getById(2);
         $this->assertEquals('foobar', $swimlane['name']);
+        $this->assertEquals(1, $swimlane['task_limit']);
     }
 
     public function testDisableEnable()


### PR DESCRIPTION
This PR allows projects and swimlanes to be configured with task limits that apply to their whole scope (i.e. all active tasks in a project or swimlane, respectively), as opposed to the usual per-column task limits.