### PR TITLE
Update the number of tasks across all swimlanes according to the description

### DIFF
--- a/app/Template/board/table_column.php
+++ b/app/Template/board/table_column.php
@@ -104,12 +104,12 @@
                 <span><span class="ui-helper-hidden-accessible"><?= t('Task count') ?> </span><?= $column['column_nb_tasks'] ?></span>
             </span>
             <?php endif ?>
-            <?php if (! empty($column['column_nb_open_tasks'])): ?>
+            <?php if (! empty($swimlane['nb_open_tasks'])): ?>
             <span title="<?= t('Total number of tasks in this column across all swimlanes') ?>" class="board-column-header-task-count">
                 <?php if ($column['task_limit'] > 0): ?>
-                    (<span><span class="ui-helper-hidden-accessible"><?= t('Total number of tasks in this column across all swimlanes') ?> </span><?= $column['column_nb_open_tasks'] ?></span> / <span title="<?= t('Task limit') ?>"><span class="ui-helper-hidden-accessible"><?= t('Task limit') ?> </span><?= $this->text->e($column['task_limit']) ?></span>)
+                    (<span><span class="ui-helper-hidden-accessible"><?= t('Total number of tasks in this column across all swimlanes') ?> </span><?= $swimlane['nb_open_tasks'] ?></span> / <span title="<?= t('Task limit') ?>"><span class="ui-helper-hidden-accessible"><?= t('Task limit') ?> </span><?= $this->text->e($column['task_limit']) ?></span>)
                 <?php else: ?>
-                    (<span><span class="ui-helper-hidden-accessible"><?= t('Total number of tasks in this column across all swimlanes') ?> </span><?= $column['column_nb_open_tasks'] ?></span>)
+                    (<span><span class="ui-helper-hidden-accessible"><?= t('Total number of tasks in this column across all swimlanes') ?> </span><?= $swimlane['nb_open_tasks'] ?></span>)
                 <?php endif ?>
             </span>
             <?php endif ?>


### PR DESCRIPTION
Current content `$column['column_nb_open_tasks']` represents the number of open tasks in the current column. 
But according to the description: "Total number of tasks in this column across all swimlanes", the value of `$swimlane['nb_open_tasks']` should be the right number.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression
- [ ] I have updated the unit tests and integration tests accordingly
- [x] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

