### PR TITLE
Add hidden accessible form input labels

### DIFF
--- a/app/Helper/TaskHelper.php
+++ b/app/Helper/TaskHelper.php
@@ -54,6 +54,8 @@ class TaskHelper extends Base
                 'placeholder="'.t('Title').'"'
             )
         );
+
+        return $html;
     }
 
     public function renderDescriptionField(array $values, array $errors)

--- a/app/Helper/TaskHelper.php
+++ b/app/Helper/TaskHelper.php
@@ -42,7 +42,8 @@ class TaskHelper extends Base
 
     public function renderTitleField(array $values, array $errors)
     {
-        return $this->helper->form->text(
+        $html = $this->helper->form->label(t('Title'), 'title', ['class="ui-helper-hidden-accessible"']);
+        $html .= $this->helper->form->text(
             'title',
             $values,
             $errors,

--- a/app/Template/avatar_file/show.php
+++ b/app/Template/avatar_file/show.php
@@ -14,6 +14,7 @@
 
 <h3><?= t('Upload my avatar image') ?></h3>
 <form method="post" enctype="multipart/form-data" action="<?= $this->url->href('AvatarFileController', 'upload', array('user_id' => $user['id']), true) ?>">
+    <?= $this->form->label(t('Avatar'), 'avatar', ['class="ui-helper-hidden-accessible"']) ?>
     <?= $this->form->file('avatar') ?>
 
     <div class="form-actions">


### PR DESCRIPTION
For form inputs that do not have a label element, where possible use the form helper to provide a hidden one which is still accessible to screen readers. The hidden labels make use of existing translation terms therefore these will be available in all languages. Resolves #4070.