### PR TITLE
LDAP protocol/host/port configuration by URL; make BASE_DN optional

### DIFF
--- a/app/Core/Ldap/Client.php
+++ b/app/Core/Ldap/Client.php
@@ -70,8 +70,8 @@ class Client
      *
      * @access public
      *
-     * @param  string $server LDAP server hostname or IP
-     * @param  int    $port   LDAP port
+     * @param  string $server LDAP server URI (ldap[s]://hostname:port) or hostname (deprecated) 
+     * @param  int    $port   LDAP port (deprecated)
      * @param  bool   $tls    Start TLS
      * @param  bool   $verify Skip SSL certificate verification
      * @return Client
@@ -88,7 +88,12 @@ class Client
             putenv('LDAPTLS_REQCERT=never');
         }
 
-        $this->ldap = @ldap_connect($server, $port);
+        if (is_integer($port)) {
+            $this->ldap = @ldap_connect($server, $port);
+        }
+        else {
+            $this->ldap = @ldap_connect($server);
+        }
 
         if ($this->ldap === false) {
             throw new ConnectionException('Malformed LDAP server hostname or LDAP server port');

--- a/app/Core/Ldap/Client.php
+++ b/app/Core/Ldap/Client.php
@@ -88,11 +88,11 @@ class Client
             putenv('LDAPTLS_REQCERT=never');
         }
 
-        if (is_integer($port)) {
-            $this->ldap = @ldap_connect($server, $port);
+        if (filter_var($server, FILTER_VALIDATE_URL) !== false) {
+            $this->ldap = @ldap_connect($server);
         }
         else {
-            $this->ldap = @ldap_connect($server);
+            $this->ldap = @ldap_connect($server, $port);
         }
 
         if ($this->ldap === false) {

--- a/app/Core/Ldap/User.php
+++ b/app/Core/Ldap/User.php
@@ -342,10 +342,6 @@ class User
      */
     public function getBaseDn()
     {
-        if (! LDAP_USER_BASE_DN) {
-            throw new LogicException('LDAP user base DN empty, check the parameter LDAP_USER_BASE_DN');
-        }
-
         return LDAP_USER_BASE_DN;
     }
 

--- a/config.default.php
+++ b/config.default.php
@@ -102,11 +102,8 @@ define('DB_TIMEOUT', null);
 // Enable LDAP authentication (false by default)
 define('LDAP_AUTH', false);
 
-// LDAP server hostname
+// LDAP server protocol, hostname and port URL (ldap[s]://hostname:port)
 define('LDAP_SERVER', '');
-
-// LDAP server port (389 by default)
-define('LDAP_PORT', 389);
 
 // By default, require certificate to be verified for ldaps:// style URL. Set to false to skip the verification
 define('LDAP_SSL_VERIFY', true);

--- a/tests/units/Core/Ldap/LdapUserTest.php
+++ b/tests/units/Core/Ldap/LdapUserTest.php
@@ -785,14 +785,6 @@ class LdapUserTest extends Base
         $this->assertEquals(array('is_ldap_user' => 1), $user->getExtraAttributes());
     }
 
-    public function testGetBaseDnNotConfigured()
-    {
-        $this->expectException('\LogicException');
-
-        $user = new User($this->query);
-        $user->getBaseDn();
-    }
-
     public function testGetLdapUserPatternNotConfigured()
     {
         $this->expectException('\LogicException');


### PR DESCRIPTION
Querying an Active Directory Global Catalog across an entire forest requires : 
- using `ldap_connect($uri)` instead of `ldap_connect($host, $port)`
- using an empty base DN

PHP `ldap_connect($host, $port)` function signature is deprecated : https://www.php.net/manual/en/function.ldap-connect.php
