### PR TITLE
Add ARIA label to modal link with title attribute

### DIFF
--- a/app/Helper/ModalHelper.php
+++ b/app/Helper/ModalHelper.php
@@ -49,7 +49,8 @@ class ModalHelper extends Base
 
     public function medium($icon, $label, $controller, $action, array $params = array(), $title = '')
     {
-        $html = '<i class="fa fa-'.$icon.' fa-fw js-modal-medium" aria-hidden="true"></i>'.$label;
+        $ariaLabel = (empty($title) ? 'aria-hidden="true"' : 'role="img" aria-label="'.$title.'"');
+        $html = '<i class="fa fa-'.$icon.' fa-fw js-modal-medium" '.$ariaLabel.'></i>'.$label;
         return $this->helper->url->link($html, $controller, $action, $params, false, 'js-modal-medium', $title);
     }
 


### PR DESCRIPTION
For modal links which have a title attribute, add an ARIA role and label containing the same text. Resolves #4070.