### PR TITLE
Use an absolute filepath in AssetHelper css() & js() functions

### DIFF
--- a/app/Helper/AssetHelper.php
+++ b/app/Helper/AssetHelper.php
@@ -21,7 +21,9 @@ class AssetHelper extends Base
      */
     public function js($filename, $async = false)
     {
-        return '<script '.($async ? 'async' : '').' defer type="text/javascript" src="'.$this->helper->url->dir().$filename.'?'.filemtime($filename).'"></script>';
+        $dir = dirname(__DIR__,2);
+        $filepath = $dir.'/'.$filename;
+        return '<script '.($async ? 'async' : '').' defer type="text/javascript" src="'.$this->helper->url->dir().$filename.'?'.filemtime($filepath).'"></script>';
     }
 
     /**
@@ -34,7 +36,9 @@ class AssetHelper extends Base
      */
     public function css($filename, $is_file = true, $media = 'screen')
     {
-        return '<link rel="stylesheet" href="'.$this->helper->url->dir().$filename.($is_file ? '?'.filemtime($filename) : '').'" media="'.$media.'">';
+        $dir = dirname(__DIR__,2);
+        $filepath = $dir.'/'.$filename;
+        return '<link rel="stylesheet" href="'.$this->helper->url->dir().$filename.($is_file ? '?'.filemtime($filepath) : '').'" media="'.$media.'">';
     }
 
     /**


### PR DESCRIPTION
Regarding issue https://github.com/kanboard/kanboard/issues/4657

I have an unconventional Kanboard install, where kanboard is in a subdirecory of the DOCUMENT_ROOT. 

This causes error like:
```
 Warning: filemtime(): stat failed for assets/css/vendor.min.css in DOCUMENT_ROOT/kan/app/Helper/AssetHelper.php on line 43
```
where kanboard is in the `kan` folder.

This PR builds an absolute path for the filemtime() call, which fixes the problem.