### PR TITLE
tests: port assertEquals() with delta to assertEqualsWithDelta()

### DIFF
--- a/tests/units/Action/TaskUpdateStartDateTest.php
+++ b/tests/units/Action/TaskUpdateStartDateTest.php
@@ -36,7 +36,7 @@ class TaskUpdateStartDateTest extends Base
 
         $task = $taskFinderModel->getById(1);
         $this->assertNotEmpty($task);
-        $this->assertEquals(time(), $task['date_started'], 'Date started delta', 2);
+        $this->assertEqualsWithDelta(time(), $task['date_started'], 2, 'Date started delta');
     }
 
     public function testWithWrongColumn()

--- a/tests/units/Analytic/AverageLeadCycleTimeAnalyticTest.php
+++ b/tests/units/Analytic/AverageLeadCycleTimeAnalyticTest.php
@@ -43,10 +43,10 @@ class AverageLeadCycleTimeAnalyticTest extends Base
         $stats = $averageLeadCycleTimeAnalytic->build(1);
 
         $this->assertEquals(5, $stats['count']);
-        $this->assertEquals(3600 + 1800 + 3600 + 2*3600, $stats['total_lead_time'], '', 10);
-        $this->assertEquals(1800 + 900, $stats['total_cycle_time'], '', 5);
-        $this->assertEquals((3600 + 1800 + 3600 + 2*3600) / 5, $stats['avg_lead_time'], '', 5);
-        $this->assertEquals((1800 + 900) / 5, $stats['avg_cycle_time'], '', 5);
+        $this->assertEqualsWithDelta(3600 + 1800 + 3600 + 2 * 3600, $stats['total_lead_time'], 10, '');
+        $this->assertEqualsWithDelta(1800 + 900, $stats['total_cycle_time'], 5, '');
+        $this->assertEqualsWithDelta((3600 + 1800 + 3600 + 2 * 3600) / 5, $stats['avg_lead_time'], 5, '');
+        $this->assertEqualsWithDelta((1800 + 900) / 5, $stats['avg_cycle_time'], 5, '');
     }
 
     public function testBuildWithNoTasks()

--- a/tests/units/Analytic/AverageTimeSpentColumnAnalyticTest.php
+++ b/tests/units/Analytic/AverageTimeSpentColumnAnalyticTest.php
@@ -30,23 +30,23 @@ class AverageTimeSpentColumnAnalyticTest extends Base
         $stats = $averageLeadCycleTimeAnalytic->build(1);
 
         $this->assertEquals(2, $stats[1]['count']);
-        $this->assertEquals(3600+1800, $stats[1]['time_spent'], '', 3);
-        $this->assertEquals((int) ((3600+1800)/2), $stats[1]['average'], '', 3);
+        $this->assertEqualsWithDelta(3600 + 1800, $stats[1]['time_spent'], 3, '');
+        $this->assertEqualsWithDelta((int)((3600 + 1800) / 2), $stats[1]['average'], 3, '');
         $this->assertEquals('Backlog', $stats[1]['title']);
 
         $this->assertEquals(0, $stats[2]['count']);
-        $this->assertEquals(0, $stats[2]['time_spent'], '', 3);
-        $this->assertEquals(0, $stats[2]['average'], '', 3);
+        $this->assertEqualsWithDelta(0, $stats[2]['time_spent'], 3, '');
+        $this->assertEqualsWithDelta(0, $stats[2]['average'], 3, '');
         $this->assertEquals('Ready', $stats[2]['title']);
 
         $this->assertEquals(0, $stats[3]['count']);
-        $this->assertEquals(0, $stats[3]['time_spent'], '', 3);
-        $this->assertEquals(0, $stats[3]['average'], '', 3);
+        $this->assertEqualsWithDelta(0, $stats[3]['time_spent'], 3, '');
+        $this->assertEqualsWithDelta(0, $stats[3]['average'], 3, '');
         $this->assertEquals('Work in progress', $stats[3]['title']);
 
         $this->assertEquals(0, $stats[4]['count']);
-        $this->assertEquals(0, $stats[4]['time_spent'], '', 3);
-        $this->assertEquals(0, $stats[4]['average'], '', 3);
+        $this->assertEqualsWithDelta(0, $stats[4]['time_spent'], 3, '');
+        $this->assertEqualsWithDelta(0, $stats[4]['average'], 3, '');
         $this->assertEquals('Done', $stats[4]['title']);
     }
 
