### PR TITLE
Add option to configure SMTP HELO name

### DIFF
--- a/app/Core/Mail/Transport/Smtp.php
+++ b/app/Core/Mail/Transport/Smtp.php
@@ -23,6 +23,8 @@ class Smtp extends Mail
         $transport = Swift_SmtpTransport::newInstance(MAIL_SMTP_HOSTNAME, MAIL_SMTP_PORT);
         $transport->setUsername(MAIL_SMTP_USERNAME);
         $transport->setPassword(MAIL_SMTP_PASSWORD);
+	if (!is_null(MAIL_SMTP_HELO_NAME))
+	        $transport->setLocalDomain(MAIL_SMTP_HELO_NAME);
         $transport->setEncryption(MAIL_SMTP_ENCRYPTION);
 
         if (HTTP_VERIFY_SSL_CERTIFICATE === false) {

--- a/app/Core/Mail/Transport/Smtp.php
+++ b/app/Core/Mail/Transport/Smtp.php
@@ -23,8 +23,9 @@ class Smtp extends Mail
         $transport = Swift_SmtpTransport::newInstance(MAIL_SMTP_HOSTNAME, MAIL_SMTP_PORT);
         $transport->setUsername(MAIL_SMTP_USERNAME);
         $transport->setPassword(MAIL_SMTP_PASSWORD);
-	if (!is_null(MAIL_SMTP_HELO_NAME))
-	        $transport->setLocalDomain(MAIL_SMTP_HELO_NAME);
+        if (!is_null(MAIL_SMTP_HELO_NAME)) {
+                $transport->setLocalDomain(MAIL_SMTP_HELO_NAME);
+        }
         $transport->setEncryption(MAIL_SMTP_ENCRYPTION);
 
         if (HTTP_VERIFY_SSL_CERTIFICATE === false) {

--- a/app/constants.php
+++ b/app/constants.php
@@ -109,6 +109,7 @@ defined('MAIL_SMTP_HOSTNAME') or define('MAIL_SMTP_HOSTNAME', getenv('MAIL_SMTP_
 defined('MAIL_SMTP_PORT') or define('MAIL_SMTP_PORT', intval(getenv('MAIL_SMTP_PORT')) ?: 25);
 defined('MAIL_SMTP_USERNAME') or define('MAIL_SMTP_USERNAME', getenv('MAIL_SMTP_USERNAME') ?: '');
 defined('MAIL_SMTP_PASSWORD') or define('MAIL_SMTP_PASSWORD', getenv('MAIL_SMTP_PASSWORD') ?: '');
+defined('MAIL_SMTP_HELO_NAME') or define('MAIL_SMTP_HELO_NAME', getenv('MAIL_SMTP_HELO_NAME') ?: null);
 defined('MAIL_SMTP_ENCRYPTION') or define('MAIL_SMTP_ENCRYPTION', getenv('MAIL_SMTP_ENCRYPTION') ?: null);
 defined('MAIL_SENDMAIL_COMMAND') or define('MAIL_SENDMAIL_COMMAND', getenv('MAIL_SENDMAIL_COMMAND') ?: '/usr/sbin/sendmail -bs');
 

--- a/config.default.php
+++ b/config.default.php
@@ -52,6 +52,7 @@ define('MAIL_SMTP_HOSTNAME', '');
 define('MAIL_SMTP_PORT', 25);
 define('MAIL_SMTP_USERNAME', '');
 define('MAIL_SMTP_PASSWORD', '');
+define('MAIL_SMTP_HELO_NAME', null); // valid: null (default), or FQDN
 define('MAIL_SMTP_ENCRYPTION', null); // Valid values are null (not a string "null"), "ssl" or "tls"
 
 // Sendmail command to use when the transport is "sendmail"


### PR DESCRIPTION
Some SMTP setups check the HELO/EHLO name supplied by the connecting
client. Allow this to be configured explicitly.

(This is needed for the MTA my installation works with...)