### PR TITLE
Enable Sqlite WAL mode by default

### DIFF
--- a/app/ServiceProvider/DatabaseProvider.php
+++ b/app/ServiceProvider/DatabaseProvider.php
@@ -117,10 +117,11 @@ class DatabaseProvider implements ServiceProviderInterface
     {
         require_once __DIR__.'/../Schema/Sqlite.php';
 
-        return new Database(array(
+        return new Database([
             'driver' => 'sqlite',
             'filename' => DB_FILENAME,
-        ));
+            'wal_mode' => DB_WAL_MODE,
+        ]);
     }
 
     /**

--- a/app/constants.php
+++ b/app/constants.php
@@ -43,6 +43,7 @@ defined('DB_DRIVER') or define('DB_DRIVER', getenv('DB_DRIVER') ?: 'sqlite');
 
 // Sqlite configuration
 defined('DB_FILENAME') or define('DB_FILENAME', getenv('DB_FILENAME') ?: DATA_DIR.DIRECTORY_SEPARATOR.'db.sqlite');
+defined('DB_WAL_MODE') or define('DB_WAL_MODE', getenv('DB_WAL_MODE') ? strtolower(getenv('DB_WAL_MODE')) === 'true' : true);
 
 // Mysql/Postgres configuration
 defined('DB_USERNAME') or define('DB_USERNAME', getenv('DB_USERNAME') ?: 'root');

--- a/libs/picodb/lib/PicoDb/Driver/Sqlite.php
+++ b/libs/picodb/lib/PicoDb/Driver/Sqlite.php
@@ -36,6 +36,12 @@ class Sqlite extends Base
         }
 
         $this->pdo = new PDO('sqlite:'.$settings['filename'], null, null, $options);
+
+        // Official docs: https://sqlite.org/wal.html
+        if (isset($settings['wal_mode']) && $settings['wal_mode'] === true) {
+            $this->pdo->exec('PRAGMA journal_mode=wal');
+        }
+
         $this->enableForeignKeys();
     }
 


### PR DESCRIPTION
WAL provides more concurrency as readers do not block writers and, a writer does not block readers. Reading and writing can proceed concurrently.

This change might reduce the number of errors related to locked databases.

For reference: https://sqlite.org/wal.html

Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I have updated the unit tests and integration tests accordingly
- [X] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