@@ -79,23 +79,23 @@ class AverageTimeSpentColumnAnalyticTest extends Base
         $stats = $averageLeadCycleTimeAnalytic->build(1);
 
         $this->assertEquals(2, $stats[1]['count']);
-        $this->assertEquals(3600+1800, $stats[1]['time_spent'], '', 3);
-        $this->assertEquals((int) ((3600+1800)/2), $stats[1]['average'], '', 3);
+        $this->assertEqualsWithDelta(3600 + 1800, $stats[1]['time_spent'], 3, '');
+        $this->assertEqualsWithDelta((int)((3600 + 1800) / 2), $stats[1]['average'], 3, '');
         $this->assertEquals('Backlog', $stats[1]['title']);
 
         $this->assertEquals(0, $stats[2]['count']);
-        $this->assertEquals(0, $stats[2]['time_spent'], '', 3);
-        $this->assertEquals(0, $stats[2]['average'], '', 3);
+        $this->assertEqualsWithDelta(0, $stats[2]['time_spent'], 3, '');
+        $this->assertEqualsWithDelta(0, $stats[2]['average'], 3, '');
         $this->assertEquals('Ready', $stats[2]['title']);
 
         $this->assertEquals(2, $stats[3]['count']);
-        $this->assertEquals(1800, $stats[3]['time_spent'], '', 3);
-        $this->assertEquals(900, $stats[3]['average'], '', 3);
+        $this->assertEqualsWithDelta(1800, $stats[3]['time_spent'], 3, '');
+        $this->assertEqualsWithDelta(900, $stats[3]['average'], 3, '');
         $this->assertEquals('Work in progress', $stats[3]['title']);
 
         $this->assertEquals(0, $stats[4]['count']);
-        $this->assertEquals(0, $stats[4]['time_spent'], '', 3);
-        $this->assertEquals(0, $stats[4]['average'], '', 3);
+        $this->assertEqualsWithDelta(0, $stats[4]['time_spent'], 3, '');
+        $this->assertEqualsWithDelta(0, $stats[4]['average'], 3, '');
         $this->assertEquals('Done', $stats[4]['title']);
     }
 }

--- a/tests/units/Model/CommentModelTest.php
+++ b/tests/units/Model/CommentModelTest.php
@@ -25,8 +25,8 @@ class CommentModelTest extends Base
         $this->assertEquals(1, $comment['task_id']);
         $this->assertEquals(1, $comment['user_id']);
         $this->assertEquals('admin', $comment['username']);
-        $this->assertEquals(time(), $comment['date_creation'], '', 3);
-        $this->assertEquals(time(), $comment['date_modification'], '', 3);
+        $this->assertEqualsWithDelta(time(), $comment['date_creation'], 3, '');
+        $this->assertEqualsWithDelta(time(), $comment['date_modification'], 3, '');
 
         $comment = $commentModel->getById(2);
         $this->assertNotEmpty($comment);
@@ -34,8 +34,8 @@ class CommentModelTest extends Base
         $this->assertEquals(1, $comment['task_id']);
         $this->assertEquals(0, $comment['user_id']);
         $this->assertEquals('', $comment['username']);
-        $this->assertEquals(time(), $comment['date_creation'], '', 3);
-        $this->assertEquals(time(), $comment['date_modification'], '', 3);
+        $this->assertEqualsWithDelta(time(), $comment['date_creation'], 3, '');
+        $this->assertEqualsWithDelta(time(), $comment['date_modification'], 3, '');
     }
 
     public function testGetAll()
@@ -75,7 +75,7 @@ class CommentModelTest extends Base
         $comment = $commentModel->getById(1);
         $this->assertNotEmpty($comment);
         $this->assertEquals('bla', $comment['comment']);
-        $this->assertEquals(time(), $comment['date_modification'], '', 3);
+        $this->assertEqualsWithDelta(time(), $comment['date_modification'], 3, '');
     }
 
     public function testRemove()

--- a/tests/units/Model/ProjectActivityTest.php
+++ b/tests/units/Model/ProjectActivityTest.php
@@ -28,7 +28,7 @@ class ProjectActivityTest extends Base
         $events = $projectActivity->getQuery()->desc('id')->findAll();
 
         $this->assertCount(2, $events);
