### PR TITLE
Translate subtask status on demand (Fixes #4476)

### DIFF
--- a/app/Controller/SubtaskRestrictionController.php
+++ b/app/Controller/SubtaskRestrictionController.php
@@ -24,8 +24,8 @@ class SubtaskRestrictionController extends BaseController
 
         $this->response->html($this->template->render('subtask_restriction/show', array(
             'status_list' => array(
-                SubtaskModel::STATUS_TODO => t('Todo'),
-                SubtaskModel::STATUS_DONE => t('Done'),
+                SubtaskModel::STATUS_TODO => 'Todo',
+                SubtaskModel::STATUS_DONE => 'Done',
             ),
             'subtask_inprogress' => $this->subtaskStatusModel->getSubtaskInProgress($this->userSession->getId()),
             'subtask' => $subtask,

--- a/app/Export/SubtaskExport.php
+++ b/app/Export/SubtaskExport.php
@@ -77,7 +77,7 @@ class SubtaskExport extends Base
         $values = array();
         $values[] = $subtask['id'];
         $values[] = $subtask['title'];
-        $values[] = $this->subtask_status[$subtask['status']];
+        $values[] = t($this->subtask_status[$subtask['status']]);
         $values[] = $subtask['assignee_name'] ?: $subtask['assignee_username'];
         $values[] = $subtask['time_estimated'];
         $values[] = $subtask['time_spent'];

--- a/app/Model/SubtaskModel.php
+++ b/app/Model/SubtaskModel.php
@@ -64,9 +64,9 @@ class SubtaskModel extends Base
     public function getStatusList()
     {
         return array(
-            self::STATUS_TODO       => t('Todo'),
-            self::STATUS_INPROGRESS => t('In progress'),
-            self::STATUS_DONE       => t('Done'),
+            self::STATUS_TODO       => 'Todo',
+            self::STATUS_INPROGRESS => 'In progress',
+            self::STATUS_DONE       => 'Done',
         );
     }
 

--- a/app/Template/event/subtask_create.php
+++ b/app/Template/event/subtask_create.php
@@ -10,7 +10,7 @@
 
     <ul>
         <li>
-            <?= $this->text->e($subtask['title']) ?> (<strong><?= $this->text->e($subtask['status_name']) ?></strong>)
+            <?= $this->text->e($subtask['title']) ?> (<strong><?= $this->text->e(t($subtask['status_name'])) ?></strong>)
         </li>
         <li>
             <?php if ($subtask['username']): ?>

--- a/app/Template/event/subtask_update.php
+++ b/app/Template/event/subtask_update.php
@@ -10,7 +10,7 @@
 
     <ul>
         <li>
-            <?= $this->text->e($subtask['title']) ?> (<strong><?= $this->text->e($subtask['status_name']) ?></strong>)
+            <?= $this->text->e($subtask['title']) ?> (<strong><?= $this->text->e(t($subtask['status_name'])) ?></strong>)
         </li>
         <li>
             <?php if ($subtask['username']): ?>


### PR DESCRIPTION
This PR moves the translation of subtask status strings to on-demand when it needs to be displayed to the user in order to fix #4476.

Tested and working for:

- RSS feed
- JSON-RPC
- Last activity feed
- Exports (subtask exports, csv)

Let me know if I missed anything!



Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression
- [x] I follow existing [coding style](https://docs.kanboard.org/en/latest/developer_guide/coding_standards.html)

