### PR TITLE
Update Hungarian translation

### DIFF
--- a/app/Locale/hu_HU/translations.php
+++ b/app/Locale/hu_HU/translations.php
@@ -1424,5 +1424,6 @@ return array(
     'Comment' => 'Megjegyzés',
     'Collapse vertically' => 'Összecsukás függőlegesen',
     'Expand vertically' => 'Kinyitás függőlegesen',
-    // 'MXN - Mexican Peso' => '',
+    'MXN - Mexican Peso' => 'MXN – mexikói peso',
+    'HUF - Hungarian Forint' => 'HUF – magyar forint',
 );


### PR DESCRIPTION
Please sync the translation sources, because "HUF - Hungarian Forint" is missing from the other language files.