-        $this->assertEquals(time(), $events[0]['date_creation'], '', 1);
+        $this->assertEqualsWithDelta(time(), $events[0]['date_creation'], 1, '');
         $this->assertEquals(TaskModel::EVENT_UPDATE, $events[0]['event_name']);
         $this->assertEquals(TaskModel::EVENT_CLOSE, $events[1]['event_name']);
     }

--- a/tests/units/Model/ProjectDailyStatsTest.php
+++ b/tests/units/Model/ProjectDailyStatsTest.php
@@ -45,10 +45,10 @@ class ProjectDailyStatsTest extends Base
         $this->assertEquals($expected[0]['day'], $metrics[0]['day']);
         $this->assertEquals($expected[1]['day'], $metrics[1]['day']);
 
-        $this->assertEquals($expected[0]['avg_lead_time'], $metrics[0]['avg_lead_time'], '', 5);
-        $this->assertEquals($expected[1]['avg_lead_time'], $metrics[1]['avg_lead_time'], '', 5);
+        $this->assertEqualsWithDelta($expected[0]['avg_lead_time'], $metrics[0]['avg_lead_time'], 5, '');
+        $this->assertEqualsWithDelta($expected[1]['avg_lead_time'], $metrics[1]['avg_lead_time'], 5, '');
 
-        $this->assertEquals($expected[0]['avg_cycle_time'], $metrics[0]['avg_cycle_time'], '', 5);
-        $this->assertEquals($expected[1]['avg_cycle_time'], $metrics[1]['avg_cycle_time'], '', 5);
+        $this->assertEqualsWithDelta($expected[0]['avg_cycle_time'], $metrics[0]['avg_cycle_time'], 5, '');
+        $this->assertEqualsWithDelta($expected[1]['avg_cycle_time'], $metrics[1]['avg_cycle_time'], 5, '');
     }
 }

--- a/tests/units/Model/ProjectFileTest.php
+++ b/tests/units/Model/ProjectFileTest.php
@@ -20,7 +20,7 @@ class ProjectFileTest extends Base
         $this->assertEquals('/tmp/foo', $file['path']);
         $this->assertEquals(0, $file['is_image']);
         $this->assertEquals(1, $file['project_id']);
-        $this->assertEquals(time(), $file['date'], '', 2);
+        $this->assertEqualsWithDelta(time(), $file['date'], 2, '');
         $this->assertEquals(0, $file['user_id']);
         $this->assertEquals(10, $file['size']);
 
@@ -168,7 +168,7 @@ class ProjectFileTest extends Base
         $this->assertEquals(1, $files[0]['project_id']);
         $this->assertEquals(0, $files[0]['user_id']);
         $this->assertEquals(123, $files[0]['size']);
-        $this->assertEquals(time(), $files[0]['date'], '', 2);
+        $this->assertEqualsWithDelta(time(), $files[0]['date'], 2, '');
 
         $this->assertEquals(2, $files[1]['id']);
         $this->assertEquals('file2.doc', $files[1]['name']);
@@ -176,7 +176,7 @@ class ProjectFileTest extends Base
         $this->assertEquals(1, $files[1]['project_id']);
         $this->assertEquals(0, $files[1]['user_id']);
         $this->assertEquals(456, $files[1]['size']);
-        $this->assertEquals(time(), $files[1]['date'], '', 2);
+        $this->assertEqualsWithDelta(time(), $files[1]['date'], 2, '');
     }
 
     public function testUploadFilesWithEmptyFiles()
@@ -270,7 +270,7 @@ class ProjectFileTest extends Base
         $this->assertEquals(1, $files[0]['project_id']);
         $this->assertEquals(0, $files[0]['user_id']);
         $this->assertEquals(4, $files[0]['size']);
-        $this->assertEquals(time(), $files[0]['date'], '', 2);
+        $this->assertEqualsWithDelta(time(), $files[0]['date'], 2, '');
     }
 
     public function testUploadImageContent()
@@ -306,6 +306,6 @@ class ProjectFileTest extends Base
         $this->assertEquals(1, $files[0]['project_id']);
         $this->assertEquals(0, $files[0]['user_id']);
         $this->assertEquals(4, $files[0]['size']);
-        $this->assertEquals(time(), $files[0]['date'], '', 2);
+        $this->assertEqualsWithDelta(time(), $files[0]['date'], 2, '');
     }
 }

