### PR TITLE
Docker: Forward real hostname instead of "localhost"

### DIFF
--- a/docker/etc/nginx/nginx.conf
+++ b/docker/etc/nginx/nginx.conf
@@ -42,6 +42,7 @@ http {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_index index.php;
             include fastcgi_params;
+            fastcgi_param SERVER_NAME $host;
         }
 
         location ~ /data {


### PR DESCRIPTION
fastcgi_params sets the SERVER_NAME to the servername setting from the nginx.conf. This causes problems with invitation mails. Instead this new line (after the include!) sets SERVER_NAME to the name from the "Host" HTTP header.
