### PR TITLE
Add ARIA label for elements with titles

### DIFF
--- a/app/Helper/SubtaskHelper.php
+++ b/app/Helper/SubtaskHelper.php
@@ -121,7 +121,7 @@ class SubtaskHelper extends Base
         $html .= $this->helper->form->select('user_id', $users, $values, $errors, $attributes);
         $html .= '&nbsp;';
         $html .= '<small>';
-        $html .= '<a href="#" class="assign-me" data-target-id="form-user_id" data-current-id="'.$this->userSession->getId().'" title="'.t('Assign to me').'">'.t('Me').'</a>';
+        $html .= '<a href="#" class="assign-me" data-target-id="form-user_id" data-current-id="'.$this->userSession->getId().'" title="'.t('Assign to me').'" aria-label="'.t('Assign to me').'">'.t('Me').'</a>';
         $html .= '</small>';
 
         return $html;

--- a/app/Helper/TaskHelper.php
+++ b/app/Helper/TaskHelper.php
@@ -124,7 +124,7 @@ class TaskHelper extends Base
         $html .= $this->helper->form->select('owner_id', $users, $values, $errors, $attributes);
         $html .= '&nbsp;';
         $html .= '<small>';
-        $html .= '<a href="#" class="assign-me" data-target-id="form-owner_id" data-current-id="'.$this->userSession->getId().'" title="'.t('Assign to me').'">'.t('Me').'</a>';
+        $html .= '<a href="#" class="assign-me" data-target-id="form-owner_id" data-current-id="'.$this->userSession->getId().'" title="'.t('Assign to me').'" aria-label="'.t('Assign to me').'">'.t('Me').'</a>';
         $html .= '</small>';
 
         return $html;

--- a/app/Template/activity/filter_dropdown.php
+++ b/app/Template/activity/filter_dropdown.php
@@ -1,5 +1,5 @@
 <div class="dropdown">
-    <a href="#" class="dropdown-menu dropdown-menu-link-icon" title="<?= t('Default filters') ?>"><i class="fa fa-filter fa-fw"></i><i class="fa fa-caret-down"></i></a>
+    <a href="#" class="dropdown-menu dropdown-menu-link-icon" title="<?= t('Default filters') ?>" aria-label="<?= t('Default filters') ?>"><i class="fa fa-filter fa-fw"></i><i class="fa fa-caret-down"></i></a>
     <ul>
         <li><a href="#" class="filter-helper filter-reset" data-filter="" title="<?= t('Keyboard shortcut: "%s"', 'r') ?>"><?= t('Reset filters') ?></a></li>
         <li><a href="#" class="filter-helper" data-filter="creator:me"><?= t('My activities') ?></a></li>

--- a/app/Template/app/filters_helper.php
+++ b/app/Template/app/filters_helper.php
@@ -1,6 +1,6 @@
 <?= $this->hook->render('template:app:filters-helper:before', isset($project) ? array('project' => $project) : array()) ?>
 <div class="dropdown">
-    <a href="#" class="dropdown-menu dropdown-menu-link-icon" title="<?= t('Default filters') ?>"><i class="fa fa-filter fa-fw"></i><i class="fa fa-caret-down"></i></a>
+    <a href="#" class="dropdown-menu dropdown-menu-link-icon" title="<?= t('Default filters') ?>" aria-label="<?= t('Default filters') ?>"><i class="fa fa-filter fa-fw"></i><i class="fa fa-caret-down"></i></a>
     <ul>
         <li><a href="#" class="filter-helper filter-reset" data-filter="<?= isset($reset) ? $reset : '' ?>" title="<?= t('Keyboard shortcut: "%s"', 'r') ?>"><?= t('Reset filters') ?></a></li>
         <li><a href="#" class="filter-helper" data-filter="status:open assignee:me"><?= t('My tasks') ?></a></li>

--- a/app/Template/project_header/dropdown.php
+++ b/app/Template/project_header/dropdown.php
@@ -1,5 +1,5 @@
 <div class="dropdown">