--- a/tests/units/Model/ProjectModelTest.php
+++ b/tests/units/Model/ProjectModelTest.php
@@ -45,7 +45,7 @@ class ProjectModelTest extends Base
         $this->assertEquals(0, $project['is_private']);
         $this->assertEquals(0, $project['per_swimlane_task_limits']);
         $this->assertEquals(0, $project['task_limit']);
-        $this->assertEquals(time(), $project['last_modified'], '', 1);
+        $this->assertEqualsWithDelta(time(), $project['last_modified'], 1, '');
         $this->assertEmpty($project['token']);
         $this->assertEmpty($project['start_date']);
         $this->assertEmpty($project['end_date']);
@@ -191,7 +191,7 @@ class ProjectModelTest extends Base
 
         $project = $projectModel->getById(1);
         $this->assertNotEmpty($project);
-        $this->assertEquals($now, $project['last_modified'], 'Wrong Timestamp', 1);
+        $this->assertEqualsWithDelta($now, $project['last_modified'], 1, 'Wrong Timestamp');
 
         sleep(1);
         $this->assertTrue($projectModel->updateModificationDate(1));

--- a/tests/units/Model/SubtaskTimeTrackingModelTest.php
+++ b/tests/units/Model/SubtaskTimeTrackingModelTest.php
@@ -38,7 +38,7 @@ class SubtaskTimeTrackingModelTest extends Base
         $subtaskTimeTrackingModel = new SubtaskTimeTrackingModel($this->container);
         $projectModel = new ProjectModel($this->container);
 
-        $this->assertEquals(1, $projectModel->create(array('name' => 'test1')));
+        $this->assertEquals(1, $projectModel->create(array('name' => 'test1')), 1);
         $this->assertEquals(1, $taskCreationModel->create(array('title' => 'test 1', 'project_id' => 1, 'column_id' => 1, 'owner_id' => 1)));
         $this->assertEquals(1, $subtaskModel->create(array('title' => 'subtask #2', 'task_id' => 1, 'user_id' => 1)));
 
@@ -95,12 +95,12 @@ class SubtaskTimeTrackingModelTest extends Base
 
         $subtasks = $subtaskModel->getAll(1);
         $this->assertNotEmpty($subtasks);
-        $this->assertEquals(time(), $subtasks[0]['timer_start_date'], '', 3);
+        $this->assertEqualsWithDelta(time(), $subtasks[0]['timer_start_date'], 3, '');
         $this->assertTrue($subtasks[0]['is_timer_started']);
 
         $subtask = $subtaskModel->getByIdWithDetails(1);
         $this->assertNotEmpty($subtask);
-        $this->assertEquals(time(), $subtask['timer_start_date'], '', 3);
+        $this->assertEqualsWithDelta(time(), $subtask['timer_start_date'], 3, '');
         $this->assertTrue($subtask['is_timer_started']);
 
         // Stop the clock
@@ -183,8 +183,8 @@ class SubtaskTimeTrackingModelTest extends Base
 
         $time = $subtaskTimeTrackingModel->calculateSubtaskTime(1);
         $this->assertCount(2, $time);
-        $this->assertEquals(3.3, $time['time_spent'], 'Total spent', 0.01);
-        $this->assertEquals(7.7, $time['time_estimated'], 'Total estimated', 0.01);
+        $this->assertEqualsWithDelta(3.3, $time['time_spent'], 0.01, 'Total spent');
+        $this->assertEqualsWithDelta(7.7, $time['time_estimated'], 0.01, 'Total estimated');
     }
 
     public function testUpdateSubtaskTimeSpent()
@@ -211,16 +211,16 @@ class SubtaskTimeTrackingModelTest extends Base
         $timesheet = $subtaskTimeTrackingModel->getUserTimesheet(1);
         $this->assertNotEmpty($timesheet);
         $this->assertCount(2, $timesheet);
-        $this->assertEquals(3600, $timesheet[0]['end'] - $timesheet[0]['start'], 'Wrong timestamps', 1);
-        $this->assertEquals(3600, $timesheet[1]['end'] - $timesheet[1]['start'], 'Wrong timestamps', 1);
+        $this->assertEqualsWithDelta(3600, $timesheet[0]['end'] - $timesheet[0]['start'], 1, 'Wrong timestamps');
+        $this->assertEqualsWithDelta(3600, $timesheet[1]['end'] - $timesheet[1]['start'], 1, 'Wrong timestamps');
 
         $time = $subtaskTimeTrackingModel->calculateSubtaskTime(1);
