### PR TITLE
fix(unit_tests): use assertEqualsWithDelta() to test time_spent

### DIFF
--- a/tests/units/Model/TransitionTest.php
+++ b/tests/units/Model/TransitionTest.php
@@ -133,9 +133,9 @@ class TransitionTest extends Base
         $this->assertEquals('admin', $transitions[2]['username']);
         $this->assertEquals('admin', $transitions[3]['username']);
 
-        $this->assertEquals(1200, $transitions[0]['time_spent']);
-        $this->assertEquals(1200, $transitions[1]['time_spent']);
-        $this->assertEquals(3600, $transitions[2]['time_spent']);
-        $this->assertEquals(3600, $transitions[3]['time_spent']);
+        $this->assertEqualsWithDelta(1200, $transitions[0]['time_spent'], 3);
+        $this->assertEqualsWithDelta(1200, $transitions[1]['time_spent'], 3);
+        $this->assertEqualsWithDelta(3600, $transitions[2]['time_spent'], 3);
+        $this->assertEqualsWithDelta(3600, $transitions[3]['time_spent'], 3);
     }
 }


### PR DESCRIPTION
Timing, clock skew, and network conditions can cause slight skew in the generated/expected timestamps in the unit test vs. actual recorded timestamps in the database. This can cause flakiness in the tests due to sporadic failures when things don't perfectly align. To fix this, we change assertEquals() to assertEqualsWithDelta() with a small (3 second) delta to account for this potential delay.

Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I have updated the unit tests and integration tests accordingly
- [X] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

