### PR TITLE
new config parameter SESSION_HANDLER

### DIFF
--- a/app/Core/Session/SessionManager.php
+++ b/app/Core/Session/SessionManager.php
@@ -38,7 +38,9 @@ class SessionManager extends Base
      */
     public function open()
     {
-        session_set_save_handler(new SessionHandler($this->db), true);
+        if (SESSION_HANDLER === 'db') {
+            session_set_save_handler(new SessionHandler($this->db), true);
+        }
 
         $this->configure();
 

--- a/app/constants.php
+++ b/app/constants.php
@@ -142,6 +142,9 @@ defined('BRUTEFORCE_LOCKDOWN_DURATION') or define('BRUTEFORCE_LOCKDOWN_DURATION'
 // See http://php.net/manual/en/session.configuration.php#ini.session.cookie-lifetime
 defined('SESSION_DURATION') or define('SESSION_DURATION', intval(getenv('SESSION_DURATION')) ?: 0);
 
+// Session handler: db or php
+defined('SESSION_HANDLER') or define('SESSION_HANDLER', getenv('SESSION_HANDLER') ?: 'db');
+
 // HTTP Client
 defined('HTTP_TIMEOUT') or define('HTTP_TIMEOUT', intval(getenv('HTTP_TIMEOUT')) ?: 10);
 defined('HTTP_MAX_REDIRECTS') or define('HTTP_MAX_REDIRECTS', intval(getenv('HTTP_MAX_REDIRECTS')) ?: 3);

--- a/config.default.php
+++ b/config.default.php
@@ -240,6 +240,9 @@ define('BRUTEFORCE_LOCKDOWN_DURATION', 15);
 // See http://php.net/manual/en/session.configuration.php#ini.session.cookie-lifetime
 define('SESSION_DURATION', 0);
 
+// Session handler: db or php
+define('SESSION_HANDLER', 'db');
+
 // HTTP client proxy
 define('HTTP_PROXY_HOSTNAME', '');
 define('HTTP_PROXY_PORT', '3128');


### PR DESCRIPTION
I added a setting SESSION_HANDLER that allows to disable database-backed session handling (e.g. set SESSION_HANDLER to "php" or any value that is not "db" for now). The reason for this change is that I like my server to limit writes to the database and instead use php session files in a tmpfs store. With this change, I can navigate kanboard pages without any writes to the database.