-        $this->assertEquals(4.2, $time['time_spent'], 'Total spent', 0.01);
-        $this->assertEquals(0, $time['time_estimated'], 'Total estimated', 0.01);
+        $this->assertEqualsWithDelta(4.2, $time['time_spent'], 0.01, 'Total spent');
+        $this->assertEqualsWithDelta(0, $time['time_estimated'], 0.01, 'Total estimated');
 
         $time = $subtaskTimeTrackingModel->calculateSubtaskTime(2);
-        $this->assertEquals(0, $time['time_spent'], 'Total spent', 0.01);
-        $this->assertEquals(0, $time['time_estimated'], 'Total estimated', 0.01);
+        $this->assertEqualsWithDelta(0, $time['time_spent'], 0.01, 'Total spent');
+        $this->assertEqualsWithDelta(0, $time['time_estimated'], 0.01, 'Total estimated');
     }
 
     public function testUpdateTaskTimeTracking()
@@ -251,13 +251,13 @@ class SubtaskTimeTrackingModelTest extends Base
 
         $task = $taskFinderModel->getById(1);
         $this->assertNotEmpty($task);
-        $this->assertEquals(2.2, $task['time_spent'], 'Total spent', 0.01);
-        $this->assertEquals(1, $task['time_estimated'], 'Total estimated', 0.01);
+        $this->assertEqualsWithDelta(2.2, $task['time_spent'], 0.01, 'Total spent');
+        $this->assertEqualsWithDelta(1, $task['time_estimated'], 0.01, 'Total estimated');
 
         $task = $taskFinderModel->getById(2);
         $this->assertNotEmpty($task);
-        $this->assertEquals(3.4, $task['time_spent'], 'Total spent', 0.01);
-        $this->assertEquals(1.25, $task['time_estimated'], 'Total estimated', 0.01);
+        $this->assertEqualsWithDelta(3.4, $task['time_spent'], 0.01, 'Total spent');
+        $this->assertEqualsWithDelta(1.25, $task['time_estimated'], 0.01, 'Total estimated');
 
         $task = $taskFinderModel->getById(3);
         $this->assertNotEmpty($task);

--- a/tests/units/Model/TaskCreationModelTest.php
+++ b/tests/units/Model/TaskCreationModelTest.php
@@ -73,8 +73,8 @@ class TaskCreationModelTest extends Base
         $this->assertEquals('', $task['description']);
         $this->assertEquals('', $task['reference']);
 
-        $this->assertEquals(time(), $task['date_creation'], 'Wrong timestamp', 1);
-        $this->assertEquals(time(), $task['date_modification'], 'Wrong timestamp', 1);
+        $this->assertEqualsWithDelta(time(), $task['date_creation'], 1, 'Wrong timestamp');
+        $this->assertEqualsWithDelta(time(), $task['date_modification'], 1, 'Wrong timestamp');
         $this->assertEquals(0, $task['date_due']);
         $this->assertEquals(0, $task['date_completed']);
         $this->assertEquals(0, $task['date_started']);
@@ -302,7 +302,7 @@ class TaskCreationModelTest extends Base
         $this->assertEquals(4, $taskCreationModel->create(array('project_id' => 1, 'title' => 'test', 'date_started' => time())));
 
         $task = $taskFinderModel->getById(4);
-        $this->assertEquals(time(), $task['date_started'], '', 1);
+        $this->assertEqualsWithDelta(time(), $task['date_started'], 1, '');
 
         // Set empty string
         $this->assertEquals(5, $taskCreationModel->create(array('project_id' => 1, 'title' => 'test', 'date_started' => '')));

--- a/tests/units/Model/TaskExternalLinkTest.php
+++ b/tests/units/Model/TaskExternalLinkTest.php
@@ -27,8 +27,8 @@ class TaskExternalLinkTest extends Base
         $this->assertEquals('related', $link['dependency']);
         $this->assertEquals('weblink', $link['link_type']);
         $this->assertEquals(0, $link['creator_id']);
