### PR TITLE
Fixing variables being shared between plugins

### DIFF
--- a/app/Helper/HookHelper.php
+++ b/app/Helper/HookHelper.php
@@ -43,19 +43,20 @@ class HookHelper extends Base
     public function render($hook, array $variables = array())
     {
         $buffer = '';
+        $currentVariables = array();
 
         foreach ($this->hook->getListeners($hook) as $params) {
             if (! empty($params['variables'])) {
-                $variables = array_merge($variables, $params['variables']);
+                $currentVariables = array_merge($variables, $params['variables']);
             } elseif (! empty($params['callable'])) {
                 $result = call_user_func_array($params['callable'], $variables);
 
                 if (is_array($result)) {
-                    $variables = array_merge($variables, $result);
+                    $currentVariables = array_merge($variables, $result);
                 }
             }
 
-            $buffer .= $this->template->render($params['template'], $variables);
+            $buffer .= $this->template->render($params['template'], $currentVariables);
         }
 
         return $buffer;

--- a/app/Helper/HookHelper.php
+++ b/app/Helper/HookHelper.php
@@ -43,9 +43,9 @@ class HookHelper extends Base
     public function render($hook, array $variables = array())
     {
         $buffer = '';
-        $currentVariables = array();
 
         foreach ($this->hook->getListeners($hook) as $params) {
+            $currentVariables = $variables;
             if (! empty($params['variables'])) {
                 $currentVariables = array_merge($variables, $params['variables']);
             } elseif (! empty($params['callable'])) {


### PR DESCRIPTION
If two plugins used the same hook, the variables they use aren't cleaned out in between running each of them.  This is a super simple change creating a placeholder composite object that doesn't retain any changes between plugins. 

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression
- [x] I follow existing [coding style](https://docs.kanboard.org/en/latest/developer_guide/coding_standards.html)

