### PR TITLE
Hidden accessible titles

### DIFF
--- a/app/Helper/TaskHelper.php
+++ b/app/Helper/TaskHelper.php
@@ -238,7 +238,7 @@ class TaskHelper extends Base
     public function renderPriority($priority)
     {
         $html = '<span class="task-priority" title="'.t('Task priority').'">';
-        $html .= '<span class="ui-helper-hidden-accessible">'.t('Task priority').': </span>';
+        $html .= '<span class="ui-helper-hidden-accessible">'.t('Task priority').' </span>';
         $html .= $this->helper->text->e($priority >= 0 ? 'P'.$priority : '-P'.abs($priority));
         $html .= '</span>';
 

--- a/app/Helper/TaskHelper.php
+++ b/app/Helper/TaskHelper.php
@@ -238,6 +238,7 @@ class TaskHelper extends Base
     public function renderPriority($priority)
     {
         $html = '<span class="task-priority" title="'.t('Task priority').'">';
+        $html .= '<span class="ui-helper-hidden-accessible">'.t('Task priority').': </span>';
         $html .= $this->helper->text->e($priority >= 0 ? 'P'.$priority : '-P'.abs($priority));
         $html .= '</span>';
 

--- a/app/Template/board/table_column.php
+++ b/app/Template/board/table_column.php
@@ -8,8 +8,8 @@
 
         <!-- column in collapsed mode -->
         <div class="board-column-collapsed">
-            <small class="board-column-header-task-count" title="<?= t('Show this column') ?>">
-                <span id="task-number-column-<?= $column['id'] ?>"><?= $column['nb_tasks'] ?></span>
+            <small class="board-column-header-task-count" title="<?= t('Task count') ?>">
+                <span id="task-number-column-<?= $column['id'] ?>"><span class="ui-helper-hidden-accessible"><?= t('Task count') ?>: </span><?= $column['nb_tasks'] ?></span>
             </small>
         </div>
 
@@ -21,7 +21,7 @@
 
             <?php if ($swimlane['nb_swimlanes'] > 1 && $column['nb_tasks'] > 0): ?>
             <span title="<?= t('Task count') ?>">
-                (<span id="task-number-column-<?= $column['id'] ?>"><?= $column['nb_tasks'] ?></span>)
+                (<span id="task-number-column-<?= $column['id'] ?>"><span class="ui-helper-hidden-accessible"><?= t('Task count') ?>: </span><?= $column['nb_tasks'] ?></span>)
             </span>
             <?php endif ?>
 
@@ -84,13 +84,13 @@
             <span class="pull-right">
                 <?php if ($swimlane['nb_swimlanes'] > 1 && ! empty($column['column_score'])): ?>
                     <span title="<?= t('Total score in this column across all swimlanes') ?>">
-                        (<span><?= $column['column_score'] ?></span>)
+                        (<span><span class="ui-helper-hidden-accessible"><?= t('Total score in this column across all swimlanes') ?>: </span><?= $column['column_score'] ?></span>)
                     </span>
                 <?php endif ?>
 
                 <?php if (! empty($column['score'])): ?>
                     <span title="<?= t('Score') ?>">
-                        <?= $column['score'] ?>
+                        <span class="ui-helper-hidden-accessible"><?= t('Score') ?>: </span><?= $column['score'] ?>
                     </span>
                 <?php endif ?>
 
@@ -102,9 +102,9 @@
             <?php if (! empty($column['column_nb_open_tasks'])): ?>
             <span title="<?= t('Total number of tasks in this column across all swimlanes') ?>" class="board-column-header-task-count">
                 <?php if ($column['task_limit'] > 0): ?>
-                    (<span><?= $column['column_nb_open_tasks'] ?></span> / <span title="<?= t('Task limit') ?>"><?= $this->text->e($column['task_limit']) ?></span>)
+                    (<span><span class="ui-helper-hidden-accessible"><?= t('Total number of tasks in this column across all swimlanes') ?>: </span><?= $column['column_nb_open_tasks'] ?></span> / <span title="<?= t('Task limit') ?>"><span class="ui-helper-hidden-accessible"><?= t('Task limit') ?>: </span><?= $this->text->e($column['task_limit']) ?></span>)
                 <?php else: ?>
-                    (<span><?= $column['column_nb_open_tasks'] ?></span>)
+                    (<span><span class="ui-helper-hidden-accessible"><?= t('Total number of tasks in this column across all swimlanes') ?>: </span><?= $column['column_nb_open_tasks'] ?></span>)
                 <?php endif ?>
             </span>
             <?php endif ?>

--- a/app/Template/board/table_column.php
+++ b/app/Template/board/table_column.php
@@ -21,7 +21,7 @@
 
             <?php if ($swimlane['nb_swimlanes'] > 1 && $column['nb_tasks'] > 0): ?>
             <span title="<?= t('Task count') ?>">
-                (<span id="task-number-column-<?= $column['id'] ?>"><span class="ui-helper-hidden-accessible"><?= t('Task count') ?>: </span><?= $column['nb_tasks'] ?></span>)
+                (<span id="task-number-column-<?= $column['id'] ?>"><span class="ui-helper-hidden-accessible"><?= t('Task count') ?> </span><?= $column['nb_tasks'] ?></span>)
             </span>
             <?php endif ?>
 
@@ -84,13 +84,13 @@
             <span class="pull-right">
                 <?php if ($swimlane['nb_swimlanes'] > 1 && ! empty($column['column_score'])): ?>
                     <span title="<?= t('Total score in this column across all swimlanes') ?>">
-                        (<span><span class="ui-helper-hidden-accessible"><?= t('Total score in this column across all swimlanes') ?>: </span><?= $column['column_score'] ?></span>)
+                        (<span><span class="ui-helper-hidden-accessible"><?= t('Total score in this column across all swimlanes') ?> </span><?= $column['column_score'] ?></span>)
                     </span>
                 <?php endif ?>
 
                 <?php if (! empty($column['score'])): ?>
                     <span title="<?= t('Score') ?>">
-                        <span class="ui-helper-hidden-accessible"><?= t('Score') ?>: </span><?= $column['score'] ?>
+                        <span class="ui-helper-hidden-accessible"><?= t('Score') ?> </span><?= $column['score'] ?>
                     </span>
                 <?php endif ?>
 
@@ -102,9 +102,9 @@
             <?php if (! empty($column['column_nb_open_tasks'])): ?>
             <span title="<?= t('Total number of tasks in this column across all swimlanes') ?>" class="board-column-header-task-count">
                 <?php if ($column['task_limit'] > 0): ?>
-                    (<span><span class="ui-helper-hidden-accessible"><?= t('Total number of tasks in this column across all swimlanes') ?>: </span><?= $column['column_nb_open_tasks'] ?></span> / <span title="<?= t('Task limit') ?>"><span class="ui-helper-hidden-accessible"><?= t('Task limit') ?>: </span><?= $this->text->e($column['task_limit']) ?></span>)
+                    (<span><span class="ui-helper-hidden-accessible"><?= t('Total number of tasks in this column across all swimlanes') ?> </span><?= $column['column_nb_open_tasks'] ?></span> / <span title="<?= t('Task limit') ?>"><span class="ui-helper-hidden-accessible"><?= t('Task limit') ?> </span><?= $this->text->e($column['task_limit']) ?></span>)
                 <?php else: ?>
-                    (<span><span class="ui-helper-hidden-accessible"><?= t('Total number of tasks in this column across all swimlanes') ?>: </span><?= $column['column_nb_open_tasks'] ?></span>)
+                    (<span><span class="ui-helper-hidden-accessible"><?= t('Total number of tasks in this column across all swimlanes') ?> </span><?= $column['column_nb_open_tasks'] ?></span>)
                 <?php endif ?>
             </span>
             <?php endif ?>

--- a/app/Template/board/table_column.php
+++ b/app/Template/board/table_column.php
@@ -8,8 +8,8 @@
 
         <!-- column in collapsed mode -->
         <div class="board-column-collapsed">
-            <small class="board-column-header-task-count" title="<?= t('Task count') ?>">
-                <span id="task-number-column-<?= $column['id'] ?>"><span class="ui-helper-hidden-accessible"><?= t('Task count') ?>: </span><?= $column['nb_tasks'] ?></span>
+            <small class="board-column-header-task-count" title="<?= t('Show this column') ?>">
+                <span id="task-number-column-<?= $column['id'] ?>"><?= $column['nb_tasks'] ?></span>
             </small>
         </div>
 

--- a/app/Template/board/table_swimlane.php
+++ b/app/Template/board/table_swimlane.php
@@ -16,9 +16,9 @@
 
         <span title="<?= t('Task count') ?>" class="board-column-header-task-count swimlane-task-count-<?= $swimlane['id'] ?>">
             <?php if ($swimlane['task_limit']): ?>
-                (<span><span class="ui-helper-hidden-accessible"><?= t('Task count') ?>: </span><?= $swimlane['nb_tasks'] ?>/<?= $swimlane['task_limit'] ?>)
+                (<span><span class="ui-helper-hidden-accessible"><?= t('Task count') ?> </span><?= $swimlane['nb_tasks'] ?>/<?= $swimlane['task_limit'] ?>)
             <?php else: ?>
-                (<span><span class="ui-helper-hidden-accessible"><?= t('Task count') ?>: </span><?= $swimlane['nb_tasks'] ?>)
+                (<span><span class="ui-helper-hidden-accessible"><?= t('Task count') ?> </span><?= $swimlane['nb_tasks'] ?>)
             <?php endif ?>
         </span>
     </th>

--- a/app/Template/board/table_swimlane.php
+++ b/app/Template/board/table_swimlane.php
@@ -16,9 +16,9 @@
 
         <span title="<?= t('Task count') ?>" class="board-column-header-task-count swimlane-task-count-<?= $swimlane['id'] ?>">
             <?php if ($swimlane['task_limit']): ?>
-                (<?= $swimlane['nb_tasks'] ?>/<?= $swimlane['task_limit'] ?>)
+                (<span><span class="ui-helper-hidden-accessible"><?= t('Task count') ?>: </span><?= $swimlane['nb_tasks'] ?>/<?= $swimlane['task_limit'] ?>)
             <?php else: ?>
-                (<?= $swimlane['nb_tasks'] ?>)
+                (<span><span class="ui-helper-hidden-accessible"><?= t('Task count') ?>: </span><?= $swimlane['nb_tasks'] ?>)
             <?php endif ?>
         </span>
     </th>

--- a/app/Template/board/task_footer.php
+++ b/app/Template/board/task_footer.php
@@ -35,7 +35,7 @@
     <div class="task-board-icons-row">
         <?php if ($task['reference']): ?>
             <span class="task-board-reference" title="<?= t('Reference') ?>">
-                <?= $this->task->renderReference($task) ?>
+                <span class="ui-helper-hidden-accessible"><?= t('Reference') ?> </span><?= $this->task->renderReference($task) ?>
             </span>
         <?php endif ?>
     </div>
@@ -55,7 +55,7 @@
 
         <?php if (! empty($task['time_estimated']) || ! empty($task['time_spent'])): ?>
             <span class="task-time-estimated" title="<?= t('Time spent and estimated') ?>">
-                <?= $this->text->e($task['time_spent']) ?>/<?= $this->text->e($task['time_estimated']) ?>h
+                <span class="ui-helper-hidden-accessible"><?= t('Time spent and estimated') ?> </span><?= $this->text->e($task['time_spent']) ?>/<?= $this->text->e($task['time_estimated']) ?>h
             </span>
         <?php endif ?>
 
@@ -124,8 +124,8 @@
 
         <?php if ($task['is_active'] == 1): ?>
             <div class="task-icon-age">
-                <span title="<?= t('Task age in days')?>" class="task-icon-age-total"><?= $this->dt->age($task['date_creation']) ?></span>
-                <span title="<?= t('Days in this column')?>" class="task-icon-age-column"><?= $this->dt->age($task['date_moved']) ?></span>
+                <span title="<?= t('Task age in days')?>" class="task-icon-age-total"><span class="ui-helper-hidden-accessible"><?= t('Task age in days') ?> </span><?= $this->dt->age($task['date_creation']) ?></span>
+                <span title="<?= t('Days in this column')?>" class="task-icon-age-column"><span class="ui-helper-hidden-accessible"><?= t('Days in this column') ?> </span><?= $this->dt->age($task['date_moved']) ?></span>
             </div>
         <?php else: ?>
             <span class="task-board-closed"><i class="fa fa-ban fa-fw"></i><?= t('Closed') ?></span>

--- a/app/Template/dashboard/overview.php
+++ b/app/Template/dashboard/overview.php
@@ -43,7 +43,7 @@
                 </div>
                 <div class="table-list-details">
                     <?php foreach ($project['columns'] as $column): ?>
-                        <strong title="<?= t('Task count') ?>"><?= $column['nb_open_tasks'] ?></strong>
+                        <strong title="<?= t('Task count') ?>"><span class="ui-helper-hidden-accessible"><?= t('Task count') ?> </span><?= $column['nb_open_tasks'] ?></strong>
                         <small><?= $this->text->e($column['title']) ?></small>
                     <?php endforeach ?>
                 </div>

--- a/app/Template/header/title.php
+++ b/app/Template/header/title.php
@@ -8,7 +8,7 @@
         <?php else: ?>
             <?= $this->text->e($title) ?>
             <?php if (! empty($project) && $project['task_limit'] && array_key_exists('nb_active_tasks', $project)): ?>
-              (<span><?= intval($project['nb_active_tasks']) ?></span> / <span title="<?= t('Task limit') ?>"><?= $this->text->e($project['task_limit']) ?></span>)
+              (<span><?= intval($project['nb_active_tasks']) ?></span> / <span title="<?= t('Task limit') ?>"><span class="ui-helper-hidden-accessible"><?= t('Task limit') ?> </span><?= $this->text->e($project['task_limit']) ?></span>)
             <?php endif ?>
         <?php endif ?>
     </span>

--- a/app/Template/project_overview/columns.php
+++ b/app/Template/project_overview/columns.php
@@ -1,7 +1,7 @@
 <div class="project-overview-columns">
     <?php foreach ($columns as $column): ?>
         <div class="project-overview-column">
-            <strong title="<?= t('Task count') ?>"><?= $column['nb_open_tasks'] ?></strong>
+            <strong title="<?= t('Task count') ?>"><span class="ui-helper-hidden-accessible"><?= t('Task count') ?> </span><?= $column['nb_open_tasks'] ?></strong>
             <small><?= $this->text->e($column['title']) ?></small>
         </div>
     <?php endforeach ?>

--- a/app/Template/project_user_overview/roles.php
+++ b/app/Template/project_user_overview/roles.php
@@ -20,7 +20,7 @@
             </td>
             <td class="dashboard-project-stats">
                 <?php foreach ($project['columns'] as $column): ?>
-                    <strong title="<?= t('Task count') ?>"><?= $column['nb_open_tasks'] ?></strong>
+                    <strong title="<?= t('Task count') ?>"><span class="ui-helper-hidden-accessible"><?= t('Task count') ?> </span><?= $column['nb_open_tasks'] ?></strong>
                     <span><?= $this->text->e($column['title']) ?></span>
                 <?php endforeach ?>
             </td>

--- a/app/Template/task_external_link/table.php
+++ b/app/Template/task_external_link/table.php
@@ -29,7 +29,7 @@
                 <?= $this->text->e($link['type']) ?>
             </td>
             <td>
-                <a href="<?= $link['url'] ?>" title="<?= $this->text->e($link['url']) ?>" target="_blank"><?= $this->text->e($link['title']) ?></a>
+                <a href="<?= $link['url'] ?>" title="<?= $this->text->e($link['url']) ?>" target="_blank"><?= $this->text->e($link['title']) ?><span class="ui-helper-hidden-accessible"> (<?= $this->text->e($link['url']) ?>)</span></a>
             </td>
             <td>
                 <?= $this->text->e($link['dependency_label']) ?>

--- a/app/Template/task_list/task_icons.php
+++ b/app/Template/task_list/task_icons.php
@@ -87,7 +87,7 @@
         <?= $this->app->tooltipLink('<i class="fa fa-file-text-o"></i>', $this->url->href('BoardTooltipController', 'description', array('task_id' => $task['id'], 'project_id' => $task['project_id']))) ?>
     <?php endif ?>
 
-    <span title="<?= t('Position') ?>">(<span class="ui-helper-hidden-accessible"><?= t('Position') ?>: </span><?= $task['position'] ?>)</span>
+    <span title="<?= t('Position') ?>">(<span class="ui-helper-hidden-accessible"><?= t('Position') ?> </span><?= $task['position'] ?>)</span>
 
     <?php if ($task['is_active'] == 1): ?>
         <div class="task-icon-age">

--- a/app/Template/task_list/task_icons.php
+++ b/app/Template/task_list/task_icons.php
@@ -1,7 +1,7 @@
 <div class="task-list-icons">
     <?php if ($task['reference']): ?>
         <span class="task-board-reference" title="<?= t('Reference') ?>">
-            <?= $this->task->renderReference($task) ?>
+            <span class="ui-helper-hidden-accessible"><?= t('Reference') ?> </span><?= $this->task->renderReference($task) ?>
         </span>
     <?php endif ?>
     <?php if ($task['is_milestone'] == 1): ?>
@@ -19,7 +19,7 @@
 
     <?php if (! empty($task['time_estimated']) || ! empty($task['time_spent'])): ?>
         <span class="task-time-estimated" title="<?= t('Time spent and estimated') ?>">
-            <?= $this->text->e($task['time_spent']) ?>/<?= $this->text->e($task['time_estimated']) ?>h
+            <span class="ui-helper-hidden-accessible"><?= t('Time spent and estimated') ?> </span><?= $this->text->e($task['time_spent']) ?>/<?= $this->text->e($task['time_estimated']) ?>h
         </span>
     <?php endif ?>
 
@@ -87,12 +87,12 @@
         <?= $this->app->tooltipLink('<i class="fa fa-file-text-o"></i>', $this->url->href('BoardTooltipController', 'description', array('task_id' => $task['id'], 'project_id' => $task['project_id']))) ?>
     <?php endif ?>
 
-    <span title="<?= t('Position') ?>">(<?= $task['position'] ?>)</span>
+    <span title="<?= t('Position') ?>">(<span class="ui-helper-hidden-accessible"><?= t('Position') ?>: </span><?= $task['position'] ?>)</span>
 
     <?php if ($task['is_active'] == 1): ?>
         <div class="task-icon-age">
-            <span title="<?= t('Task age in days')?>" class="task-icon-age-total"><?= $this->dt->age($task['date_creation']) ?></span>
-            <span title="<?= t('Days in this column')?>" class="task-icon-age-column"><?= $this->dt->age($task['date_moved']) ?></span>
+            <span title="<?= t('Task age in days')?>" class="task-icon-age-total"><span class="ui-helper-hidden-accessible"><?= t('Task age in days') ?> </span><?= $this->dt->age($task['date_creation']) ?></span>
+            <span title="<?= t('Days in this column')?>" class="task-icon-age-column"><span class="ui-helper-hidden-accessible"><?= t('Days in this column') ?> </span><?= $this->dt->age($task['date_moved']) ?></span>
         </div>
     <?php else: ?>
         <span class="task-board-closed"><i class="fa fa-ban fa-fw"></i><?= t('Closed') ?></span>

--- a/tests/units/Helper/TaskHelperTest.php
+++ b/tests/units/Helper/TaskHelperTest.php
@@ -18,12 +18,12 @@ class TaskHelperTest extends Base
         $helper = new TaskHelper($this->container);
 
         $this->assertEquals(
-            '<span class="task-priority" title="Task priority"><span class="ui-helper-hidden-accessible">Task priority: </span>P2</span>',
+            '<span class="task-priority" title="Task priority"><span class="ui-helper-hidden-accessible">Task priority </span>P2</span>',
             $helper->renderPriority(2)
         );
 
         $this->assertEquals(
-            '<span class="task-priority" title="Task priority"><span class="ui-helper-hidden-accessible">Task priority: </span>-P6</span>',
+            '<span class="task-priority" title="Task priority"><span class="ui-helper-hidden-accessible">Task priority </span>-P6</span>',
             $helper->renderPriority(-6)
         );
     }

--- a/tests/units/Helper/TaskHelperTest.php
+++ b/tests/units/Helper/TaskHelperTest.php
@@ -18,12 +18,12 @@ class TaskHelperTest extends Base
         $helper = new TaskHelper($this->container);
 
         $this->assertEquals(
-            '<span class="task-priority" title="Task priority">P2</span>',
+            '<span class="task-priority" title="Task priority"><span class="ui-helper-hidden-accessible">Task priority: </span>P2</span>',
             $helper->renderPriority(2)
         );
 
         $this->assertEquals(
-            '<span class="task-priority" title="Task priority">-P6</span>',
+            '<span class="task-priority" title="Task priority"><span class="ui-helper-hidden-accessible">Task priority: </span>-P6</span>',
             $helper->renderPriority(-6)
         );
     }


### PR DESCRIPTION
For elements which have a title attribute and don't have a suitable element to which to add a `aria-label`, provide the title text hidden inline but still accessible to screen readers. Resolves #4070.