### PR TITLE
Change minimum requirement to PHP 7.4

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 Version 1.2.22 (February 12, 2022)
 ----------------------------------
 
-* Add support for PHP 8.x
+* Add support for PHP 8.x (Minimum requirement is now PHP >= 7.4)
 * Remove `project_id` from task URLs
 * Update `da_DK` translations
 * Add automatic action to set the due date when the task is moved away from a specific column

--- a/app/check_setup.php
+++ b/app/check_setup.php
@@ -1,32 +1,32 @@
 <?php
 
-// PHP 7.2.0 minimum
-if (version_compare(PHP_VERSION, '7.2.0', '<')) {
-    throw new Exception('This software requires PHP 7.2.0 minimum');
+// PHP 7.4.0 minimum
+if (version_compare(PHP_VERSION, '7.4.0', '<')) {
+    throw new Exception('This software requires PHP 7.4.0 minimum');
 }
 
 // Check data folder if sqlite
-if (DB_DRIVER === 'sqlite' && ! is_writable(dirname(DB_FILENAME))) {
-    throw new Exception('The directory "'.dirname(DB_FILENAME).'" must be writeable by your web server user');
+if (DB_DRIVER === 'sqlite' && !is_writable(dirname(DB_FILENAME))) {
+    throw new Exception('The directory "' . dirname(DB_FILENAME) . '" must be writeable by your web server user');
 }
 
 // Check PDO extensions
-if (DB_DRIVER === 'sqlite' && ! extension_loaded('pdo_sqlite')) {
+if (DB_DRIVER === 'sqlite' && !extension_loaded('pdo_sqlite')) {
     throw new Exception('PHP extension required: "pdo_sqlite"');
 }
 
-if (DB_DRIVER === 'mysql' && ! extension_loaded('pdo_mysql')) {
+if (DB_DRIVER === 'mysql' && !extension_loaded('pdo_mysql')) {
     throw new Exception('PHP extension required: "pdo_mysql"');
 }
 
-if (DB_DRIVER === 'postgres' && ! extension_loaded('pdo_pgsql')) {
+if (DB_DRIVER === 'postgres' && !extension_loaded('pdo_pgsql')) {
     throw new Exception('PHP extension required: "pdo_pgsql"');
 }
 
 // Check other extensions
 foreach (array('gd', 'mbstring', 'hash', 'openssl', 'json', 'hash', 'ctype', 'filter', 'session', 'dom', 'filter', 'SimpleXML', 'xml') as $ext) {
-    if (! extension_loaded($ext)) {
-        throw new Exception('This PHP extension is required: "'.$ext.'"');
+    if (!extension_loaded($ext)) {
+        throw new Exception('This PHP extension is required: "' . $ext . '"');
     }
 }
 

--- a/composer.json
+++ b/composer.json
@@ -13,51 +13,53 @@
         "optimize-autoloader": true,
         "discard-changes": true
     },
-    "require" : {
-        "php" : ">=7.2.0",
-        "ext-simplexml" : "*",
-        "ext-dom" : "*",
-        "ext-xml" : "*",
-        "ext-gd" : "*",
-        "ext-mbstring" : "*",
-        "ext-hash" : "*",
-        "ext-openssl" : "*",
-        "ext-json" : "*",
-        "ext-ctype" : "*",
-        "ext-filter" : "*",
-        "ext-session" : "*",
-        "christian-riesen/otp" : "1.4.3",
-        "erusev/parsedown" : "1.7.4",
-        "pimple/pimple" : "3.5.0",
+    "require": {
+        "php": ">=7.4.0",
+        "ext-simplexml": "*",
+        "ext-dom": "*",
+        "ext-xml": "*",
+        "ext-gd": "*",
+        "ext-mbstring": "*",
+        "ext-hash": "*",
+        "ext-openssl": "*",
+        "ext-json": "*",
+        "ext-ctype": "*",
+        "ext-filter": "*",
+        "ext-session": "*",
+        "christian-riesen/otp": "1.4.3",
+        "erusev/parsedown": "1.7.4",
+        "pimple/pimple": "3.5.0",
         "psr/log": "1.1.4",
-        "symfony/console" : "4.4.37",
-        "symfony/event-dispatcher" : "4.4.37",
+        "symfony/console": "4.4.37",
+        "symfony/event-dispatcher": "4.4.37",
         "symfony/finder": "5.4.3"
     },
-    "autoload" : {
-        "classmap" : ["app/"],
-        "psr-4" : {
-            "Kanboard\\" : "app/",
+    "autoload": {
+        "classmap": [
+            "app/"
+        ],
+        "psr-4": {
+            "Kanboard\\": "app/",
             "MatthiasMullie\\Minify\\": "libs/minify/src/",
             "MatthiasMullie\\PathConverter\\": "libs/path-converter/src/",
             "Gregwar\\": "libs",
             "Eluceo\\iCal\\": "libs/ical"
         },
-        "psr-0" : {
+        "psr-0": {
             "JsonRPC": "libs/jsonrpc/src",
             "PHPQRCode": "libs/phpqrcode/lib",
             "PicoDb": "libs/picodb/lib",
             "SimpleQueue": "libs",
             "SimpleValidator": "libs"
         },
-        "files" : [
+        "files": [
             "app/functions.php",
             "libs/swiftmailer/swift_required.php"
         ]
     },
-    "require-dev" : {
-        "symfony/stopwatch" : "5.4.3",
-        "phpunit/phpunit" : "9.5.13",
+    "require-dev": {
+        "symfony/stopwatch": "5.4.3",
+        "phpunit/phpunit": "9.5.13",
         "roave/security-advisories": "dev-master"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5367b4ff806bb00304200974107f8f46",
+    "content-hash": "471f84cc222b4ec429bad97351cbdf39",
     "packages": [
         {
             "name": "christian-riesen/base32",
@@ -738,12 +738,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1557,16 +1557,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.10",
+            "version": "9.2.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687"
+                "reference": "665a1ac0a763c51afc30d6d130dac0813092b17f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d5850aaf931743067f4bfc1ae4cbd06468400687",
-                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/665a1ac0a763c51afc30d6d130dac0813092b17f",
+                "reference": "665a1ac0a763c51afc30d6d130dac0813092b17f",
                 "shasum": ""
             },
             "require": {
@@ -1622,7 +1622,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.10"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.11"
             },
             "funding": [
                 {
@@ -1630,7 +1630,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-05T09:12:13+00:00"
+            "time": "2022-02-18T12:46:09+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1982,12 +1982,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "2ec9ad634c459ee60c42d99390be37c8a3c6e8e5"
+                "reference": "6ba1494c9aaa556dc45e13eaab644a280ad76558"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/2ec9ad634c459ee60c42d99390be37c8a3c6e8e5",
-                "reference": "2ec9ad634c459ee60c42d99390be37c8a3c6e8e5",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/6ba1494c9aaa556dc45e13eaab644a280ad76558",
+                "reference": "6ba1494c9aaa556dc45e13eaab644a280ad76558",
                 "shasum": ""
             },
             "conflict": {
@@ -2016,9 +2016,9 @@
                 "brightlocal/phpwhois": "<=4.2.5",
                 "buddypress/buddypress": "<7.2.1",
                 "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
-                "bytefury/crater": "<6",
+                "bytefury/crater": "<6.0.2",
                 "cachethq/cachet": "<2.5.1",
-                "cakephp/cakephp": ">=1.3,<1.3.18|>=2,<2.4.99|>=2.5,<2.5.99|>=2.6,<2.6.12|>=2.7,<2.7.6|>=3,<3.5.18|>=3.6,<3.6.15|>=3.7,<3.7.7",
+                "cakephp/cakephp": "<4.0.6",
                 "cardgate/magento2": "<2.0.33",
                 "cart2quote/module-quotation": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
                 "cartalyst/sentry": "<=2.1.6",
@@ -2030,11 +2030,11 @@
                 "codeigniter4/framework": "<4.1.8",
                 "codiad/codiad": "<=2.8.4",
                 "composer/composer": "<1.10.23|>=2-alpha.1,<2.1.9",
-                "concrete5/concrete5": "<8.5.5",
+                "concrete5/concrete5": "<9",
                 "concrete5/core": "<8.5.7",
                 "contao-components/mediaelement": ">=2.14.2,<2.21.1",
                 "contao/core": ">=2,<3.5.39",
-                "contao/core-bundle": ">=4,<4.4.56|>=4.5,<4.9.18|>=4.10,<4.11.7|= 4.10.0",
+                "contao/core-bundle": "<4.9.18|>=4.10,<4.11.7|= 4.10.0",
                 "contao/listing-bundle": ">=4,<4.4.8",
                 "craftcms/cms": "<3.7.14",
                 "croogo/croogo": "<3.0.7",
@@ -2059,7 +2059,7 @@
                 "ecodev/newsletter": "<=4",
                 "elgg/elgg": "<3.3.24|>=4,<4.0.5",
                 "endroid/qr-code-bundle": "<3.4.2",
-                "enshrined/svg-sanitize": "<0.13.1",
+                "enshrined/svg-sanitize": "<0.15",
                 "erusev/parsedown": "<1.7.2",
                 "ether/logs": "<3.0.4",
                 "ezsystems/demobundle": ">=5.4,<5.4.6.1",
@@ -2102,6 +2102,7 @@
                 "getkirby/panel": "<2.5.14",
                 "gilacms/gila": "<=1.11.4",
                 "globalpayments/php-sdk": "<2",
+                "google/protobuf": "<3.15",
                 "gos/web-socket-bundle": "<1.10.4|>=2,<2.6.1|>=3,<3.3",
                 "gree/jose": "<=2.2",
                 "gregwar/rst": "<1.0.3",
@@ -2126,6 +2127,7 @@
                 "james-heinrich/getid3": "<1.9.21",
                 "joomla/archive": "<1.1.10",
                 "joomla/session": "<1.3.1",
+                "jsdecena/laracom": "<2.0.9",
                 "jsmitty12/phpwhois": "<5.1",
                 "kazist/phpwhois": "<=4.2.6",
                 "kevinpapst/kimai2": "<1.16.7",
@@ -2143,7 +2145,7 @@
                 "league/commonmark": "<0.18.3",
                 "league/flysystem": "<1.1.4|>=2,<2.1.1",
                 "lexik/jwt-authentication-bundle": "<2.10.7|>=2.11,<2.11.3",
-                "librenms/librenms": "<=21.11",
+                "librenms/librenms": "<22.2",
                 "limesurvey/limesurvey": "<3.27.19",
                 "livehelperchat/livehelperchat": "<=3.91",
                 "livewire/livewire": ">2.2.4,<2.2.6",
@@ -2210,7 +2212,7 @@
                 "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5.0.10,<5.6.3",
                 "phpwhois/phpwhois": "<=4.2.5",
                 "phpxmlrpc/extras": "<0.6.1",
-                "pimcore/pimcore": "<=10.2.9",
+                "pimcore/pimcore": "<10.3.1",
                 "pocketmine/pocketmine-mp": "<4.0.7",
                 "pressbooks/pressbooks": "<5.18",
                 "prestashop/autoupgrade": ">=4,<4.10.1",
@@ -2225,6 +2227,7 @@
                 "propel/propel": ">=2-alpha.1,<=2-alpha.7",
                 "propel/propel1": ">=1,<=1.7.1",
                 "pterodactyl/panel": "<1.7",
+                "ptrofimov/beanstalk_console": "<1.7.14",
                 "pusher/pusher-php-server": "<2.2.1",
                 "pwweb/laravel-core": "<=0.3.6-beta",
                 "rainlab/debugbar-plugin": "<3.1",
@@ -2240,13 +2243,13 @@
                 "shopware/platform": "<=6.4.6",
                 "shopware/production": "<=6.3.5.2",
                 "shopware/shopware": "<5.7.7",
-                "showdoc/showdoc": "<2.10.2",
+                "showdoc/showdoc": "<=2.10.2",
                 "silverstripe/admin": ">=1,<1.8.1",
                 "silverstripe/assets": ">=1,<1.4.7|>=1.5,<1.5.2",
                 "silverstripe/cms": "<4.3.6|>=4.4,<4.4.4",
                 "silverstripe/comments": ">=1.3,<1.9.99|>=2,<2.9.99|>=3,<3.1.1",
                 "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
-                "silverstripe/framework": "<4.7.4",
+                "silverstripe/framework": "<4.10.1",
                 "silverstripe/graphql": "<3.5.2|>=4-alpha.1,<4-alpha.2",
                 "silverstripe/registry": ">=2.1,<2.1.2|>=2.2,<2.2.1",
                 "silverstripe/restfulserver": ">=1,<1.0.9|>=2,<2.0.4",
@@ -2260,7 +2263,7 @@
                 "simplito/elliptic-php": "<1.0.6",
                 "slim/slim": "<2.6",
                 "smarty/smarty": "<3.1.43|>=4,<4.0.3",
-                "snipe/snipe-it": "<=5.3.7",
+                "snipe/snipe-it": "<5.3.10",
                 "socalnick/scn-social-auth": "<1.15.2",
                 "socialiteproviders/steam": "<1.1",
                 "spipu/html2pdf": "<5.2.4",
@@ -2313,7 +2316,7 @@
                 "t3/dce": ">=2.2,<2.6.2",
                 "t3g/svg-sanitizer": "<1.0.3",
                 "tecnickcom/tcpdf": "<6.2.22",
-                "terminal42/contao-tablelookupwizard": ">=1,<3.3.5",
+                "terminal42/contao-tablelookupwizard": "<3.3.5",
                 "thelia/backoffice-default-template": ">=2.1,<2.1.2",
                 "thelia/thelia": ">=2.1-beta.1,<2.1.3",
                 "theonedemon/phpwhois": "<=4.2.5",
@@ -2324,7 +2327,7 @@
                 "topthink/thinkphp": "<=3.2.3",
                 "tribalsystems/zenario": "<8.8.53370",
                 "truckersmp/phpwhois": "<=4.3.1",
-                "twig/twig": "<1.38|>=2,<2.7",
+                "twig/twig": "<1.38|>=2,<2.14.11|>=3,<3.3.8",
                 "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.38|>=9,<9.5.29|>=10,<10.4.19|>=11,<11.5",
                 "typo3/cms-backend": ">=7,<=7.6.50|>=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.13|>=11,<=11.1",
                 "typo3/cms-core": ">=6.2,<=6.2.56|>=7,<=7.6.52|>=8,<=8.7.41|>=9,<9.5.29|>=10,<10.4.19|>=11,<11.5",
@@ -2421,7 +2424,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-05T03:12:57+00:00"
+            "time": "2022-02-17T14:18:41+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2929,16 +2932,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.3",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
                 "shasum": ""
             },
             "require": {
@@ -2981,7 +2984,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
             },
             "funding": [
                 {
@@ -2989,7 +2992,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-11T13:31:12+00:00"
+            "time": "2022-02-14T08:28:10+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -3648,7 +3651,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.2.0",
+        "php": ">=7.4.0",
         "ext-simplexml": "*",
         "ext-dom": "*",
         "ext-xml": "*",

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -5,7 +5,7 @@
         'type' => 'project',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
-        'reference' => 'f5bb55bdb8fe95c37877d4788cb85cfcb49c4d77',
+        'reference' => '02871400340b0d50795bd2b75649a8d8366d17f6',
         'name' => 'kanboard/kanboard',
         'dev' => false,
     ),
@@ -43,7 +43,7 @@
             'type' => 'project',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),
-            'reference' => 'f5bb55bdb8fe95c37877d4788cb85cfcb49c4d77',
+            'reference' => '02871400340b0d50795bd2b75649a8d8366d17f6',
             'dev_requirement' => false,
         ),
         'pimple/pimple' => array(


### PR DESCRIPTION
- PHP versions < 7.4 are EOL: https://www.php.net/supported-versions.php
- Libraries used by Kanboard have dropped support for older versions of PHP

Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I follow existing [coding style](https://docs.kanboard.org/en/latest/developer_guide/coding_standards.html)

