### PR TITLE
Add ARIA label to dropdown autocomplete without label

### DIFF
--- a/app/Template/header/board_selector.php
+++ b/app/Template/header/board_selector.php
@@ -1,6 +1,7 @@
 <?= $this->app->component('select-dropdown-autocomplete', array(
     'name' => 'boardId',
     'placeholder' => t('Display another project'),
+    'ariaLabel' => t('Display another project'),
     'items' => $board_selector,
     'redirect' => array(
         'regex' => 'PROJECT_ID',

--- a/app/Template/project_user_overview/sidebar.php
+++ b/app/Template/project_user_overview/sidebar.php
@@ -4,6 +4,7 @@
         'items' => $users,
         'defaultValue' => $filter['user_id'],
         'sortByKeys' => true,
+        'ariaLabel' => t('User filters'),
         'redirect' => array(
             'regex' => 'USER_ID',
             'url' => $this->url->to('ProjectUserOverviewController', $this->app->getRouterAction(), array('user_id' => 'USER_ID')),

--- a/assets/js/components/select-dropdown-autocomplete.js
+++ b/assets/js/components/select-dropdown-autocomplete.js
@@ -235,6 +235,14 @@ KB.component('select-dropdown-autocomplete', function(containerElement, options)
         return '';
     }
 
+    function getAriaLabelValue() {
+        if (options.ariaLabel) {
+            return options.ariaLabel;
+        }
+
+        return '';
+    }
+
     this.render = function () {
         KB.on('select.dropdown.loading.start', onLoadingStart);
         KB.on('select.dropdown.loading.stop', onLoadingStop);
@@ -264,6 +272,7 @@ KB.component('select-dropdown-autocomplete', function(containerElement, options)
         inputElement = KB.dom('input')
             .attr('type', 'text')
             .attr('placeholder', getPlaceholderValue())
+            .attr('aria-label', getAriaLabelValue())
             .addClass('select-dropdown-input')
             .on('focus', toggleDropdownMenu)
             .on('input', onInputChanged, true)


### PR DESCRIPTION
For select dropdown autocomplete components that do not have a visual label element, use aria-label to provide an accessible string. The ARIA labels make use of existing translation terms therefore these will be available in all languages. Resolves #4070.