### PR TITLE
Correct table collapsed column titles

### DIFF
--- a/app/Template/board/table_column.php
+++ b/app/Template/board/table_column.php
@@ -8,8 +8,8 @@
 
         <!-- column in collapsed mode -->
         <div class="board-column-collapsed">
-            <small class="board-column-header-task-count" title="<?= t('Show this column') ?>">
-                <span id="task-number-column-<?= $column['id'] ?>"><?= $column['nb_tasks'] ?></span>
+            <small class="board-column-header-task-count" title="<?= t('Task count') ?>">
+                <span id="task-number-column-<?= $column['id'] ?>"><span class="ui-helper-hidden-accessible"><?= t('Task count') ?>: </span><?= $column['nb_tasks'] ?></span>
             </small>
         </div>
 

--- a/app/Template/board/table_column.php
+++ b/app/Template/board/table_column.php
@@ -9,7 +9,7 @@
         <!-- column in collapsed mode -->
         <div class="board-column-collapsed">
             <small class="board-column-header-task-count" title="<?= t('Task count') ?>">
-                <span id="task-number-column-<?= $column['id'] ?>"><span class="ui-helper-hidden-accessible"><?= t('Task count') ?>: </span><?= $column['nb_tasks'] ?></span>
+                <span id="task-number-column-<?= $column['id'] ?>"><span class="ui-helper-hidden-accessible"><?= t('Task count') ?> </span><?= $column['nb_tasks'] ?></span>
             </small>
         </div>
 

--- a/app/Template/board/table_tasks.php
+++ b/app/Template/board/table_tasks.php
@@ -30,8 +30,8 @@
                 data-swimlane-id="<?= $swimlane['id'] ?>"
                 data-task-limit="<?= $column['task_limit'] ?>">
                 <div class="board-rotation-wrapper">
-                    <div class="board-column-title board-rotation board-toggle-column-view" data-column-id="<?= $column['id'] ?>" title="<?= t('Show this column') ?>">
-                        <i class="fa fa-plus-square" title="<?= $this->text->e($column['title']) ?>" role="button" aria-label="<?= t('Show this column') ?>"></i> <?= $this->text->e($column['title']) ?>
+                    <div class="board-column-title board-rotation board-toggle-column-view" data-column-id="<?= $column['id'] ?>" title="<?= $this->text->e($column['title']) ?>">
+                        <i class="fa fa-plus-square" title="<?= t('Show this column') ?>" role="button" aria-label="<?= t('Show this column') ?>"></i> <?= $this->text->e($column['title']) ?>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Correct the title attributes used when a board column is collapsed, so that it matches with the element's actual purpose. 

Also provide the title text hidden inline so it's accessible to screen readers, resolves #4070

# Screenshots

Element | Before | After
------------ | ------------- | -------------
Column header task count | ![image](https://user-images.githubusercontent.com/13500452/94987100-9979ef00-055b-11eb-930b-de22d0276043.png) | ![image](https://user-images.githubusercontent.com/13500452/94987094-8ff08700-055b-11eb-8026-28b6b8107bac.png)
Column label | ![image](https://user-images.githubusercontent.com/13500452/94987145-df36b780-055b-11eb-95c2-e265344bcc8e.png) | ![image](https://user-images.githubusercontent.com/13500452/94987146-e65dc580-055b-11eb-98a4-86a7bb7f90e4.png)
Expand column button | ![image](https://user-images.githubusercontent.com/13500452/94987161-068d8480-055c-11eb-8e5b-236b718e8d66.png) | ![image](https://user-images.githubusercontent.com/13500452/94987171-0ab9a200-055c-11eb-973e-a19257c673de.png)




