### PR TITLE
Issue with #4830

### DIFF
--- a/app/User/Avatar/AvatarFileProvider.php
+++ b/app/User/Avatar/AvatarFileProvider.php
@@ -23,7 +23,7 @@ class AvatarFileProvider extends Base implements AvatarProviderInterface
      */
     public function render(array $user, $size)
     {
-        $url = $this->helper->url->href('AvatarFileController', 'image', array('user_id' => $user['id'], 'hash' => md5($user['avatar_path'].$size), 'size' => $size));
+        $url = $this->helper->url->href('AvatarFileController', 'image', array('user_id' => $user['id'], 'hash' => md5($user['avatar_path']), 'size' => $size));
         $title = $this->helper->text->e($user['name'] ?: $user['username']);
         return '<img src="' . $url . '" alt="' . $title . '" title="' . $title . '">';
     }

--- a/tests/units/Formatter/UserMentionFormatterTest.php
+++ b/tests/units/Formatter/UserMentionFormatterTest.php
@@ -29,7 +29,7 @@ class UserMentionFormatterTest extends Base
         $expected = array(
             array(
                 'value' => 'someone',
-                'html' => '<div class="avatar avatar-20 avatar-inline"><img src="?controller=AvatarFileController&amp;action=image&amp;user_id=1&amp;hash=871b0146d6689014b79b878c7b120151&amp;size=20" alt="Someone" title="Someone"></div> someone <small aria-hidden="true">Someone</small>',
+                'html' => '<div class="avatar avatar-20 avatar-inline"><img src="?controller=AvatarFileController&amp;action=image&amp;user_id=1&amp;hash=5acc03af0274414544b9615fb223d925&amp;size=20" alt="Someone" title="Someone"></div> someone <small aria-hidden="true">Someone</small>',
             ),
             array(
                 'value' => 'somebody',


### PR DESCRIPTION
The added `.$size`  in `'hash' => md5($user['avatar_path'].$size` appears to be incorrectly showing avatar images.
![image](https://user-images.githubusercontent.com/26339368/199507398-3331c8c6-af41-40b8-b577-18311f0c88dc.png)

Not sure if it was intentional or not, but it appears to be a mistake, removal fixes the issue.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression
- [x] I follow existing [coding style](https://docs.kanboard.org/en/latest/developer_guide/coding_standards.html)