-        $this->assertEquals(time(), $link['date_modification'], '', 2);
-        $this->assertEquals(time(), $link['date_creation'], '', 2);
+        $this->assertEqualsWithDelta(time(), $link['date_modification'], 2, '');
+        $this->assertEqualsWithDelta(time(), $link['date_creation'], 2, '');
     }
 
     public function testCreateWithUserSession()
@@ -50,8 +50,8 @@ class TaskExternalLinkTest extends Base
         $this->assertEquals('related', $link['dependency']);
         $this->assertEquals('weblink', $link['link_type']);
         $this->assertEquals(1, $link['creator_id']);
-        $this->assertEquals(time(), $link['date_modification'], '', 2);
-        $this->assertEquals(time(), $link['date_creation'], '', 2);
+        $this->assertEqualsWithDelta(time(), $link['date_modification'], 2, '');
+        $this->assertEqualsWithDelta(time(), $link['date_creation'], 2, '');
     }
 
     public function testModification()
@@ -71,7 +71,7 @@ class TaskExternalLinkTest extends Base
         $link = $taskExternalLinkModel->getById(1);
         $this->assertNotEmpty($link);
         $this->assertEquals('https://kanboard.org/', $link['url']);
-        $this->assertEquals(time(), $link['date_modification'], '', 2);
+        $this->assertEqualsWithDelta(time(), $link['date_modification'], 2, '');
     }
 
     public function testRemove()

--- a/tests/units/Model/TaskFileModelTest.php
+++ b/tests/units/Model/TaskFileModelTest.php
@@ -24,7 +24,7 @@ class TaskFileModelTest extends Base
         $this->assertEquals('/tmp/foo', $file['path']);
         $this->assertEquals(0, $file['is_image']);
         $this->assertEquals(1, $file['task_id']);
-        $this->assertEquals(time(), $file['date'], '', 2);
+        $this->assertEqualsWithDelta(time(), $file['date'], 2, '');
         $this->assertEquals(0, $file['user_id']);
         $this->assertEquals(10, $file['size']);
 
@@ -195,7 +195,7 @@ class TaskFileModelTest extends Base
         $this->assertEquals(1, $files[0]['task_id']);
         $this->assertEquals(0, $files[0]['user_id']);
         $this->assertEquals(123, $files[0]['size']);
-        $this->assertEquals(time(), $files[0]['date'], '', 2);
+        $this->assertEqualsWithDelta(time(), $files[0]['date'], 2, '');
 
         $this->assertEquals(2, $files[1]['id']);
         $this->assertEquals('file2.doc', $files[1]['name']);
@@ -203,7 +203,7 @@ class TaskFileModelTest extends Base
         $this->assertEquals(1, $files[1]['task_id']);
         $this->assertEquals(0, $files[1]['user_id']);
         $this->assertEquals(456, $files[1]['size']);
-        $this->assertEquals(time(), $files[1]['date'], '', 2);
+        $this->assertEqualsWithDelta(time(), $files[1]['date'], 2, '');
     }
 
     public function testUploadFilesWithEmptyFiles()
@@ -299,7 +299,7 @@ class TaskFileModelTest extends Base
         $this->assertEquals(1, $files[0]['task_id']);
         $this->assertEquals(0, $files[0]['user_id']);
         $this->assertEquals(4, $files[0]['size']);
-        $this->assertEquals(time(), $files[0]['date'], '', 2);
+        $this->assertEqualsWithDelta(time(), $files[0]['date'], 2, '');
     }
 
     public function testUploadFileContentWithObjectStorageError()

--- a/tests/units/Model/TaskFinderModelTest.php
+++ b/tests/units/Model/TaskFinderModelTest.php
@@ -33,9 +33,9 @@ class TaskFinderModelTest extends Base
         $this->assertEquals('test', $task['reference']);
         $this->assertEquals('Task #1', $task['title']);
         $this->assertEquals('desc', $task['description']);
-        $this->assertEquals(time(), $task['date_creation'], 'Delta', 1);
-        $this->assertEquals(time(), $task['date_modification'], 'Delta', 1);
-        $this->assertEquals(time(), $task['date_moved'], 'Delta', 1);
+        $this->assertEqualsWithDelta(time(), $task['date_creation'], 1, 'Delta');
+        $this->assertEqualsWithDelta(time(), $task['date_modification'], 1, 'Delta');
+        $this->assertEqualsWithDelta(time(), $task['date_moved'], 1, 'Delta');
         $this->assertEquals(0, $task['date_completed']);
         $this->assertEquals(0, $task['date_due']);
         $this->assertEquals(0, $task['date_started']);

