### PR TITLE
Allow use of the user's DN as the group filter substitution

### DIFF
--- a/app/Core/Ldap/Group.php
+++ b/app/Core/Ldap/Group.php
@@ -56,7 +56,7 @@ class Group
      */
     public function find($query)
     {
-        $this->query->execute($this->getBasDn(), $query, $this->getAttributes());
+        $this->query->execute($this->getBaseDn(), $query, $this->getAttributes());
         $groups = array();
 
         if ($this->query->hasResult()) {
@@ -119,7 +119,7 @@ class Group
      * @access public
      * @return string
      */
-    public function getBasDn()
+    public function getBaseDn()
     {
         if (! LDAP_GROUP_BASE_DN) {
             throw new LogicException('LDAP group base DN empty, check the parameter LDAP_GROUP_BASE_DN');

--- a/app/Core/Ldap/User.php
+++ b/app/Core/Ldap/User.php
@@ -67,7 +67,7 @@ class User
      */
     public function find($query)
     {
-        $this->query->execute($this->getBasDn(), $query, $this->getAttributes());
+        $this->query->execute($this->getBaseDn(), $query, $this->getAttributes());
         $user = null;
 
         if ($this->query->hasResult()) {
@@ -324,7 +324,7 @@ class User
      * @access public
      * @return string
      */
-    public function getBasDn()
+    public function getBaseDn()
     {
         if (! LDAP_USER_BASE_DN) {
             throw new LogicException('LDAP user base DN empty, check the parameter LDAP_USER_BASE_DN');

--- a/app/constants.php
+++ b/app/constants.php
@@ -89,6 +89,7 @@ defined('LDAP_GROUP_PROVIDER') or define('LDAP_GROUP_PROVIDER', strtolower(geten
 defined('LDAP_GROUP_BASE_DN') or define('LDAP_GROUP_BASE_DN', getenv('LDAP_GROUP_BASE_DN') ?: '');
 defined('LDAP_GROUP_FILTER') or define('LDAP_GROUP_FILTER', getenv('LDAP_GROUP_FILTER') ?: '');
 defined('LDAP_GROUP_USER_FILTER') or define('LDAP_GROUP_USER_FILTER', getenv('LDAP_GROUP_USER_FILTER') ?: '');
+defined('LDAP_GROUP_USER_ATTRIBUTE') or define('LDAP_GROUP_USER_ATTRIBUTE', getenv('LDAP_GROUP_USER_ATTRIBUTE') ?: 'username');
 defined('LDAP_GROUP_ATTRIBUTE_NAME') or define('LDAP_GROUP_ATTRIBUTE_NAME', getenv('LDAP_GROUP_ATTRIBUTE_NAME') ?: 'cn');
 
 // Proxy authentication

--- a/config.default.php
+++ b/config.default.php
@@ -184,6 +184,10 @@ define('LDAP_GROUP_FILTER', '');
 // Example for OpenLDAP: (&(objectClass=posixGroup)(memberUid=%s))
 define('LDAP_GROUP_USER_FILTER', '');
 
+// LDAP attribute for the user in the group filter
+// 'username' or 'dn'
+define('LDAP_GROUP_USER_ATTRIBUTE', 'username');
+
 // LDAP attribute for the group name
 define('LDAP_GROUP_ATTRIBUTE_NAME', 'cn');
 

--- a/tests/units/Core/Ldap/LdapGroupTest.php
+++ b/tests/units/Core/Ldap/LdapGroupTest.php
@@ -37,7 +37,7 @@ class LdapGroupTest extends Base
             ->setConstructorArgs(array($this->query))
             ->setMethods(array(
                 'getAttributeName',
-                'getBasDn',
+                'getBaseDn',
             ))
             ->getMock();
     }
@@ -96,7 +96,7 @@ class LdapGroupTest extends Base
 
         $this->group
             ->expects($this->any())
-            ->method('getBasDn')
+            ->method('getBaseDn')
             ->will($this->returnValue('CN=Users,DC=kanboard,DC=local'));
 
         $groups = $this->group->find('(&(objectClass=group)(sAMAccountName=Kanboard*))');
@@ -142,7 +142,7 @@ class LdapGroupTest extends Base
 
         $this->group
             ->expects($this->any())
-            ->method('getBasDn')
+            ->method('getBaseDn')
             ->will($this->returnValue('CN=Users,DC=kanboard,DC=local'));
 
         $groups = $this->group->find('(&(objectClass=group)(sAMAccountName=Kanboard*))');
@@ -154,6 +154,6 @@ class LdapGroupTest extends Base
         $this->expectException('\LogicException');
 
         $group = new Group($this->query);
-        $group->getBasDn();
+        $group->getBaseDn();
     }
 }

--- a/tests/units/Core/Ldap/LdapUserTest.php
+++ b/tests/units/Core/Ldap/LdapUserTest.php
@@ -56,7 +56,7 @@ class LdapUserTest extends Base
                 'getGroupUserFilter',
                 'getGroupAdminDn',
                 'getGroupManagerDn',
-                'getBasDn',
+                'getBaseDn',
             ))
             ->getMock();
     }
@@ -127,7 +127,7 @@ class LdapUserTest extends Base
 
         $this->user
             ->expects($this->any())
-            ->method('getBasDn')
+            ->method('getBaseDn')
             ->will($this->returnValue('ou=People,dc=kanboard,dc=local'));
 
         $user = $this->user->find('(uid=my_ldap_user)');
@@ -202,7 +202,7 @@ class LdapUserTest extends Base
 
         $this->user
             ->expects($this->any())
-            ->method('getBasDn')
+            ->method('getBaseDn')
             ->will($this->returnValue('ou=People,dc=kanboard,dc=local'));
 
         $user = $this->user->find('(uid=my_ldap_user)');
@@ -293,7 +293,7 @@ class LdapUserTest extends Base
 
         $this->user
             ->expects($this->any())
-            ->method('getBasDn')
+            ->method('getBaseDn')
             ->will($this->returnValue('ou=People,dc=kanboard,dc=local'));
 
         $user = $this->user->find('(uid=my_ldap_user)');
@@ -396,7 +396,7 @@ class LdapUserTest extends Base
 
         $this->user
             ->expects($this->any())
-            ->method('getBasDn')
+            ->method('getBaseDn')
             ->will($this->returnValue('ou=People,dc=kanboard,dc=local'));
 
         $user = $this->user->find('(uid=my_ldap_user)');
@@ -451,7 +451,7 @@ class LdapUserTest extends Base
 
         $this->user
             ->expects($this->any())
-            ->method('getBasDn')
+            ->method('getBaseDn')
             ->will($this->returnValue('ou=People,dc=kanboard,dc=local'));
 
         $user = $this->user->find('(uid=my_ldap_user)');
@@ -543,7 +543,7 @@ class LdapUserTest extends Base
 
         $this->user
             ->expects($this->any())
-            ->method('getBasDn')
+            ->method('getBaseDn')
             ->will($this->returnValue('OU=Users,DC=kanboard,DC=local'));
 
         $this->group
@@ -649,7 +649,7 @@ class LdapUserTest extends Base
 
         $this->user
             ->expects($this->any())
-            ->method('getBasDn')
+            ->method('getBaseDn')
             ->will($this->returnValue('OU=Users,DC=kanboard,DC=local'));
 
         $this->group
@@ -760,7 +760,7 @@ class LdapUserTest extends Base
 
         $this->user
             ->expects($this->any())
-            ->method('getBasDn')
+            ->method('getBaseDn')
             ->will($this->returnValue('OU=Users,DC=kanboard,DC=local'));
 
         $this->group
@@ -790,7 +790,7 @@ class LdapUserTest extends Base
         $this->expectException('\LogicException');
 
         $user = new User($this->query);
-        $user->getBasDn();
+        $user->getBaseDn();
     }
 
     public function testGetLdapUserPatternNotConfigured()


### PR DESCRIPTION
* create the `LDAP_GROUP_USER_ATTRIBUTE` property, defaulting to `username`  
(other possible value : `dn`)  