### PR TITLE
Solve PHP 8 "named parameter" impact

### DIFF
--- a/app/Helper/HookHelper.php
+++ b/app/Helper/HookHelper.php
@@ -49,7 +49,7 @@ class HookHelper extends Base
             if (! empty($params['variables'])) {
                 $currentVariables = array_merge($variables, $params['variables']);
             } elseif (! empty($params['callable'])) {
-                $result = call_user_func_array($params['callable'], $variables);
+                $result = call_user_func_array($params['callable'], array_values($variables));
 
                 if (is_array($result)) {
                     $currentVariables = array_merge($variables, $result);


### PR DESCRIPTION
[PHP 8 introduces named parameters.](https://php.watch/versions/8.0/named-parameters)  
This with `call_user_func_array` may cause errors in plugins like:

https://github.com/creecros/Group_assign/pull/64

It is fixable per plugin, but the mitigation should probably take place in kanboard base.