### PR TITLE
Update SubtaskTaskConversionModel.php

### DIFF
--- a/app/Model/SubtaskTaskConversionModel.php
+++ b/app/Model/SubtaskTaskConversionModel.php
@@ -39,7 +39,7 @@ class SubtaskTaskConversionModel extends Base
         ));
 
         if ($task_id !== false) {
-            $this->taskLinkModel->create($task_id, $subtask['task_id'], 6);
+            $this->taskLinkModel->create($task_id, $subtask['task_id'], 7);
             $this->tagDuplicationModel->duplicateTaskTags($parent_task['id'], $task_id);
             $this->subtaskModel->remove($subtask_id);
         }


### PR DESCRIPTION
I (very carefully) suggest, there might be a wrong `link_id` of `6` passed onto the `create` function of the converted subtask, as the link of ID `#6` according to the `links table` in the db belongs to a `is a parent` link label while the correct one for a subtask should be `is a child of` (which it seems to be the ID `7`).

Rlated issue: #4409

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression
- [x] I follow existing [coding style](https://docs.kanboard.org/en/latest/developer_guide/coding_standards.html)

