### PR TITLE
Search4950

### DIFF
--- a/app/Filter/TaskTagFilter.php
+++ b/app/Filter/TaskTagFilter.php
@@ -78,12 +78,10 @@ class TaskTagFilter extends BaseFilter implements FilterInterface
 
     protected function getQueryOfTaskIdsWithGivenTag()
     {
-        $this->value = '%'.$this->value.'%';
-
         return $this->db
             ->table(TagModel::TABLE)
             ->columns(TaskTagModel::TABLE.'.task_id')
-            ->ilike(TagModel::TABLE.'.name', $this->value)
+            ->ilike(TagModel::TABLE.'.name', '%'.$this->value.'%')
             ->join(TaskTagModel::TABLE, 'tag_id', 'id');
     }
 }

--- a/app/Filter/TaskTagFilter.php
+++ b/app/Filter/TaskTagFilter.php
@@ -78,6 +78,8 @@ class TaskTagFilter extends BaseFilter implements FilterInterface
 
     protected function getQueryOfTaskIdsWithGivenTag()
     {
+        $this->value = '%'.$this->value.'%';
+
         return $this->db
             ->table(TagModel::TABLE)
             ->columns(TaskTagModel::TABLE.'.task_id')


### PR DESCRIPTION
Do you follow the guidelines?

- [ ] I have tested my changes
- [ ] There is no breaking change
- [ ] There is no regression
- [ ] I have updated the unit tests and integration tests accordingly
- [ ] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

I'm sorry, I'm getting 'PHP Fatal error:  Cannot acquire reference to $GLOBALS in /usr/share/php/PHPUnit/Util/Configuration.php on line 407' while trying to run phpunit -c tests/units.sqlite.xml
I tried looking for the error: "Bumping the phpunit/phpunit dependency from >=8.5 to >=8.5.23 did resolve this issue."
My installed version of phpunit: 8.5.2. 
If anyone could point me in the right direction, I would appreciate it, thank you.


