### PR TITLE
Subtask conversion int. link parent/child incosistencies

### DIFF
--- a/app/Schema/Mysql.php
+++ b/app/Schema/Mysql.php
@@ -1104,8 +1104,8 @@ function version_46(PDO $pdo)
     $rq->execute(array('is duplicated by', get_last_insert_id($pdo)));
     $arq->execute(array(get_last_insert_id($pdo), 'duplicates'));
 
-    $rq->execute(array('is a parent of', 0));
-    $rq->execute(array('is a child of', get_last_insert_id($pdo)));
+    $rq->execute(array('is a child of', 0));
+    $rq->execute(array('is a parent of', get_last_insert_id($pdo)));
     $arq->execute(array(get_last_insert_id($pdo), 'is a parent of'));
 
     $rq->execute(array('is a milestone of', 0));


### PR DESCRIPTION
Relates to #4888 

There is an inconsistency in the order of the `is a child of` and `is a parent of` between databases. While [Mysql.php](https://github.com/kanboard/kanboard/blob/e5d22682cbc13bc6345183d4c3e68f3be3c074aa/app/Schema/Mysql.php#L1067-L1118) defines the link label `is a parent of` as ID 7 and `is a child of` as ID 7, both the [Postgre.php](https://github.com/kanboard/kanboard/blob/e5d22682cbc13bc6345183d4c3e68f3be3c074aa/app/Schema/Postgres.php#L944-L978) and [Sqlite.php](https://github.com/kanboard/kanboard/blob/e5d22682cbc13bc6345183d4c3e68f3be3c074aa/app/Schema/Sqlite.php#L904-L938) work with an inverted order of the two, and define `is a parent of` as ID 7 while `is a child of` is ID 6.

This change will, however, switch all the current `parent / child` internal links of the MySQL users so some consequent steps might be needed.

Do you follow the guidelines?

- [ ] I have tested my changes
- [ ] There is no breaking change
- [ ] There is no regression
- [ ] I follow existing [coding style](https://docs.kanboard.org/en/latest/developer_guide/coding_standards.html)