--- a/tests/units/Model/TaskModificationModelTest.php
+++ b/tests/units/Model/TaskModificationModelTest.php
@@ -240,7 +240,7 @@ class TaskModificationModelTest extends Base
         $this->assertTrue($taskModificationModel->update(array('id' => 1, 'date_started' => time())));
 
         $task = $taskFinderModel->getById(1);
-        $this->assertEquals(time(), $task['date_started'], '', 1);
+        $this->assertEqualsWithDelta(time(), $task['date_started'], 1, '');
     }
 
     public function testChangeTimeEstimated()

--- a/tests/units/Model/TaskRecurrenceModelTest.php
+++ b/tests/units/Model/TaskRecurrenceModelTest.php
@@ -54,27 +54,27 @@ class TaskRecurrenceModelTest extends Base
 
         $values = array('date_due' => 1431291376, 'recurrence_factor' => 1, 'recurrence_basedate' => TaskModel::RECURRING_BASEDATE_TRIGGERDATE, 'recurrence_timeframe' => TaskModel::RECURRING_TIMEFRAME_DAYS);
         $taskRecurrenceModel->calculateRecurringTaskDueDate($values);
-        $this->assertEquals(time() + 86400, $values['date_due'], '', 1);
+        $this->assertEqualsWithDelta(time() + 86400, $values['date_due'], 1, '');
 
         $values = array('date_due' => 1431291376, 'recurrence_factor' => -2, 'recurrence_basedate' => TaskModel::RECURRING_BASEDATE_TRIGGERDATE, 'recurrence_timeframe' => TaskModel::RECURRING_TIMEFRAME_DAYS);
         $taskRecurrenceModel->calculateRecurringTaskDueDate($values);
-        $this->assertEquals(time() - 2 * 86400, $values['date_due'], '', 1);
+        $this->assertEqualsWithDelta(time() - 2 * 86400, $values['date_due'], 1, '');
 
         $values = array('date_due' => 1431291376, 'recurrence_factor' => 1, 'recurrence_basedate' => TaskModel::RECURRING_BASEDATE_DUEDATE, 'recurrence_timeframe' => TaskModel::RECURRING_TIMEFRAME_DAYS);
         $taskRecurrenceModel->calculateRecurringTaskDueDate($values);
-        $this->assertEquals(1431291376 + 86400, $values['date_due'], '', 1);
+        $this->assertEqualsWithDelta(1431291376 + 86400, $values['date_due'], 1, '');
 
         $values = array('date_due' => 1431291376, 'recurrence_factor' => -1, 'recurrence_basedate' => TaskModel::RECURRING_BASEDATE_DUEDATE, 'recurrence_timeframe' => TaskModel::RECURRING_TIMEFRAME_DAYS);
         $taskRecurrenceModel->calculateRecurringTaskDueDate($values);
-        $this->assertEquals(1431291376 - 86400, $values['date_due'], '', 1);
+        $this->assertEqualsWithDelta(1431291376 - 86400, $values['date_due'], 1, '');
 
         $values = array('date_due' => 1431291376, 'recurrence_factor' => 2, 'recurrence_basedate' => TaskModel::RECURRING_BASEDATE_DUEDATE, 'recurrence_timeframe' => TaskModel::RECURRING_TIMEFRAME_MONTHS);
         $taskRecurrenceModel->calculateRecurringTaskDueDate($values);
-        $this->assertEquals(1436561776, $values['date_due'], '', 1);
+        $this->assertEqualsWithDelta(1436561776, $values['date_due'], 1, '');
 
         $values = array('date_due' => 1431291376, 'recurrence_factor' => 2, 'recurrence_basedate' => TaskModel::RECURRING_BASEDATE_DUEDATE, 'recurrence_timeframe' => TaskModel::RECURRING_TIMEFRAME_YEARS);
         $taskRecurrenceModel->calculateRecurringTaskDueDate($values);
-        $this->assertEquals(1494449776, $values['date_due'], '', 1);
+        $this->assertEqualsWithDelta(1494449776, $values['date_due'], 1, '');
     }
 
     public function testDuplicateRecurringTask()
