### PR TITLE
new hook model:task:duplication:aftersave

### DIFF
--- a/app/Model/TaskDuplicationModel.php
+++ b/app/Model/TaskDuplicationModel.php
@@ -60,7 +60,7 @@ class TaskDuplicationModel extends Base
             $this->taskLinkModel->create($new_task_id, $task_id, 4);
         }
 
-        $hook_values = [ 'source_task_id' => $task_id, 'target_task_id' => $new_task_id];
+        $hook_values = [ 'source_task_id' => $task_id, 'destination_task_id' => $new_task_id];
         $this->hook->reference('model:task:duplication:aftersave', $hook_values);
 
         return $new_task_id;

--- a/app/Model/TaskDuplicationModel.php
+++ b/app/Model/TaskDuplicationModel.php
@@ -60,6 +60,9 @@ class TaskDuplicationModel extends Base
             $this->taskLinkModel->create($new_task_id, $task_id, 4);
         }
 
+        $hook_values = [ 'source_task_id' => $task_id, 'target_task_id' => $new_task_id];
+        $this->hook->reference('model:task:duplication:aftersave', $hook_values);
+
         return $new_task_id;
     }
 

--- a/app/Model/TaskProjectDuplicationModel.php
+++ b/app/Model/TaskProjectDuplicationModel.php
@@ -33,6 +33,9 @@ class TaskProjectDuplicationModel extends TaskDuplicationModel
             $this->taskLinkModel->create($new_task_id, $task_id, 4);
         }
 
+        $hook_values = [ 'source_task_id' => $task_id, 'target_task_id' => $new_task_id];
+        $this->hook->reference('model:task:duplication:aftersave', $hook_values);
+
         return $new_task_id;
     }
 

--- a/app/Model/TaskProjectDuplicationModel.php
+++ b/app/Model/TaskProjectDuplicationModel.php
@@ -33,8 +33,8 @@ class TaskProjectDuplicationModel extends TaskDuplicationModel
             $this->taskLinkModel->create($new_task_id, $task_id, 4);
         }
 
-        $hook_values = [ 'source_task_id' => $task_id, 'target_task_id' => $new_task_id];
-        $this->hook->reference('model:task:duplication:aftersave', $hook_values);
+        $hook_values = [ 'source_task_id' => $task_id, 'destination_task_id' => $new_task_id];
+        $this->hook->reference('model:task:project_duplication:aftersave', $hook_values);
 
         return $new_task_id;
     }


### PR DESCRIPTION
New hook to allow plugins to do something after task duplication, without overwriting core models.

See https://github.com/BlueTeck/kanboard_plugin_coverimage/pull/33

Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I follow existing [coding style](https://docs.kanboard.org/en/latest/developer_guide/coding_standards.html)

