### PR TITLE
Fix for #4443. Color selection on automatic actions

### DIFF
--- a/app/Helper/FormHelper.php
+++ b/app/Helper/FormHelper.php
@@ -72,6 +72,22 @@ class FormHelper extends Base
     }
 
     /**
+     * Display a color select field
+     *
+     * @access public
+     * @param  string $name Field name
+     * @param  array $values Form values
+     * @return string
+     */
+    public function colorSelect($name, array $values)
+    {
+      $colors = $this->colorModel->getList();
+      $html = $this->label(t('Color'), $name);
+      $html .= $this->select($name, $colors, $values, array(), array('tabindex="4"'), 'color-picker');
+      return $html;
+    }
+
+    /**
      * Display a radio field group
      *
      * @access public

--- a/app/Helper/TaskHelper.php
+++ b/app/Helper/TaskHelper.php
@@ -108,9 +108,7 @@ class TaskHelper extends Base
 
     public function renderColorField(array $values)
     {
-        $colors = $this->colorModel->getList();
-        $html = $this->helper->form->label(t('Color'), 'color_id');
-        $html .= $this->helper->form->select('color_id', $colors, $values, array(), array('tabindex="4"'), 'color-picker');
+        $html = $this->helper->form->colorSelect('color_id', $values);
         return $html;
     }
 

--- a/app/Template/action_creation/params.php
+++ b/app/Template/action_creation/params.php
@@ -25,8 +25,7 @@
             <?= $this->form->label($param_desc, $param_name) ?>
             <?= $this->form->select('params['.$param_name.']', $projects_list, $values) ?>
         <?php elseif ($this->text->contains($param_name, 'color_id')): ?>
-            <?= $this->form->label($param_desc, $param_name) ?>
-            <?= $this->form->select('params['.$param_name.']', $colors_list, $values) ?>
+            <?= $this->form->colorSelect('params['.$param_name.']', $values) ?>
         <?php elseif ($this->text->contains($param_name, 'category_id')): ?>
             <?= $this->form->label($param_desc, $param_name) ?>
             <?= $this->form->select('params['.$param_name.']', $categories_list, $values) ?>


### PR DESCRIPTION
Shows improved color selection on automatic actions. Abstracts the color select form field for easier global use.

I left the task function renderColorField because it abstracts naming the field "color_id" for the other calls to it. But I can go and simply update all calls to renderColorField so they call selectColor directly instead if we want to remove that layer of abstraction.

Tested this, making sure that the color selected is what is used during the automatic action.