### PR TITLE
Use a HMAC to sign and validate CSRF tokens, instead of generating random  ones and storing them in the session data.

### DIFF
--- a/app/Core/Security/Token.php
+++ b/app/Core/Security/Token.php
@@ -12,6 +12,11 @@ use Kanboard\Core\Base;
  */
 class Token extends Base
 {
+    protected static $KEY_LENGTH = 32;
+    protected static $NONCE_LENGTH = 16;
+    protected static $HMAC_ALGO = 'sha256';
+    protected static $HMAC_LENGTH = 16;
+
     /**
      * Generate a random token with different methods: openssl or /dev/urandom or fallback to uniqid()
      *
@@ -19,9 +24,9 @@ class Token extends Base
      * @access public
      * @return string  Random token
      */
-    public static function getToken()
+    public static function getToken($length = 30)
     {
-        return bin2hex(random_bytes(30));
+        return bin2hex(random_bytes($length));
     }
 
     /**
@@ -55,35 +60,72 @@ class Token extends Base
      */
     public function validateCSRFToken($token)
     {
-        $tokens = session_get('csrf');
-        if (isset($tokens[$token])) {
-            unset($tokens[$token]);
-            session_set('csrf', $tokens);
-            return true;
-        }
-
-        return false;
+        return $this->validateSessionToken('csrf', $token);
     }
 
+    /**
+     * Check if the token exists as a reusable CSRF token
+     *
+     * @access public
+     * @param  string   $token   CSRF token
+     * @return bool
+     */
     public function validateReusableCSRFToken($token)
     {
-        $tokens = session_get('pcsrf');
-        if (isset($tokens[$token])) {
-            return true;
-        }
-
-        return false;
+        return $this->validateSessionToken('pcsrf', $token);
     }
 
-    protected function createSessionToken($key)
+    /**
+     * Generate a session token of the given type
+     *
+     * @access protected
+     * @param  string   $type    Token type
+     * @return string  Random token
+     */
+    protected function createSessionToken($type)
     {
-        if (! session_exists($key)) {
-            session_set($key, []);
-        }
+        $nonce = self::getToken(self::$NONCE_LENGTH);
+        return $nonce . $this->signSessionToken($type, $nonce);
+    }
 
-        $nonce = self::getToken();
-        session_merge($key, [$nonce => true]);
+    /**
+     * Check a session token of the given type
+     *
+     * @access protected
+     * @param  string   $type    Token type
+     * @param  string   $token   Session token
+     * @return bool
+     */
+    protected function validateSessionToken($type, $token)
+    {
+        if (!is_string($token))
+            return false;
+        if (strlen($token) != (self::$NONCE_LENGTH + self::$HMAC_LENGTH) * 2)
+            return false;
 
-        return $nonce;
+        $nonce = substr($token, 0, self::$NONCE_LENGTH * 2);
+        $hmac = substr($token, self::$NONCE_LENGTH * 2, self::$HMAC_LENGTH * 2);
+
+        return hash_equals($this->signSessionToken($type, $nonce), $hmac);
+    }
+
+    /**
+     * Sign a nonce with the key belonging to the given type
+     *
+     * @access protected
+     * @param  string   $type    Token type
+     * @param  string   $nonce   Nonce to sign
+     * @return string
+     */
+    protected function signSessionToken($type, $nonce)
+    {
+        if (!session_exists($type . '_key'))
+            session_set($type . '_key', self::getToken(self::$KEY_LENGTH));
+
+        $data = $nonce . '-' . session_id();
+        $key = session_get($type . '_key');
+        $hmac = hash_hmac(self::$HMAC_ALGO, $data, $key, true);
+
+        return bin2hex(substr($hmac, 0, self::$HMAC_LENGTH));
     }
 }


### PR DESCRIPTION
Reduces number of writes to sessions table and fixes kanboard issue #4942.

Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I follow existing [coding style](https://docs.kanboard.org/en/latest/developer_guide/coding_standards.html)

