### PR TITLE
Add ARIA label to project select role without label

### DIFF
--- a/app/Template/project_permission/groups.php
+++ b/app/Template/project_permission/groups.php
@@ -21,6 +21,7 @@
                         'roles' => $roles,
                         'role' => $group['role'],
                         'id' => $group['id'],
+                        'ariaLabel' => t('Role'),
                         'url' => $this->url->to('ProjectPermissionController', 'changeGroupRole', array('project_id' => $project['id'])),
                     )) ?>
                 </td>

--- a/app/Template/project_permission/users.php
+++ b/app/Template/project_permission/users.php
@@ -17,6 +17,7 @@
                         'roles' => $roles,
                         'role' => $user['role'],
                         'id' => $user['id'],
+                        'ariaLabel' => t('Role'),
                         'url' => $this->url->to('ProjectPermissionController', 'changeUserRole', array('project_id' => $project['id'])),
                     )) ?>
                 </td>

--- a/assets/js/components/project-select-role.js
+++ b/assets/js/components/project-select-role.js
@@ -33,6 +33,14 @@ KB.component('project-select-role', function (containerElement, options) {
         containerElement.appendChild(componentElement);
     }
 
+    function getAriaLabelValue() {
+        if (options.ariaLabel) {
+            return options.ariaLabel;
+        }
+
+        return '';
+    }
+
     function buildComponentElement() {
         var roles = [];
         var container = KB.dom('div');
@@ -49,7 +57,7 @@ KB.component('project-select-role', function (containerElement, options) {
             }
         }
 
-        container.add(KB.dom('select').change(onChange).for('option', roles).build());
+        container.add(KB.dom('select').attr('aria-label', getAriaLabelValue()).change(onChange).for('option', roles).build());
 
         if (isLoading) {
             container.text(' ');


### PR DESCRIPTION
For select dropdown autocomplete components that do not have a visual label element, use aria-label to provide an accessible string. The ARIA labels make use of existing translation terms therefore these will be available in all languages. Resolves #4070.