-    <a href="#" class="dropdown-menu action-menu" title="<?= t('Configure this project') ?>"><i class="fa fa-cog"></i><i class="fa fa-caret-down"></i></a>
+    <a href="#" class="dropdown-menu action-menu" title="<?= t('Configure this project') ?>" aria-label="<?= t('Configure this project') ?>"><i class="fa fa-cog"></i><i class="fa fa-caret-down"></i></a>
     <ul>
         <?php if ($board_view): ?>
         <li>

--- a/app/Template/project_header/search.php
+++ b/app/Template/project_header/search.php
@@ -14,7 +14,7 @@
             <?php if (isset($custom_filters_list) && ! empty($custom_filters_list)): ?>
             <div class="input-addon-item">
                 <div class="dropdown">
-                    <a href="#" class="dropdown-menu dropdown-menu-link-icon" title="<?= t('Custom filters') ?>"><i class="fa fa-bookmark fa-fw"></i><i class="fa fa-caret-down"></i></a>
+                    <a href="#" class="dropdown-menu dropdown-menu-link-icon" title="<?= t('Custom filters') ?>" aria-label="<?= t('Custom filters') ?>"><i class="fa fa-bookmark fa-fw"></i><i class="fa fa-caret-down"></i></a>
                     <ul>
                         <?php foreach ($custom_filters_list as $filter): ?>
                             <li><a href="#" class="filter-helper" data-<?php if ($filter['append']): ?><?= 'append-' ?><?php endif ?>filter='<?= $this->text->e($filter['filter']) ?>'><?= $this->text->e($filter['name']) ?></a></li>
@@ -27,7 +27,7 @@
             <?php if (isset($users_list)): ?>
             <div class="input-addon-item">
                 <div class="dropdown">
-                    <a href="#" class="dropdown-menu dropdown-menu-link-icon" title="<?= t('User filters') ?>"><i class="fa fa-user fa-fw"></i> <i class="fa fa-caret-down"></i></a>
+                    <a href="#" class="dropdown-menu dropdown-menu-link-icon" title="<?= t('User filters') ?>" aria-label="<?= t('Custom filters') ?>"><i class="fa fa-user fa-fw"></i> <i class="fa fa-caret-down"></i></a>
                     <ul>
                         <li><a href="#" class="filter-helper" data-unique-filter="assignee:nobody"><?= t('Not assigned') ?></a></li>
                         <li><a href="#" class="filter-helper" data-unique-filter="assignee:anybody"><?= t('Assigned') ?></a></li>
@@ -42,7 +42,7 @@
             <?php if (isset($categories_list) && ! empty($categories_list)): ?>
             <div class="input-addon-item">
                 <div class="dropdown">
-                    <a href="#" class="dropdown-menu dropdown-menu-link-icon" title="<?= t('Category filters') ?>"><i class="fa fa-folder-open fa-fw"></i><i class="fa fa-caret-down"></i></a>
+                    <a href="#" class="dropdown-menu dropdown-menu-link-icon" title="<?= t('Category filters') ?>" aria-label="<?= t('Category filters') ?>"><i class="fa fa-folder-open fa-fw"></i><i class="fa fa-caret-down"></i></a>
                     <ul>
                         <li><a href="#" class="filter-helper" data-unique-filter="category:none"><?= t('No category') ?></a></li>
                         <?php foreach ($categories_list as $category): ?>


### PR DESCRIPTION
For those elements which have a title attribute add an `aria-label` containing the same text. Resolves #4070.

The `aria-label` has intentionally been omitted in the following circumstances:
- Images with `alt` and `title`, as the alt attribute already serves the same purpose, eg [AvatarFileProvider::render](https://github.com/kanboard/kanboard/blob/master/app/User/Avatar/AvatarFileProvider.php#L24)
- A label or text element already exists, as [`aria-label` overrides any other native labelling mechanism](https://developers.google.com/web/fundamentals/accessibility/semantics-aria/aria-labels-and-relationships#aria-label), eg [URLHelper::link](https://github.com/kanboard/kanboard/blob/master/app/Helper/UrlHelper.php#L98)
- The title can be included inline without any disruption to the front end, further PRs will be created for these :smiley: 