@@ -106,7 +106,7 @@ class TaskRecurrenceModelTest extends Base
         $this->assertNotEmpty($task);
         $this->assertEquals(TaskModel::RECURRING_STATUS_PROCESSED, $task['recurrence_status']);
         $this->assertEquals(2, $task['recurrence_child']);
-        $this->assertEquals(1436561776, $task['date_due'], '', 2);
+        $this->assertEqualsWithDelta(1436561776, $task['date_due'], 2, '');
 
         $task = $taskFinderModel->getById(2);
         $this->assertNotEmpty($task);
@@ -116,7 +116,7 @@ class TaskRecurrenceModelTest extends Base
         $this->assertEquals(TaskModel::RECURRING_BASEDATE_TRIGGERDATE, $task['recurrence_basedate']);
         $this->assertEquals(1, $task['recurrence_parent']);
         $this->assertEquals(2, $task['recurrence_factor']);
-        $this->assertEquals(strtotime('+2 days'), $task['date_due'], '', 2);
+        $this->assertEqualsWithDelta(strtotime('+2 days'), $task['date_due'], 2, '');
 
         $tags = $taskTagModel->getList(2);
         $this->assertCount(2, $tags);

--- a/tests/units/Model/TaskStatusModelTest.php
+++ b/tests/units/Model/TaskStatusModelTest.php
@@ -72,7 +72,7 @@ class TaskStatusModelTest extends Base
         $this->assertNotEmpty($task);
         $this->assertEquals(TaskModel::STATUS_OPEN, $task['is_active']);
         $this->assertEquals(0, $task['date_completed']);
-        $this->assertEquals(time(), $task['date_modification'], '', 1);
+        $this->assertEqualsWithDelta(time(), $task['date_modification'], 1, '');
 
         // We close the task
 
@@ -85,8 +85,8 @@ class TaskStatusModelTest extends Base
         $task = $taskFinderModel->getById(1);
         $this->assertNotEmpty($task);
         $this->assertEquals(TaskModel::STATUS_CLOSED, $task['is_active']);
-        $this->assertEquals(time(), $task['date_completed'], 'Bad completion timestamp', 1);
-        $this->assertEquals(time(), $task['date_modification'], 'Bad modification timestamp', 1);
+        $this->assertEqualsWithDelta(time(), $task['date_completed'], 1, 'Bad completion timestamp');
+        $this->assertEqualsWithDelta(time(), $task['date_modification'], 1, 'Bad modification timestamp');
 
         // We open the task again
 
@@ -97,7 +97,7 @@ class TaskStatusModelTest extends Base
         $this->assertNotEmpty($task);
         $this->assertEquals(TaskModel::STATUS_OPEN, $task['is_active']);
         $this->assertEquals(0, $task['date_completed']);
-        $this->assertEquals(time(), $task['date_modification'], '', 1);
+        $this->assertEqualsWithDelta(time(), $task['date_modification'], 1, '');
 
         $called = $this->container['dispatcher']->getCalledListeners();
         $this->assertCount(2, $called);

--- a/tests/units/Model/TransitionTest.php
+++ b/tests/units/Model/TransitionTest.php
@@ -34,7 +34,7 @@ class TransitionTest extends Base
         $this->assertEquals('', $transitions[0]['name']);
         $this->assertEquals('admin', $transitions[0]['username']);
         $this->assertEquals(1, $transitions[0]['user_id']);
-        $this->assertEquals(time(), $transitions[0]['date'], '', 3);
+        $this->assertEqualsWithDelta(time(), $transitions[0]['date'], 3, '');
         $this->assertEquals(3600, $transitions[0]['time_spent']);
     }
 


### PR DESCRIPTION
assertEquals() in phpunit 9.5 no longer takes a delta parameter and has assertEqualsWithDelta() as a replacement. This means float get compared without a delta atm, and a recent phpunit release (9.5.25) has made float comparisons stricter resulting in test suite errors such as:

1) SubtaskTimeTrackingModelTest::testCalculateSubtaskTime Total spent
Failed asserting that 3.3000000000000003 matches expected 3.3. tests/units/Model/SubtaskTimeTrackingModelTest.php:186

This replaces all assertEquals() calls that pass a delta value with assertEqualsWithDelta().

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression
- [x] I follow existing [coding style](https://docs.kanboard.org/en/latest/developer_guide/coding_standards.html)

