### PR TITLE
Fix broken user mentions in popup comment form

### DIFF
--- a/app/Controller/CommentController.php
+++ b/app/Controller/CommentController.php
@@ -25,6 +25,7 @@ class CommentController extends BaseController
     public function create(array $values = array(), array $errors = array())
     {
         $task = $this->getTask();
+        $values['project_id'] = $task['project_id'];
 
         $this->response->html($this->helper->layout->task('comment/create', array(
             'values' => $values,
@@ -77,6 +78,8 @@ class CommentController extends BaseController
         if (empty($values)) {
             $values = $comment;
         }
+
+        $values['project_id'] = $task['project_id'];
 
         $this->response->html($this->template->render('comment/edit', array(
             'values' => $values,


### PR DESCRIPTION
This commit partially reverts commit

> commit 61e63ef9e012d494864d4a0f0341a8aa2b49c5d6
> Author: Tomas Dittmann <chaosmeist3r@gmail.com>
> Date:   Sat Feb 5 05:59:33 2022 +0100
>
>   Remove `project_id` from task URLs

where those things should have been kept

(cf FormHelper::textEditor for the need for $values['project_id'])

Do you follow the guidelines?

- [ ] I have tested my changes
- [ ] There is no breaking change
- [ ] There is no regression
- [ ] I have updated the unit tests and integration tests accordingly
- [ ] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

