### PR TITLE
config.php.default: clarify meaning of LDAP_USER_CREATION

### DIFF
--- a/config.default.php
+++ b/config.default.php
@@ -158,7 +158,8 @@ define('LDAP_USER_ATTRIBUTE_PHOTO', '');
 // Put an empty string to disable language sync
 define('LDAP_USER_ATTRIBUTE_LANGUAGE', '');
 
-// Allow automatic LDAP user creation
+// Automatically create a user profile when a user authenticates via LDAP.
+// If set to false, only LDAP users can log in for whom a Kanboard profile already exists.
 define('LDAP_USER_CREATION', true);
 
 // Set new user as Manager


### PR DESCRIPTION
While the documentation explains the meaning of LDAP_USER_CREATION very well, the example config file just contains the explanation "Allow automatic LDAP user creation". This might confuse some admins (such as me) as it can be interpreted as "create an LDAP user for new local users". This commit expands the explanation to clarify the meaning of LDAP_USER_CREATION.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression
- [x] I follow existing [coding style](https://docs.kanboard.org/en/latest/developer_guide/coding_standards.html)

