### PR TITLE
Update Vagrantfile to Ubuntu 20.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,8 @@
 
 $script = <<SCRIPT
 apt-get update
-apt-get install -y apache2 libapache2-mod-php7.0 php7.0-cli php7.0-mbstring php7.0-sqlite3 php7.0-zip \
-    php7.0-opcache php7.0-json php7.0-mysql php7.0-pgsql php7.0-ldap php7.0-gd php7.0-xml php7.0-curl && \
+apt-get install -y apache2 libapache2-mod-php7.4 php7.4-cli php7.4-mbstring php7.4-sqlite3 php7.4-zip \
+    php7.4-opcache php7.4-json php7.4-mysql php7.4-pgsql php7.4-ldap php7.4-gd php7.4-xml php7.4-curl && \
 apt-get clean && \
 echo "ServerName localhost" >> /etc/apache2/apache2.conf && \
 sed -ri 's/AllowOverride None/AllowOverride All/g' /etc/apache2/apache2.conf && \
@@ -13,20 +13,16 @@ service apache2 restart
 rm -f /var/www/html/index.html
 date > /etc/vagrant_provisioned_at
 
-curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/local/bin --filename=composer
+curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 cd /var/www/html && composer install
-
-wget -q -O phpunit https://phar.phpunit.de/phpunit-5.phar
-chmod +x phpunit
-sudo mv phpunit /usr/local/bin/phpunit
 
 SCRIPT
 
 Vagrant.configure("2") do |config|
-
+  config.vm.boot_timeout = 1200
   config.vm.define "ubuntu" do |m|
-    m.vm.box = "ubuntu/xenial64"
+    m.vm.box = "ubuntu/focal64"
     m.vm.provision "shell", inline: $script
     m.vm.synced_folder ".", "/var/www/html", owner: "www-data", group: "www-data"
     m.vm.network :forwarded_port, guest: 80, host: 8001


### PR DESCRIPTION
Hi,
Kanboard requirements are PHP 7.2, the VagrantFile was based on Ubuntu 16.04 and PHP 7.0, i passed it on Ubuntu 20.04 and PHP 7.4. All tests passed when i run make test-sqlite and when i try http://localhost:8001 it's ok too.
To do that i have to install a vagrant plugin named vagrant-vbguest to install virtualbox guest addition tools : vagrant plugin install vagrant-vbguest and i need to upgrade the boot_timeout to wait until the ssh key generating for vagrant was finished.

Available to discuss.

Julien ANNE
Sorry for my bad english.