### PR TITLE
keyboard shortcut added for vertical expand/collapse in board view

### DIFF
--- a/app/Template/project_header/dropdown.php
+++ b/app/Template/project_header/dropdown.php
@@ -20,10 +20,10 @@
         </li>
         <li>
             <span class="filter-vert-collapse">
-                <i class="fa fa-arrow-up fa-fw"></i> <a href="#" class="filter-vert-toggle-collapse"><?= t('Collapse vertically') ?></a>
+                <i class="fa fa-arrow-up fa-fw"></i> <a href="#" class="filter-vert-toggle-collapse" title="<?= t('Keyboard shortcut: "%s"', 'p') ?>"><?= t('Collapse vertically') ?></a>
             </span>
             <span class="filter-vert-expand" style="display: none">
-                <i class="fa fa-arrow-down fa-fw"></i> <a href="#" class="filter-vert-toggle-collapse"><?= t('Expand vertically') ?></a>
+                <i class="fa fa-arrow-down fa-fw"></i> <a href="#" class="filter-vert-toggle-collapse" title="<?= t('Keyboard shortcut: "%s"', 'p') ?>"><?= t('Expand vertically') ?></a>
             </span>
         </li>
         <?php endif ?>

--- a/assets/js/components/keyboard-shortcuts.js
+++ b/assets/js/components/keyboard-shortcuts.js
@@ -54,6 +54,12 @@ KB.keyboardShortcuts = function () {
             }
         });
 
+        KB.onKey('p', function () {
+            if (! KB.modal.isOpen()) {
+                _KB.get('BoardVerticalScrolling').toggle();
+            }
+        });
+
         KB.onKey('s', function () {
             if (! KB.modal.isOpen()) {
                 _KB.get('BoardCollapsedMode').toggle();


### PR DESCRIPTION
I missed a keyboard shortcut for vertical expand/collapse as it exists for horizontal scrolling for years. I choose 'p' as key (pile, pack), please feel free to change it.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression
- [x] I follow existing [coding style](https://docs.kanboard.org/en/latest/developer_guide/coding_standards.html)

