### PR TITLE
Merge filemtimefix andpluginsdir fix

### DIFF
--- a/app/Helper/AssetHelper.php
+++ b/app/Helper/AssetHelper.php
@@ -21,7 +21,9 @@ class AssetHelper extends Base
      */
     public function js($filename, $async = false)
     {
-        return '<script '.($async ? 'async' : '').' defer type="text/javascript" src="'.$this->helper->url->dir().$filename.'?'.filemtime($filename).'"></script>';
+        $dir = dirname(__DIR__,2);
+        $filepath = $dir.'/'.$filename;
+        return '<script '.($async ? 'async' : '').' defer type="text/javascript" src="'.$this->helper->url->dir().$filename.'?'.filemtime($filepath).'"></script>';
     }
 
     /**
@@ -34,7 +36,9 @@ class AssetHelper extends Base
      */
     public function css($filename, $is_file = true, $media = 'screen')
     {
-        return '<link rel="stylesheet" href="'.$this->helper->url->dir().$filename.($is_file ? '?'.filemtime($filename) : '').'" media="'.$media.'">';
+        $dir = dirname(__DIR__,2);
+        $filepath = $dir.'/'.$filename;
+        return '<link rel="stylesheet" href="'.$this->helper->url->dir().$filename.($is_file ? '?'.filemtime($filepath) : '').'" media="'.$media.'">';
     }
 
     /**

--- a/app/Helper/AssetHelper.php
+++ b/app/Helper/AssetHelper.php
@@ -21,6 +21,7 @@ class AssetHelper extends Base
      */
     public function js($filename, $async = false)
     {
+        $filename = $this->getCorrectAssetFilename($filename);
         $dir = dirname(__DIR__,2);
         $filepath = $dir.'/'.$filename;
         return '<script '.($async ? 'async' : '').' defer type="text/javascript" src="'.$this->helper->url->dir().$filename.'?'.filemtime($filepath).'"></script>';
@@ -36,6 +37,7 @@ class AssetHelper extends Base
      */
     public function css($filename, $is_file = true, $media = 'screen')
     {
+        $filename = $this->getCorrectAssetFilename($filename);
         $dir = dirname(__DIR__,2);
         $filepath = $dir.'/'.$filename;
         return '<link rel="stylesheet" href="'.$this->helper->url->dir().$filename.($is_file ? '?'.filemtime($filepath) : '').'" media="'.$media.'">';
@@ -65,5 +67,28 @@ class AssetHelper extends Base
     public function colorCss()
     {
         return '<style>'.$this->colorModel->getCss().'</style>';
+    }
+
+    /**
+     * Corrects the relative path given by plugins that rely upon the assumption that PLUGINS_DIR always points to DOCUMENT_ROOT/plugins
+     *
+     * @param string $filename The filename given by a template:layout:css or template:layout:js hook
+     * @return string
+     */
+    public function getCorrectAssetFilename($filename){
+        $fn = str_replace('\\', '/', $filename);
+        $fnParts = explode('/', $filename);
+        if ($fnParts[0] != 'plugins') return $filename;
+        $root = realpath(dirname(__DIR__, 2));
+        $pDir = realpath(PLUGINS_DIR);
+        if ($root.'/plugins' == $pDir)return $filename;
+
+        array_shift($fnParts);
+        $relPluginsDirPath = implode('/', $fnParts);
+        $absPath = $pDir.'/'.$relPluginsDirPath;
+        $relKanboardDirPath = $this->helper->file->getRelativePath($root, $absPath);
+        $filename = $relKanboardDirPath;
+
+        return $filename;
     }
 }

--- a/app/Helper/FileHelper.php
+++ b/app/Helper/FileHelper.php
@@ -119,4 +119,43 @@ class FileHelper extends Base
 
         return null;
     }
+
+    /**
+     * This function was found on StackOverflow at https://stackoverflow.com/a/2638272/802469 
+     *
+     *
+     */
+    function getRelativePath($from, $to)
+    {
+        // some compatibility fixes for Windows paths
+        $from = is_dir($from) ? rtrim($from, '\/') . '/' : $from;
+        $to   = is_dir($to)   ? rtrim($to, '\/') . '/'   : $to;
+        $from = str_replace('\\', '/', $from);
+        $to   = str_replace('\\', '/', $to);
+
+        $from     = explode('/', $from);
+        $to       = explode('/', $to);
+        $relPath  = $to;
+
+        foreach($from as $depth => $dir) {
+            // find first non-matching dir
+            if($dir === $to[$depth]) {
+                // ignore this directory
+                array_shift($relPath);
+            } else {
+                // get number of remaining dirs to $from
+                $remaining = count($from) - $depth;
+                if($remaining > 1) {
+                    // add traversals up to first matching dir
+                    $padLength = (count($relPath) + $remaining - 1) * -1;
+                    $relPath = array_pad($relPath, $padLength, '..');
+                    break;
+                } else {
+                    $relPath[0] = './' . $relPath[0];
+                }
+            }
+        }
+        return implode('/', $relPath);
+    }
+
 }


### PR DESCRIPTION
This merges my other two PRs:
https://github.com/kanboard/kanboard/pull/4722
and
https://github.com/kanboard/kanboard/pull/4720

Alltogether, these allow a kanboard install to:
- be stored in a subdirectory of the document root
- Use an alternative plugins_dir
- Keep existing plugins working that use the plugins/ assumption

This fails to:
- Provide a standardized way to provide your asset path in a plugin
    - Plugins will still need to use `plugins/MyPlugin/Assets/myasset.css`.  