### PR TITLE
Add ARIA label to form text editor without label

### DIFF
--- a/app/Helper/FormHelper.php
+++ b/app/Helper/FormHelper.php
@@ -237,6 +237,7 @@ class FormHelper extends Base
             'labelWrite' => t('Write'),
             'labelTitle' => t('Title'),
             'placeholder' => t('Write your text in Markdown'),
+            'ariaLabel' => isset($attributes['aria-label']) ? $attributes['aria-label'] : '',
             'autofocus' => isset($attributes['autofocus']) && $attributes['autofocus'],
             'suggestOptions' => array(
                 'triggers' => array(

--- a/app/Helper/TaskHelper.php
+++ b/app/Helper/TaskHelper.php
@@ -60,7 +60,7 @@ class TaskHelper extends Base
 
     public function renderDescriptionField(array $values, array $errors)
     {
-        return $this->helper->form->textEditor('description', $values, $errors, array('tabindex' => 2));
+        return $this->helper->form->textEditor('description', $values, $errors, array('tabindex' => 2, 'aria-label' => t('Description')));
     }
 
     public function renderDescriptionTemplateDropdown($projectId)

--- a/app/Template/comment/create.php
+++ b/app/Template/comment/create.php
@@ -9,7 +9,7 @@
 <form method="post" action="<?= $this->url->href('CommentController', 'save', array('task_id' => $task['id'], 'project_id' => $task['project_id'])) ?>" autocomplete="off">
     <?= $this->form->csrf() ?>
 
-    <?= $this->form->textEditor('comment', $values, $errors, array('autofocus' => true, 'required' => true)) ?>
+    <?= $this->form->textEditor('comment', $values, $errors, array('autofocus' => true, 'required' => true, 'aria-label' => t('New comment'))) ?>
 
     <?= $this->modal->submitButtons() ?>
 </form>

--- a/app/Template/comment/edit.php
+++ b/app/Template/comment/edit.php
@@ -5,7 +5,7 @@
 <form method="post" action="<?= $this->url->href('CommentController', 'update', array('task_id' => $task['id'], 'project_id' => $task['project_id'], 'comment_id' => $comment['id'])) ?>" autocomplete="off">
     <?= $this->form->csrf() ?>
 
-    <?= $this->form->textEditor('comment', $values, $errors, array('autofocus' => true, 'required' => true)) ?>
+    <?= $this->form->textEditor('comment', $values, $errors, array('autofocus' => true, 'required' => true, 'aria-label' => t('Comment'))) ?>
 
     <?= $this->modal->submitButtons() ?>
 </form>

--- a/app/Template/comment_list/create.php
+++ b/app/Template/comment_list/create.php
@@ -3,6 +3,6 @@
 </div>
 <form method="post" action="<?= $this->url->href('CommentListController', 'save', array('task_id' => $task['id'], 'project_id' => $task['project_id'])) ?>" autocomplete="off">
     <?= $this->form->csrf() ?>
-    <?= $this->form->textEditor('comment', array('project_id' => $task['project_id']), array(), array('required' => true)) ?>
+    <?= $this->form->textEditor('comment', array('project_id' => $task['project_id']), array(), array('required' => true, 'aria-label' => t('New comment'))) ?>
     <?= $this->modal->submitButtons() ?>
 </form>

--- a/app/Template/comment_mail/create.php
+++ b/app/Template/comment_mail/create.php
@@ -42,7 +42,7 @@
         </div>
     <?php endif ?>
 
-    <?= $this->form->textEditor('comment', $values, $errors, array('required' => true, 'tabindex' => 3)) ?>
+    <?= $this->form->textEditor('comment', $values, $errors, array('required' => true, 'tabindex' => 3, 'aria-label' => t('New comment'))) ?>
 
     <?= $this->modal->submitButtons(array(
         'submitLabel' => t('Send by email'),

--- a/app/Template/task_comments/create.php
+++ b/app/Template/task_comments/create.php
@@ -3,6 +3,6 @@
     <?= $this->form->hidden('task_id', $values) ?>
     <?= $this->form->hidden('user_id', $values) ?>
 
-    <?= $this->form->textEditor('comment', $values, $errors, array('required' => true)) ?>
+    <?= $this->form->textEditor('comment', $values, $errors, array('required' => true, 'aria-label' => t('New comment'))) ?>
     <?= $this->modal->submitButtons() ?>
 </form>

--- a/assets/js/components/text-editor.js
+++ b/assets/js/components/text-editor.js
@@ -62,6 +62,10 @@ KB.component('text-editor', function (containerElement, options) {
             textareaElement.attr('required', 'required');
         }
 
+        if (options.ariaLabel) {
+            textareaElement.attr('arai-label', options.ariaLabel);
+        }
+
         // Order is important for IE11 (especially for the placeholder)
         var textWrapper = KB.dom(containerElement).find('script');
         textareaElement.html(textWrapper.innerHTML);

--- a/assets/js/components/text-editor.js
+++ b/assets/js/components/text-editor.js
@@ -63,7 +63,7 @@ KB.component('text-editor', function (containerElement, options) {
         }
 
         if (options.ariaLabel) {
-            textareaElement.attr('arai-label', options.ariaLabel);
+            textareaElement.attr('aria-label', options.ariaLabel);
         }
 
         // Order is important for IE11 (especially for the placeholder)


### PR DESCRIPTION
For form text editors that do not have a visual label element, use aria-label to provide an accessible string. The ARIA labels make use of existing translation terms therefore these will be available in all languages. Resolves #4070.