### PR TITLE
Restore PHP 7.3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,13 @@
     "config": {
         "preferred-install": "dist",
         "optimize-autoloader": true,
-        "discard-changes": true
+        "discard-changes": true,
+        "platform": {
+            "php": "7.3"
+        }
     },
     "require" : {
-        "php" : ">=7.2.0",
+        "php" : ">=7.3",
         "ext-simplexml" : "*",
         "ext-dom" : "*",
         "ext-xml" : "*",


### PR DESCRIPTION
The last update bumped two dependencies leading to newer PHP requirements.
psr/container to 2.0 which requires PHP 7.4 and phpunit to 9.5 requiring
PHP 7.3.

This sets the targeted platform to 7.3 again, so a composer update should
downgrade psr/container and at least restore 7.3 support.

TODO: This is missing a lock file and vendor update.
