### PR TITLE
feat: duplicate attachments & external links during task duplication & importing

### DIFF
--- a/app/Model/FileModel.php
+++ b/app/Model/FileModel.php
@@ -199,10 +199,15 @@ abstract class FileModel extends Base
             $this->fireDestructionEvent($file_id);
 
             $file = $this->getById($file_id);
-            $this->objectStorage->remove($file['path']);
 
-            if ($file['is_image'] == 1) {
-                $this->objectStorage->remove($this->getThumbnailPath($file['path']));
+            // Only remove files from disk attached to a single task.
+            $multiple_tasks_count = $this->db->table($this->getTable())->eq('path', $file['path'])->count();
+            if ($multiple_tasks_count === 1) {
+                $this->objectStorage->remove($file['path']);
+
+                if ($file['is_image'] == 1) {
+                    $this->objectStorage->remove($this->getThumbnailPath($file['path']));
+                }
             }
 
             return $this->db->table($this->getTable())->eq('id', $file['id'])->remove();

--- a/app/Model/TaskProjectDuplicationModel.php
+++ b/app/Model/TaskProjectDuplicationModel.php
@@ -31,6 +31,24 @@ class TaskProjectDuplicationModel extends TaskDuplicationModel
         if ($new_task_id !== false) {
             $this->tagDuplicationModel->duplicateTaskTagsToAnotherProject($task_id, $new_task_id, $project_id);
             $this->taskLinkModel->create($new_task_id, $task_id, 4);
+
+            $attachments = $this->taskFileModel->getAll($task_id);
+            $externalLinks = $this->taskExternalLinkModel->getAll($task_id);
+
+            foreach ($attachments as $attachment) {
+                $this->taskFileModel->create($new_task_id, $attachment['name'], $attachment['path'], $attachment['size']);
+            }
+
+            foreach ($externalLinks as $externalLink) {
+                $this->taskExternalLinkModel->create([
+                    'task_id' => $new_task_id,
+                    'creator_id' => $externalLink['creator_id'],
+                    'dependency' => $externalLink['dependency'],
+                    'title' => $externalLink['title'],
+                    'link_type' => $externalLink['link_type'],
+                    'url' => $externalLink['url'],
+                ]);
+            }
         }
 
         $hook_values = [ 'source_task_id' => $task_id, 'destination_task_id' => $new_task_id];


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression
- [ ] I have updated the unit tests and integration tests accordingly
- [x] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

Hi,

this PR adds functionality to duplicate attached files and external links for a task being duplicated to another project.

This means, when importing tasks from another project, or duplicating a task into another project, the task's attached files and external links are duplicated along with other attributes, like title and description.

No files are duplicated on disk. Instead, a new entry in the `task_has_files` table is created for the duplicate task, pointing to the same file on disk. In the duplicate task the attachment retains its original uploader as creator.

When removing a task, or removing an attachment from a task, the underlying file is only removed from disk, if there are no other tasks using the same file as attachment.

This functionality does not apply when duplicating a task within the same project.

Furthermore, internal links to other tasks are not duplicated, either.

This PR addresses requested functionality described in #4253.

Let me know any feedback you might have on this.

Cheers!
