### PR TITLE
createLdapUser API procedure fails if LDAP groups is not configured

### DIFF
--- a/app/Api/Procedure/UserProcedure.php
+++ b/app/Api/Procedure/UserProcedure.php
@@ -103,7 +103,7 @@ class UserProcedure extends BaseProcedure
                 'username' => $user->getUsername(),
                 'name' => $user->getName(),
                 'email' => $user->getEmail(),
-                'role' => $user->getRole(),
+                'role' => $user->getRole() ?: Role::APP_USER,
                 'is_ldap_user' => 1,
             );
 


### PR DESCRIPTION
Behavior changed in commit 4d1205a0fec20bd3e2a429443e2b2e37aadf010c

See PR #4674

Do you follow the guidelines?

- [ ] I have tested my changes
- [ ] There is no breaking change
- [ ] There is no regression
- [ ] I follow existing [coding style](https://docs.kanboard.org/en/latest/developer_guide/coding_standards.html)

