### PR TITLE
Add ARIA label to letter avatars

### DIFF
--- a/app/Formatter/UserMentionFormatter.php
+++ b/app/Formatter/UserMentionFormatter.php
@@ -48,7 +48,7 @@ class UserMentionFormatter extends BaseFormatter implements FormatterInterface
             $html .= ' '.$this->helper->text->e($user['username']);
 
             if (! empty($user['name'])) {
-                $html .= ' <small>'.$this->helper->text->e($user['name']).'</small>';
+                $html .= ' <small aria-hidden="true">'.$this->helper->text->e($user['name']).'</small>';
             }
 
             $result[] = array(

--- a/app/User/Avatar/LetterAvatarProvider.php
+++ b/app/User/Avatar/LetterAvatarProvider.php
@@ -32,13 +32,15 @@ class LetterAvatarProvider extends Base implements AvatarProviderInterface
     {
         $initials = $this->helper->user->getInitials($user['name'] ?: $user['username']);
         $rgb = $this->getBackgroundColor($user['name'] ?: $user['username']);
+        $name = $this->helper->text->e($user['name'] ?: $user['username']);
 
         return sprintf(
-            '<div class="avatar-letter" style="background-color: rgb(%d, %d, %d)" title="%s">%s</div>',
+            '<div class="avatar-letter" style="background-color: rgb(%d, %d, %d)" title="%s" role="img" aria-label="%s">%s</div>',
             $rgb[0],
             $rgb[1],
             $rgb[2],
-            $this->helper->text->e($user['name'] ?: $user['username']),
+            $name,
+            $name,
             $this->helper->text->e($initials)
         );
     }

--- a/tests/units/Formatter/UserMentionFormatterTest.php
+++ b/tests/units/Formatter/UserMentionFormatterTest.php
@@ -33,7 +33,7 @@ class UserMentionFormatterTest extends Base
             ),
             array(
                 'value' => 'somebody',
-                'html' => '<div class="avatar avatar-20 avatar-inline"><div class="avatar-letter" style="background-color: rgb(191, 210, 121)" title="somebody">S</div></div> somebody',
+                'html' => '<div class="avatar avatar-20 avatar-inline"><div class="avatar-letter" style="background-color: rgb(191, 210, 121)" title="somebody" role="img" aria-label="somebody">S</div></div> somebody',
             ),
         );
 

--- a/tests/units/Formatter/UserMentionFormatterTest.php
+++ b/tests/units/Formatter/UserMentionFormatterTest.php
@@ -29,7 +29,7 @@ class UserMentionFormatterTest extends Base
         $expected = array(
             array(
                 'value' => 'someone',
-                'html' => '<div class="avatar avatar-20 avatar-inline"><img src="?controller=AvatarFileController&amp;action=image&amp;user_id=1&amp;hash=5acc03af0274414544b9615fb223d925&amp;size=20" alt="Someone" title="Someone"></div> someone <small>Someone</small>',
+                'html' => '<div class="avatar avatar-20 avatar-inline"><img src="?controller=AvatarFileController&amp;action=image&amp;user_id=1&amp;hash=5acc03af0274414544b9615fb223d925&amp;size=20" alt="Someone" title="Someone"></div> someone <small aria-hidden="true">Someone</small>',
             ),
             array(
                 'value' => 'somebody',

--- a/tests/units/User/Avatar/LetterAvatarProviderTest.php
+++ b/tests/units/User/Avatar/LetterAvatarProviderTest.php
@@ -23,7 +23,7 @@ class LetterAvatarProviderTest extends Base
     {
         $provider = new LetterAvatarProvider($this->container);
         $user = array('id' => 123, 'name' => 'Kanboard Admin', 'username' => 'bob', 'email' => '');
-        $expected = '<div class="avatar-letter" style="background-color: rgb(120, 83, 58)" title="Kanboard Admin">KA</div>';
+        $expected = '<div class="avatar-letter" style="background-color: rgb(120, 83, 58)" title="Kanboard Admin" role="img" aria-label="Kanboard Admin">KA</div>';
         $this->assertEquals($expected, $provider->render($user, 48));
     }
 
@@ -31,7 +31,7 @@ class LetterAvatarProviderTest extends Base
     {
         $provider = new LetterAvatarProvider($this->container);
         $user = array('id' => 123, 'name' => '', 'username' => 'admin', 'email' => '');
-        $expected = '<div class="avatar-letter" style="background-color: rgb(134, 45, 132)" title="admin">A</div>';
+        $expected = '<div class="avatar-letter" style="background-color: rgb(134, 45, 132)" title="admin" role="img" aria-label="admin">A</div>';
         $this->assertEquals($expected, $provider->render($user, 48));
     }
 
@@ -39,7 +39,7 @@ class LetterAvatarProviderTest extends Base
     {
         $provider = new LetterAvatarProvider($this->container);
         $user = array('id' => 123, 'name' => 'ü', 'username' => 'admin', 'email' => '');
-        $expected = '<div class="avatar-letter" style="background-color: rgb(62, 147, 31)" title="ü">Ü</div>';
+        $expected = '<div class="avatar-letter" style="background-color: rgb(62, 147, 31)" title="ü" role="img" aria-label="ü">Ü</div>';
         $this->assertEquals($expected, $provider->render($user, 48));
     }
 }


### PR DESCRIPTION
For letter avatars with a title attribute use aria-label to provide an accessible string for screen readers. Resolves #4070.