### PR TITLE
don't look for project_id for files

### DIFF
--- a/app/Controller/BaseController.php
+++ b/app/Controller/BaseController.php
@@ -95,16 +95,10 @@ abstract class BaseController extends Base
     {
         $task_id = $this->request->getIntegerParam('task_id');
         $file_id = $this->request->getIntegerParam('file_id');
-        $project_id = $this->request->getIntegerParam('project_id');
         $model = 'projectFileModel';
 
         if ($task_id > 0) {
             $model = 'taskFileModel';
-            $task_project_id = $this->taskFinderModel->getProjectId($task_id);
-
-            if ($project_id != $task_project_id) {
-                throw new AccessForbiddenException();
-            }
         }
 
         $file = $this->$model->getById($file_id);
@@ -114,8 +108,6 @@ abstract class BaseController extends Base
         }
 
         if (isset($file['task_id']) && $file['task_id'] != $task_id) {
-            throw new AccessForbiddenException();
-        } else if (isset($file['project_id']) && $file['project_id'] != $project_id) {
             throw new AccessForbiddenException();
         }
 


### PR DESCRIPTION
it is only used for late accessibility checking (it was already checked in middleware).

With this, you can create stable file links (as long as the file exists)

I need this change for my [inline image plugin](https://github.com/Chaosmeister/PITM)


- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression
- [x] I follow existing [coding style](https://docs.kanboard.org/en/latest/developer_guide/coding_standards.html)

