### PR TITLE
Add ARIA label to user mention

### DIFF
--- a/app/Core/Markdown.php
+++ b/app/Core/Markdown.php
@@ -92,6 +92,7 @@ class Markdown extends Parsedown
 
             if (! empty($user)) {
                 $url = $this->container['helper']->url->to('UserViewController', 'profile', array('user_id' => $user['id']));
+                $name = $user['name'] ?: $user['username'];
 
                 return array(
                     'extent'  => strlen($username) + 1,
@@ -101,7 +102,8 @@ class Markdown extends Parsedown
                         'attributes' => array(
                             'href'  => $url,
                             'class' => 'user-mention-link',
-                            'title' => $user['name'] ?: $user['username'],
+                            'title' => $name,
+                            'aria-label' => $name,
                         ),
                     ),
                 );

--- a/tests/units/Helper/TextHelperTest.php
+++ b/tests/units/Helper/TextHelperTest.php
@@ -67,42 +67,42 @@ class TextHelperTest extends Base
         $this->assertEquals(2, $userModel->create(array('username' => 'firstname.lastname', 'name' => 'Firstname Lastname')));
 
         $this->assertEquals(
-            '<p>Text <a href="?controller=UserViewController&amp;action=profile&amp;user_id=1" class="user-mention-link" title="admin">@admin</a> @notfound</p>',
+            '<p>Text <a href="?controller=UserViewController&amp;action=profile&amp;user_id=1" class="user-mention-link" title="admin" aria-label="admin">@admin</a> @notfound</p>',
             $textHelper->markdown('Text @admin @notfound')
         );
 
         $this->assertEquals(
-            '<p>Text <a href="?controller=UserViewController&amp;action=profile&amp;user_id=1" class="user-mention-link" title="admin">@admin</a>,</p>',
+            '<p>Text <a href="?controller=UserViewController&amp;action=profile&amp;user_id=1" class="user-mention-link" title="admin" aria-label="admin">@admin</a>,</p>',
             $textHelper->markdown('Text @admin,')
         );
 
         $this->assertEquals(
-            '<p>Text <a href="?controller=UserViewController&amp;action=profile&amp;user_id=1" class="user-mention-link" title="admin">@admin</a>!</p>',
+            '<p>Text <a href="?controller=UserViewController&amp;action=profile&amp;user_id=1" class="user-mention-link" title="admin" aria-label="admin">@admin</a>!</p>',
             $textHelper->markdown('Text @admin!')
         );
 
         $this->assertEquals(
-            '<p>Text <a href="?controller=UserViewController&amp;action=profile&amp;user_id=1" class="user-mention-link" title="admin">@admin</a>? </p>',
+            '<p>Text <a href="?controller=UserViewController&amp;action=profile&amp;user_id=1" class="user-mention-link" title="admin" aria-label="admin">@admin</a>? </p>',
             $textHelper->markdown('Text @admin? ')
         );
 
         $this->assertEquals(
-            '<p>Text <a href="?controller=UserViewController&amp;action=profile&amp;user_id=1" class="user-mention-link" title="admin">@admin</a>.</p>',
+            '<p>Text <a href="?controller=UserViewController&amp;action=profile&amp;user_id=1" class="user-mention-link" title="admin" aria-label="admin">@admin</a>.</p>',
             $textHelper->markdown('Text @admin.')
         );
 
         $this->assertEquals(
-            '<p>Text <a href="?controller=UserViewController&amp;action=profile&amp;user_id=1" class="user-mention-link" title="admin">@admin</a>: test</p>',
+            '<p>Text <a href="?controller=UserViewController&amp;action=profile&amp;user_id=1" class="user-mention-link" title="admin" aria-label="admin">@admin</a>: test</p>',
             $textHelper->markdown('Text @admin: test')
         );
 
         $this->assertEquals(
-            '<p>Text <a href="?controller=UserViewController&amp;action=profile&amp;user_id=1" class="user-mention-link" title="admin">@admin</a>: test</p>',
+            '<p>Text <a href="?controller=UserViewController&amp;action=profile&amp;user_id=1" class="user-mention-link" title="admin" aria-label="admin">@admin</a>: test</p>',
             $textHelper->markdown('Text @admin: test')
         );
 
         $this->assertEquals(
-            '<p>Text <a href="?controller=UserViewController&amp;action=profile&amp;user_id=2" class="user-mention-link" title="Firstname Lastname">@firstname.lastname</a>. test</p>',
+            '<p>Text <a href="?controller=UserViewController&amp;action=profile&amp;user_id=2" class="user-mention-link" title="Firstname Lastname" aria-label="Firstname Lastname">@firstname.lastname</a>. test</p>',
             $textHelper->markdown('Text @firstname.lastname. test')
         );
 


### PR DESCRIPTION
For user mention with a title attribute, use aria-label to provide an accessible string for screen readers. Resolves #4070.