### PR TITLE
For action "Send a task by email to someone" allow subject with template

### DIFF
--- a/app/Action/TaskEmail.php
+++ b/app/Action/TaskEmail.php
@@ -80,12 +80,18 @@ class TaskEmail extends Base
     public function doAction(array $data)
     {
         $user = $this->userModel->getById($this->getParam('user_id'));
+        $subject = $this->getParam('subject');
+        
+        foreach ($data["task"] as $key => $value) {
+            $placeholder = sprintf('{{%s}}', $key);
+            $subject = str_replace($placeholder, $value, $subject);
+        }
 
         if (! empty($user['email'])) {
             $this->emailClient->send(
                 $user['email'],
                 $user['name'] ?: $user['username'],
-                $this->getParam('subject'),
+                $subject,
                 $this->template->render('notification/task_create', array(
                     'task' => $data['task'],
                 ))


### PR DESCRIPTION
For automatic action "Send a task by email to someone", the Subject of the e-mail can contain a template using interpolation expressions (with double braces).

For example, to have the email's subject look like (e.g. task moved to column "Done"):
**Done: Make sales report (# 1000)**

Add the following action:

**Send a task by email to someone**
-  Event name = Move a task to another column
-  Column = Done
-  User that will receive the email = Harry
-  Email subject = **{{column_title}}: {{title}} (#{{id}})**