### PR TITLE
Show group membership(s) in user-summary and user-list

### DIFF
--- a/app/Helper/UserHelper.php
+++ b/app/Helper/UserHelper.php
@@ -110,7 +110,7 @@ class UserHelper extends Base
     }
 
     /**
-     * Get group names(as a comma-separted list) for a given user
+     * Get group names(as a comma-separated list) for a given user
      *
      * @access public
      * @param  integer   $user_id   User id

--- a/app/Helper/UserHelper.php
+++ b/app/Helper/UserHelper.php
@@ -110,6 +110,18 @@ class UserHelper extends Base
     }
 
     /**
+     * Get group names(as a comma-separted list) for a given user
+     *
+     * @access public
+     * @param  integer   $user_id   User id
+     * @return string
+     */
+    public function getGroupNames($user_id)
+    {
+        return implode(', ', array_column($this->groupMemberModel->getGroups($user_id), 'name'));
+    }
+
+    /**
      * Check application access
      *
      * @param  string  $controller

--- a/app/Locale/bs_BA/translations.php
+++ b/app/Locale/bs_BA/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Ukloni grupu',
     'Group removed successfully.' => 'Grupa uspješno uklonjena.',
     'Unable to remove this group.' => 'Nemoguće ukloniti grupu.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Prava na projektu',
     'Manager' => 'Menadžer',
     'Project Manager' => 'Menadžer projekta',

--- a/app/Locale/ca_ES/translations.php
+++ b/app/Locale/ca_ES/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Elimina el grup',
     'Group removed successfully.' => 'Grup eliminat correctament.',
     'Unable to remove this group.' => 'No es pot eliminar aquest grup.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Permisos de projectes',
     'Manager' => 'Gerent',
     'Project Manager' => 'Gerent de projectes',

--- a/app/Locale/cs_CZ/translations.php
+++ b/app/Locale/cs_CZ/translations.php
@@ -838,6 +838,7 @@ return array(
     // 'Remove group' => '',
     // 'Group removed successfully.' => '',
     // 'Unable to remove this group.' => '',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Oprávnění projektu',
     'Manager' => 'Správce',
     'Project Manager' => 'Správce projektu',

--- a/app/Locale/da_DK/translations.php
+++ b/app/Locale/da_DK/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Fjerne gruppe',
     'Group removed successfully.' => 'Gruppe fjernet.',
     'Unable to remove this group.' => 'Kan ikke fjerne gruppe.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Projekt tilladelser',
     'Manager' => 'Leder',
     'Project Manager' => 'Projektleder',

--- a/app/Locale/de_DE/translations.php
+++ b/app/Locale/de_DE/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Gruppe löschen',
     'Group removed successfully.' => 'Gruppe erfolgreich gelöscht.',
     'Unable to remove this group.' => 'Gruppe konnte nicht gelöscht werden.',
+    'Group membership(s):' => 'Gruppen-Mitgliedschaft(en):',
     'Project Permissions' => 'Projekt Berechtigungen',
     'Manager' => 'Manager',
     'Project Manager' => 'Projekt Manager',

--- a/app/Locale/el_GR/translations.php
+++ b/app/Locale/el_GR/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Αφαίρεση ομάδας',
     'Group removed successfully.' => 'Η ομάδα αφαιρέθηκε με επιτυχία.',
     'Unable to remove this group.' => 'Δεν είναι δυνατή η αφαίρεση της ομάδας.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Επιτρέψεις έργου',
     'Manager' => 'Διευθυντής',
     'Project Manager' => 'Διευθυντής έργου',

--- a/app/Locale/es_ES/translations.php
+++ b/app/Locale/es_ES/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Eliminar grupo',
     'Group removed successfully.' => 'Grupo eliminado correctamente.',
     'Unable to remove this group.' => 'No se pudo eliminar este grupo.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Permisos del proyecto',
     'Manager' => 'Gerente',
     'Project Manager' => 'Gerente de proyecto',

--- a/app/Locale/es_VE/translations.php
+++ b/app/Locale/es_VE/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Eliminar grupo',
     'Group removed successfully.' => 'Grupo eliminado correctamente.',
     'Unable to remove this group.' => 'No se pudo eliminar este grupo.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Permisos del proyecto',
     'Manager' => 'Gerente',
     'Project Manager' => 'Gerente de proyecto',

--- a/app/Locale/fa_IR/translations.php
+++ b/app/Locale/fa_IR/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'حذف گروه',
     'Group removed successfully.' => 'گروه با موفقیت حذف شد.',
     'Unable to remove this group.' => 'حذف این گروه امکان پذیر نیست.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'مجوز های پروژه',
     'Manager' => 'مدیر',
     'Project Manager' => 'مدیر پروژه',

--- a/app/Locale/fi_FI/translations.php
+++ b/app/Locale/fi_FI/translations.php
@@ -838,6 +838,7 @@ return array(
     // 'Remove group' => '',
     // 'Group removed successfully.' => '',
     // 'Unable to remove this group.' => '',
+    // 'Group membership(s):' => ':',
     // 'Project Permissions' => '',
     // 'Manager' => '',
     // 'Project Manager' => '',

--- a/app/Locale/fr_FR/translations.php
+++ b/app/Locale/fr_FR/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Supprimer le groupe',
     'Group removed successfully.' => 'Groupe supprimé avec succès.',
     'Unable to remove this group.' => 'Impossible de supprimer ce groupe.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Permissions du projet',
     'Manager' => 'Gestionnaire',
     'Project Manager' => 'Chef de projet',

--- a/app/Locale/hr_HR/translations.php
+++ b/app/Locale/hr_HR/translations.php
@@ -838,6 +838,7 @@ return array(
     // 'Remove group' => '',
     // 'Group removed successfully.' => '',
     // 'Unable to remove this group.' => '',
+    // 'Group membership(s):' => ':',
     // 'Project Permissions' => '',
     // 'Manager' => '',
     // 'Project Manager' => '',

--- a/app/Locale/hu_HU/translations.php
+++ b/app/Locale/hu_HU/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Csoport eltávolítása',
     'Group removed successfully.' => 'A csoport sikeresen eltávolítva.',
     'Unable to remove this group.' => 'Nem lehet eltávolítani a csoportot.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Projektjogosultságok',
     'Manager' => 'Vezető',
     'Project Manager' => 'Projektvezető',

--- a/app/Locale/id_ID/translations.php
+++ b/app/Locale/id_ID/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Hapus grup',
     'Group removed successfully.' => 'Grup berhasil dihapus',
     'Unable to remove this group.' => 'Tidak dapat menghapus grup ini',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Izin Proyek',
     'Manager' => 'Manajer',
     'Project Manager' => 'Manajer Proyek',

--- a/app/Locale/it_IT/translations.php
+++ b/app/Locale/it_IT/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Rimuovi gruppo',
     'Group removed successfully.' => 'Gruppo rimosso con successo.',
     'Unable to remove this group.' => 'Impossibile rimuovere questo gruppo.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Permessi del progetto',
     'Manager' => 'Manager',
     'Project Manager' => 'Manager del progetto',

--- a/app/Locale/ja_JP/translations.php
+++ b/app/Locale/ja_JP/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'グループを削除',
     'Group removed successfully.' => 'グループは正常に削除されました',
     'Unable to remove this group.' => 'このグループを削除できません',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'プロジェクトの権限',
     'Manager' => '組織の管理者',
     'Project Manager' => 'プロジェクト管理者',

--- a/app/Locale/ko_KR/translations.php
+++ b/app/Locale/ko_KR/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => '그룹 삭제',
     'Group removed successfully.' => '그룹이 성공적으로 삭제되었습니다',
     'Unable to remove this group.' => '그룹 삭제 비활성화',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => '프로젝트 권한',
     'Manager' => '매니저',
     'Project Manager' => '프로젝트 매니저',

--- a/app/Locale/my_MY/translations.php
+++ b/app/Locale/my_MY/translations.php
@@ -838,6 +838,7 @@ return array(
     // 'Remove group' => '',
     // 'Group removed successfully.' => '',
     // 'Unable to remove this group.' => '',
+    // 'Group membership(s):' => ':',
     // 'Project Permissions' => '',
     // 'Manager' => '',
     // 'Project Manager' => '',

--- a/app/Locale/nb_NO/translations.php
+++ b/app/Locale/nb_NO/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Fjern gruppe',
     'Group removed successfully.' => 'Gruppen er fjernet',
     'Unable to remove this group.' => 'Kunne ikke fjerne gruppen',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Prosjektrettigheter',
     'Manager' => 'Leder',
     'Project Manager' => 'Prosjektleder',

--- a/app/Locale/nl_NL/translations.php
+++ b/app/Locale/nl_NL/translations.php
@@ -838,6 +838,7 @@ return array(
     // 'Remove group' => '',
     // 'Group removed successfully.' => '',
     // 'Unable to remove this group.' => '',
+    // 'Group membership(s):' => ':',
     // 'Project Permissions' => '',
     // 'Manager' => '',
     // 'Project Manager' => '',

--- a/app/Locale/pl_PL/translations.php
+++ b/app/Locale/pl_PL/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Usuń grupę',
     'Group removed successfully.' => 'Grupa została usunięta.',
     'Unable to remove this group.' => 'Nie można usunąć grupy.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Prawa dostępowe projektu',
     'Manager' => 'Menedżer',
     'Project Manager' => 'Menedżer projektu',

--- a/app/Locale/pt_BR/translations.php
+++ b/app/Locale/pt_BR/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Remover o grupo',
     'Group removed successfully.' => 'Grupo removido com sucesso.',
     'Unable to remove this group.' => 'Não foi possível remover este grupo.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Permissões do projeto',
     'Manager' => 'Gerente',
     'Project Manager' => 'Gerente de projeto',

--- a/app/Locale/pt_PT/translations.php
+++ b/app/Locale/pt_PT/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Remover grupo.',
     'Group removed successfully.' => 'Grupo removido com sucesso.',
     'Unable to remove this group.' => 'Não foi possivel remover este grupo.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Permissões de Projeto',
     'Manager' => 'Gestor',
     'Project Manager' => 'Gestor de Projeto',

--- a/app/Locale/ro_RO/translations.php
+++ b/app/Locale/ro_RO/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Șterge grupul',
     'Group removed successfully.' => 'Grupul a fost șters.',
     'Unable to remove this group.' => 'Nu am putut șterge grupul.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Permisiunile proiectului',
     'Manager' => 'Gestionar',
     'Project Manager' => 'Șef de proiect',

--- a/app/Locale/ru_RU/translations.php
+++ b/app/Locale/ru_RU/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Удалить группу',
     'Group removed successfully.' => 'Группа успешно удалена.',
     'Unable to remove this group.' => 'Невозможно удалить группу.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Разрешения проекта',
     'Manager' => 'Менеджер',
     'Project Manager' => 'Менеджер проекта',

--- a/app/Locale/sk_SK/translations.php
+++ b/app/Locale/sk_SK/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Odstrániť skupinu',
     'Group removed successfully.' => 'Skupina úspešne odstránená.',
     'Unable to remove this group.' => 'Nemožno odstrániť skupinu.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Povolenia projektu',
     'Manager' => 'Správca',
     'Project Manager' => 'Správca projektu',

--- a/app/Locale/sr_Latn_RS/translations.php
+++ b/app/Locale/sr_Latn_RS/translations.php
@@ -838,6 +838,7 @@ return array(
     // 'Remove group' => '',
     // 'Group removed successfully.' => '',
     // 'Unable to remove this group.' => '',
+    // 'Group membership(s):' => ':',
     // 'Project Permissions' => '',
     // 'Manager' => '',
     // 'Project Manager' => '',

--- a/app/Locale/sv_SE/translations.php
+++ b/app/Locale/sv_SE/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Ta bort grupp',
     // 'Group removed successfully.' => '',
     // 'Unable to remove this group.' => '',
+    // 'Group membership(s):' => ':',
     // 'Project Permissions' => '',
     // 'Manager' => '',
     'Project Manager' => 'Projektägare',

--- a/app/Locale/th_TH/translations.php
+++ b/app/Locale/th_TH/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'ลบกลุ่ม',
     'Group removed successfully.' => 'ลบกลุ่มเรียบร้อย',
     'Unable to remove this group.' => 'ไม่สามารถลบกลุ่มนี้',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'การอนุญาตใช้งานโปรเจค',
     'Manager' => 'ผู้จัดการ',
     'Project Manager' => 'ผู้จัดการโปรเจค',

--- a/app/Locale/tr_TR/translations.php
+++ b/app/Locale/tr_TR/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Grubu sil',
     'Group removed successfully.' => 'Grup başarıyla silindi.',
     'Unable to remove this group.' => 'Grup silinemedi.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Proje izimleri',
     'Manager' => 'Müdür',
     'Project Manager' => 'Proje müdürü',

--- a/app/Locale/uk_UA/translations.php
+++ b/app/Locale/uk_UA/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Видалити групу',
     'Group removed successfully.' => 'Групу успішно видалено.',
     'Unable to remove this group.' => 'Не вдалося видалити групу.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Дозволи проєкту',
     'Manager' => 'Керівник',
     'Project Manager' => 'Керівник проєкту',

--- a/app/Locale/vi_VN/translations.php
+++ b/app/Locale/vi_VN/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => 'Loại bỏ nhóm',
     'Group removed successfully.' => 'Nhóm đã xoá thành công.',
     'Unable to remove this group.' => 'Không thể xóa nhóm này.',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => 'Quyền dự án',
     'Manager' => 'Giám đốc',
     'Project Manager' => 'Quản lý dự án',

--- a/app/Locale/zh_CN/translations.php
+++ b/app/Locale/zh_CN/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => '删除用户组',
     'Group removed successfully.' => '用户组已删除',
     'Unable to remove this group.' => '无法删除该用户组',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => '项目权限',
     'Manager' => '管理员',
     'Project Manager' => '项目管理员',

--- a/app/Locale/zh_TW/translations.php
+++ b/app/Locale/zh_TW/translations.php
@@ -838,6 +838,7 @@ return array(
     'Remove group' => '删除群組',
     'Group removed successfully.' => '群組已删除',
     'Unable to remove this group.' => '無法删除群組',
+    // 'Group membership(s):' => ':',
     'Project Permissions' => '專案全線',
     'Manager' => '管理員',
     'Project Manager' => '專案管理員',

--- a/app/Template/user_list/user_details.php
+++ b/app/Template/user_list/user_details.php
@@ -10,4 +10,8 @@
     <?php if (! empty($user['email'])): ?>
         <span><a href="mailto:<?= $this->text->e($user['email']) ?>"><?= $this->text->e($user['email']) ?></a></span>
     <?php endif ?>
+
+    <?php if (! empty($this->user->getGroupNames($user['id'])) ): ?>
+        <span><i class="fa fa-fw fa-group aria-hidden="true"></i> <?= $this->user->getGroupNames($user['id']) ?></span>
+    <?php endif ?>
 </div>

--- a/app/Template/user_view/show.php
+++ b/app/Template/user_view/show.php
@@ -14,6 +14,7 @@
 </div>
 <ul class="panel">
     <li><?= t('Role:') ?> <strong><?= $this->user->getRoleName($user['role']) ?></strong></li>
+    <li><?= t('Group membership(s):') ?> <strong><?= $this->user->getGroupNames($user['id']) ?></strong></li>
     <li><?= t('Account type:') ?> <strong><?= $user['is_ldap_user'] ? t('Remote') : t('Local') ?></strong></li>
     <li><?= $user['twofactor_activated'] == 1 ? t('Two factor authentication enabled') :  t('Two factor authentication disabled') ?></li>
     <li><?= t('Number of failed login:') ?> <strong><?= $user['nb_failed_login'] ?></strong></li>


### PR DESCRIPTION
I missed a quick way to see the group-membership(s) of a given user, so I added this feature.

### Screenshots
**User-summary-page**
_There's a new line beneath the user role-information, that displays all group-memberships for the current user_
![UserInformation](https://user-images.githubusercontent.com/48651533/77829064-cfa76380-711f-11ea-9bc1-b463428d7c1e.png)


**User-list**
_In the userlist, you can see the group-membership(s) of each user. If a user has no group-memberships, no additional info is displayed_
![UserListNoLimit](https://user-images.githubusercontent.com/48651533/77829101-172def80-7120-11ea-9d16-d2abff7f7432.png)

### Information
This is my second attempt at that feature, while [the first version (PR 4446)](https://github.com/kanboard/kanboard/pull/4446) had 2 "issues"
* Displaying group-memberships in user-list was not implemented
* Travis-Checks had gotten stuck somehow
*  Therefore: PR 4446 closed