### PR TITLE
Enable action to run on multiple triggers

### DIFF
--- a/app/Action/TaskMoveColumnCategoryChange.php
+++ b/app/Action/TaskMoveColumnCategoryChange.php
@@ -33,6 +33,8 @@ class TaskMoveColumnCategoryChange extends Base
     {
         return array(
             TaskModel::EVENT_UPDATE,
+            TaskModel::EVENT_CREATE,
+            TaskModel::EVENT_CREATE_UPDATE,
         );
     }
 


### PR DESCRIPTION
This is a non-breaking change that will allow the "Move column on category change" automatic action to be triggered on create, update, or create/update.

Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I follow existing [coding style](https://docs.kanboard.org/en/latest/developer_guide/coding_standards.html)

