### PR TITLE
fix(version): remove whitespace at end of APP_VERSION constant

### DIFF
--- a/app/functions.php
+++ b/app/functions.php
@@ -199,7 +199,7 @@ function build_app_version($ref, $commit_hash)
     if ($commit_hash !== '$Format:%H$') {
         return 'master.'.$commit_hash;
     } else if (file_exists('/version.txt')) {
-        return file_get_contents('/version.txt');
+        return rtrim(file_get_contents('/version.txt'));
     }
 
     return 'master.unknown_revision';


### PR DESCRIPTION
The Dockerfile contains `echo $VERSION > /version.txt`, where `echo`
implicitly causes a newline at the end of the file. To avoid that,
one could use `echo -n`, but then the file isn't nicely readable when
doing a `cat` or something simular.

This fix `rtrims` (i.e. "Strip whitespace (or other
characters) from the end of a string") the contents of the version file.

Fixes kanboard/kanboard#4708