### PR TITLE
filemtime() now uses absolute path to file in AssetHelper

### DIFF
--- a/app/Helper/AssetHelper.php
+++ b/app/Helper/AssetHelper.php
@@ -21,7 +21,9 @@ class AssetHelper extends Base
      */
     public function js($filename, $async = false)
     {
-        return '<script '.($async ? 'async' : '').' defer type="text/javascript" src="'.$this->helper->url->dir().$filename.'?'.filemtime($filename).'"></script>';
+        $dir = dirname(__DIR__,2);
+        $filepath = $dir.'/'.$filename;
+        return '<script '.($async ? 'async' : '').' defer type="text/javascript" src="'.$this->helper->url->dir().$filename.'?'.filemtime($filepath).'"></script>';
     }
 
     /**
@@ -34,7 +36,9 @@ class AssetHelper extends Base
      */
     public function css($filename, $is_file = true, $media = 'screen')
     {
-        return '<link rel="stylesheet" href="'.$this->helper->url->dir().$filename.($is_file ? '?'.filemtime($filename) : '').'" media="'.$media.'">';
+        $dir = dirname(__DIR__,2);
+        $filepath = $dir.'/'.$filename;
+        return '<link rel="stylesheet" href="'.$this->helper->url->dir().$filename.($is_file ? '?'.filemtime($filepath) : '').'" media="'.$media.'">';
     }
 
     /**


### PR DESCRIPTION
In regard to https://github.com/kanboard/kanboard/issues/4657


## Tests
I did not run tests. I tried to, but I'm new to phpunit & not really sure how to make it all work. Before I made ANY changes to the source code, I did a `composer install`, then I ran tests with phpunit-7.0 (downloaded PHAR) but most of them failed & there were some errors.