### PR TITLE
Dont force role of user if no ldap groups defined

### DIFF
--- a/app/Core/Ldap/User.php
+++ b/app/Core/Ldap/User.php
@@ -125,7 +125,7 @@ class User
             return null;
         }
 	
-	if (LDAP_USER_DEFAULT_ROLE_MANAGER) {
+        if (LDAP_USER_DEFAULT_ROLE_MANAGER) {
             $role = Role::APP_MANAGER;
         } else {
             $role = Role::APP_USER;

--- a/app/Core/Ldap/User.php
+++ b/app/Core/Ldap/User.php
@@ -121,15 +121,14 @@ class User
      */
     protected function getRole(array $groupIds)
     {
-        $role = Role::APP_USER;
-
         if (! $this->hasGroupsConfigured()) {
-            if (LDAP_USER_DEFAULT_ROLE_MANAGER) {
-                $role = Role::APP_MANAGER;
-            } else {
-                $role = Role::APP_USER;
-            }
-            return $role;
+            return null;
+        }
+	
+	if (LDAP_USER_DEFAULT_ROLE_MANAGER) {
+            $role = Role::APP_MANAGER;
+        } else {
+            $role = Role::APP_USER;
         }
 
         foreach ($groupIds as $groupId) {

--- a/tests/units/Core/Ldap/LdapUserTest.php
+++ b/tests/units/Core/Ldap/LdapUserTest.php
@@ -136,7 +136,7 @@ class LdapUserTest extends Base
         $this->assertEquals('my_ldap_user', $user->getUsername());
         $this->assertEquals('My LDAP user', $user->getName());
         $this->assertEquals('user1@localhost', $user->getEmail());
-        $this->assertEquals(Role::APP_USER, $user->getRole());
+        $this->assertEquals(null, $user->getRole());
         $this->assertSame('', $user->getPhoto());
         $this->assertEquals(array(), $user->getExternalGroupIds());
         $this->assertEquals(array('is_ldap_user' => 1), $user->getExtraAttributes());


### PR DESCRIPTION
We should not force role of user on LDAP logins if there are not Manager/Admin groups defined, return null to get the one from database as before.