### PR TITLE
Enable external group synchronization deactivation.

### DIFF
--- a/app/Core/User/UserProfile.php
+++ b/app/Core/User/UserProfile.php
@@ -52,7 +52,9 @@ class UserProfile extends Base
             $profile = $this->userModel->getById($user->getInternalId());
         } elseif ($user->getExternalIdColumn() && $user->getExternalId()) {
             $profile = $this->userSync->synchronize($user);
-            $this->groupSync->synchronize($profile['id'], $user->getExternalGroupIds());
+            if (LDAP_GROUP_SYNC) {
+                $this->groupSync->synchronize($profile['id'], $user->getExternalGroupIds());
+            }
         }
 
         if (! empty($profile) && $profile['is_active'] == 1) {

--- a/app/constants.php
+++ b/app/constants.php
@@ -92,6 +92,8 @@ defined('LDAP_GROUP_FILTER') or define('LDAP_GROUP_FILTER', getenv('LDAP_GROUP_F
 defined('LDAP_GROUP_USER_FILTER') or define('LDAP_GROUP_USER_FILTER', getenv('LDAP_GROUP_USER_FILTER') ?: '');
 defined('LDAP_GROUP_USER_ATTRIBUTE') or define('LDAP_GROUP_USER_ATTRIBUTE', getenv('LDAP_GROUP_USER_ATTRIBUTE') ?: 'username');
 defined('LDAP_GROUP_ATTRIBUTE_NAME') or define('LDAP_GROUP_ATTRIBUTE_NAME', getenv('LDAP_GROUP_ATTRIBUTE_NAME') ?: 'cn');
+defined('LDAP_GROUP_SYNC') or define('LDAP_GROUP_SYNC', getenv('LDAP_GROUP_SYNC') ?: true);
+
 
 // Proxy authentication
 defined('REVERSE_PROXY_AUTH') or define('REVERSE_PROXY_AUTH', strtolower(getenv('REVERSE_PROXY_AUTH')) === 'true');

--- a/config.default.php
+++ b/config.default.php
@@ -195,6 +195,9 @@ define('LDAP_GROUP_USER_ATTRIBUTE', 'username');
 // LDAP attribute for the group name
 define('LDAP_GROUP_ATTRIBUTE_NAME', 'cn');
 
+// Enable/Disable groups synchronization when external authentication is used.
+define('LDAP_GROUP_SYNC', true);
+
 // Enable/disable the reverse proxy authentication
 define('REVERSE_PROXY_AUTH', false);
 

--- a/docker/etc/php7/php-fpm.d/env.conf
+++ b/docker/etc/php7/php-fpm.d/env.conf
@@ -154,6 +154,9 @@ env[TOTP_ISSUER] = $TOTP_ISSUER
 ; Comma separated list of fields to not synchronize when using external authentication providers
 env[EXTERNAL_AUTH_EXCLUDE_FIELDS] = $EXTERNAL_AUTH_EXCLUDE_FIELDS
 
+; Enable/Disable groups synchronization when external authentication is used.
+env[LDAP_GROUP_SYNC] = $LDAP_GROUP_SYNC
+
 env[SHOW_GROUP_MEMBERSHIPS_IN_USERLIST] = $SHOW_GROUP_MEMBERSHIPS_IN_USERLIST
 env[SHOW_GROUP_MEMBERSHIPS_IN_USERLIST_WITH_LIMIT] = $SHOW_GROUP_MEMBERSHIPS_IN_USERLIST_WITH_LIMIT
 


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression
- [x] I follow existing [coding style](https://docs.kanboard.org/en/latest/developer_guide/coding_standards.html)

This commit aims to deactivate group synchronization when one has not configured its LDAP server to use posixGroup memberOf or groupOfNames. Group synchronization can be done by an external program/script.