### PR TITLE
Consistent Column+Swimlane-Headers

### DIFF
--- a/app/Template/board/table_container.php
+++ b/app/Template/board/table_container.php
@@ -21,8 +21,14 @@
         <?php foreach ($swimlanes as $index => $swimlane): ?>
             <?php if (! ($swimlane['nb_tasks'] === 0 && isset($not_editable))): ?>
 
-                <!-- Note: Do not show swimlane row on the top otherwise we can't collapse columns -->
-                <?php if ($index > 0 && $swimlane['nb_swimlanes'] > 1): ?>
+                <!-- Note: Columns must render first otherwise we can't collapse them -->
+                <?= $this->render('board/table_column', array(
+                    'swimlane' => $swimlane,
+                    'not_editable' => isset($not_editable),
+                )) ?>
+
+                <!-- Hide first swimlane-header if project has only 1 swimlane -->
+                <?php if ($index === 0 && $swimlane['nb_swimlanes'] > 1): ?>
                     <?= $this->render('board/table_swimlane', array(
                         'project' => $project,
                         'swimlane' => $swimlane,
@@ -30,12 +36,7 @@
                     )) ?>
                 <?php endif ?>
 
-                <?= $this->render('board/table_column', array(
-                    'swimlane' => $swimlane,
-                    'not_editable' => isset($not_editable),
-                )) ?>
-
-                <?php if ($index === 0 && $swimlane['nb_swimlanes'] > 1): ?>
+                <?php if ($index > 0 && $swimlane['nb_swimlanes'] > 1): ?>
                     <?= $this->render('board/table_swimlane', array(
                         'project' => $project,
                         'swimlane' => $swimlane,


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [ ] There is no breaking change
- [x] There is no regression
- [x] I follow existing [coding style](https://docs.kanboard.org/en/latest/developer_guide/coding_standards.html)

(Sort of) fixes: https://github.com/kanboard/kanboard/issues/4759

As reported in the issue above, I have also experienced that our users find the inconsistent order of the column and swimlane-headers slightly confusing.
From what I know for now, the columns need to be rendered first to "generate" the general setup of columns in order for the collapsing of columns to work correctly. So my attempt just makes the column-headers always appear above the swimlane-header.
The swimlane-header is still being suppressed, if only one swimlane exists.

Hope you like it.



