### PR TITLE
fix: fire event after `TaskMoveColumnOnDueDate` action (fixes #5021)

### DIFF
--- a/app/Action/TaskMoveColumnOnDueDate.php
+++ b/app/Action/TaskMoveColumnOnDueDate.php
@@ -81,7 +81,7 @@ class TaskMoveColumnOnDueDate extends Base
                     $this->getParam('dest_column_id'),
                     1,
                     $task['swimlane_id'],
-                    false
+                    true
                 );
             }
         }


### PR DESCRIPTION
please refer to the issue description in the connected issue: https://github.com/kanboard/kanboard/issues/5021

as requested there, this is our hotfix as a pull request. it runs on our production installation and enables follow up actions after `TaskMoveColumnOnDueDate` (since it now fires events after execution).