### PR TITLE
save tasklist order in user session

### DIFF
--- a/app/Controller/TaskListController.php
+++ b/app/Controller/TaskListController.php
@@ -35,11 +35,16 @@ class TaskListController extends BaseController
             $formatter = $this->taskListFormatter;
         }
 
+        list($order, $direction) = $this->userSession->getListOrder($project['id']);
+        $direction = $this->request->getStringParam('direction', $direction);
+        $order = $this->request->getStringParam('order', $order);
+        $this->userSession->setListOrder($project['id'], $order, $direction);
+
         $paginator = $this->paginator
             ->setUrl('TaskListController', 'show', array('project_id' => $project['id']))
             ->setMax(30)
-            ->setOrder(TaskModel::TABLE.'.id')
-            ->setDirection('DESC')
+            ->setOrder($order)
+            ->setDirection($direction)
             ->setFormatter($formatter)
             ->setQuery($this->taskLexer
                 ->build($search)

--- a/app/Core/User/UserSession.php
+++ b/app/Core/User/UserSession.php
@@ -240,4 +240,35 @@ class UserSession extends Base
     {
         session_set('filters:'.$projectID, $filters);
     }
+
+    /**
+     * Get project list order from the session
+     *
+     * @access public
+     * @param  integer  $projectID
+     * @return array
+     */
+    public function getListOrder($projectID)
+    {
+        $default = ['tasks.id', 'DESC'];
+
+        if (! session_exists('listOrder:'.$projectID)) {
+            return $default;
+        }        
+
+        return session_get('listOrder:'.$projectID);
+    }
+
+    /**
+     * Save project list order in the session
+     *
+     * @access public
+     * @param  integer  $projectID
+     * @param  string   $listOrder
+     * @param  string   $listDirection
+     */
+    public function setListOrder($projectID, $listOrder, $listDirection)
+    {
+        session_set('listOrder:'.$projectID, [$listOrder, $listDirection]);
+    }
 }

--- a/tests/units/Core/User/UserSessionTest.php
+++ b/tests/units/Core/User/UserSessionTest.php
@@ -97,6 +97,28 @@ class UserSessionTest extends Base
         $this->assertEquals('assignee:bob', $userSession->getFilters(2));
     }
 
+    public function testListOrder()
+    {
+        $userSession = new UserSession($this->container);
+        list($order, $direction) = $userSession->getListOrder(1);
+        $this->assertEquals('tasks.id', $order);
+        $this->assertEquals('DESC', $direction);
+
+        $userSession->setListOrder(1, 'tasks.priority', 'ASC');
+        list($order, $direction) = $userSession->getListOrder(1);
+        $this->assertEquals('tasks.priority', $order);
+        $this->assertEquals('ASC', $direction);
+
+        list($order, $direction) = $userSession->getListOrder(2);
+        $this->assertEquals('tasks.id', $order);
+        $this->assertEquals('DESC', $direction);
+
+        $userSession->setListOrder(2, 'tasks.is_active', 'DESC');
+        list($order, $direction) = $userSession->getListOrder(2);
+        $this->assertEquals('tasks.is_active', $order);
+        $this->assertEquals('DESC', $direction);
+    }
+
     public function testPostAuthentication()
     {
         $userSession = new UserSession($this->container);


### PR DESCRIPTION
Keep the order and direction in task list view (according to search query).