### PR TITLE
fixed example for LDAP_USER_ATTRIBUTE_USERNAME

### DIFF
--- a/config.default.php
+++ b/config.default.php
@@ -135,7 +135,7 @@ define('LDAP_USER_BASE_DN', '');
 define('LDAP_USER_FILTER', '');
 
 // LDAP attribute for username
-// Example for ActiveDirectory: 'samaccountname'
+// Example for ActiveDirectory: 'sAMAccountName'
 // Example for OpenLDAP: 'uid'
 define('LDAP_USER_ATTRIBUTE_USERNAME', 'uid');
 


### PR DESCRIPTION
using samaccountname as a value for this configuration key does not work, needed correct capitalization