### PR TITLE
Add ARIA label for form inputs without labels

### DIFF
--- a/app/Template/dashboard/overview.php
+++ b/app/Template/dashboard/overview.php
@@ -6,7 +6,7 @@
         <?= $this->form->hidden('action', array('action' => 'index')) ?>
 
         <div class="input-addon">
-            <?= $this->form->text('search', array(), array(), array('placeholder="'.t('Search').'"'), 'input-addon-field') ?>
+            <?= $this->form->text('search', array(), array(), array('placeholder="'.t('Search').'"', 'aria-label="'.t('Search').'"'), 'input-addon-field') ?>
             <div class="input-addon-item">
                 <?= $this->render('app/filters_helper') ?>
             </div>

--- a/app/Template/group/index.php
+++ b/app/Template/group/index.php
@@ -9,7 +9,7 @@
     <form method="get" action="<?= $this->url->dir() ?>" class="search">
         <?= $this->form->hidden('controller', array('controller' => 'GroupListController')) ?>
         <?= $this->form->hidden('action', array('action' => 'index')) ?>
-        <?= $this->form->text('search', $values, array(), array('placeholder="'.t('Search').'"')) ?>
+        <?= $this->form->text('search', $values, array(), array('placeholder="'.t('Search').'"', 'aria-label="'.t('Search').'"')) ?>
     </form>
 </div>
 

--- a/app/Template/project_header/search.php
+++ b/app/Template/project_header/search.php
@@ -6,7 +6,7 @@
         <?= $this->form->hidden('project_id', $filters) ?>
 
         <div class="input-addon">
-            <?= $this->form->text('search', $filters, array(), array('placeholder="'.t('Filter').'"'), 'input-addon-field') ?>
+            <?= $this->form->text('search', $filters, array(), array('placeholder="'.t('Filter').'"', 'aria-label="'.t('Filter').'"'), 'input-addon-field') ?>
             <div class="input-addon-item">
                 <?= $this->render('app/filters_helper', array('reset' => 'status:open', 'project' => $project)) ?>
             </div>

--- a/app/Template/project_list/listing.php
+++ b/app/Template/project_list/listing.php
@@ -26,7 +26,7 @@
     <form method="get" action="<?= $this->url->dir() ?>" class="search">
         <?= $this->form->hidden('controller', array('controller' => 'ProjectListController')) ?>
         <?= $this->form->hidden('action', array('action' => 'show')) ?>
-        <?= $this->form->text('search', $values, array(), array('placeholder="'.t('Search').'"')) ?>
+        <?= $this->form->text('search', $values, array(), array('placeholder="'.t('Search').'"', 'aria-label="'.t('Search').'"')) ?>
     </form>
 </div>
 

--- a/app/Template/project_permission/groups.php
+++ b/app/Template/project_permission/groups.php
@@ -51,7 +51,7 @@
             ),
                 'autocomplete') ?>
 
-            <?= $this->form->select('role', $roles, $values, $errors) ?>
+            <?= $this->form->select('role', $roles, $values, $errors, array('aria-label="'.t('Role').'"')) ?>
 
             <button type="submit" class="btn btn-blue"><?= t('Add') ?></button>
         </form>

--- a/app/Template/project_permission/users.php
+++ b/app/Template/project_permission/users.php
@@ -51,7 +51,7 @@
                 ),
                 'autocomplete') ?>
 
-            <?= $this->form->select('role', $roles, $values, $errors) ?>
+            <?= $this->form->select('role', $roles, $values, $errors, array('aria-label="'.t('Role').'"')) ?>
 
             <button type="submit" class="btn btn-blue"><?= t('Add') ?></button>
         </form>

--- a/app/Template/search/activity.php
+++ b/app/Template/search/activity.php
@@ -12,7 +12,7 @@
         <?= $this->form->hidden('action', $values) ?>
 
         <div class="input-addon">
-            <?= $this->form->text('search', $values, array(), array(empty($values['search']) ? 'autofocus' : '', 'placeholder="'.t('Search').'"'), 'input-addon-field') ?>
+            <?= $this->form->text('search', $values, array(), array(empty($values['search']) ? 'autofocus' : '', 'placeholder="'.t('Search').'"', 'aria-label="'.t('Search').'"'), 'input-addon-field') ?>
             <div class="input-addon-item">
                 <?= $this->render('app/filters_helper') ?>
             </div>

--- a/app/Template/search/index.php
+++ b/app/Template/search/index.php
@@ -12,7 +12,7 @@
         <?= $this->form->hidden('action', $values) ?>
 
         <div class="input-addon">
-            <?= $this->form->text('search', $values, array(), array(empty($values['search']) ? 'autofocus' : '', 'placeholder="'.t('Search').'"'), 'input-addon-field') ?>
+            <?= $this->form->text('search', $values, array(), array(empty($values['search']) ? 'autofocus' : '', 'placeholder="'.t('Search').'"', 'aria-label="'.t('Search').'"'), 'input-addon-field') ?>
             <div class="input-addon-item">
                 <?= $this->render('app/filters_helper') ?>
             </div>

--- a/app/Template/task_creation/duplicate_projects.php
+++ b/app/Template/task_creation/duplicate_projects.php
@@ -17,7 +17,7 @@
             $projects_list,
             $values,
             array(),
-            array('multiple')
+            array('multiple', 'aria-label="'.t('Duplicate to multiple projects').'"')
         ) ?>
 
         <?= $this->modal->submitButtons() ?>

--- a/app/Template/user_list/listing.php
+++ b/app/Template/user_list/listing.php
@@ -21,7 +21,7 @@
     <form method="get" action="<?= $this->url->dir() ?>" class="search">
         <?= $this->form->hidden('controller', array('controller' => 'UserListController')) ?>
         <?= $this->form->hidden('action', array('action' => 'search')) ?>
-        <?= $this->form->text('search', $values, array(), array('placeholder="'.t('Search').'"')) ?>
+        <?= $this->form->text('search', $values, array(), array('placeholder="'.t('Search').'"', 'aria-label="'.t('Search').'"')) ?>
     </form>
 </div>
 


### PR DESCRIPTION
For form inputs that do not have a visual label element, use `aria-label` to provide an accessible string. The ARIA labels make use of existing translation terms therefore these will be available in all languages. Resolves #4070.