### PR TITLE
Trigger EVENT_MOVE_COLUMN event when moving task to another swimlane

### DIFF
--- a/app/Model/TaskPositionModel.php
+++ b/app/Model/TaskPositionModel.php
@@ -287,6 +287,15 @@ class TaskPositionModel extends Base
                 $changes,
                 $changes
             );
+
+            if ($task['column_id'] != $new_column_id) {
+                $this->taskEventJob->execute(
+                    $task['id'],
+                    array(TaskModel::EVENT_MOVE_COLUMN),
+                    $changes,
+                    $changes
+                );
+            }
         } elseif ($task['column_id'] != $new_column_id) {
             $this->taskEventJob->execute(
                 $task['id'],

--- a/tests/units/Model/TaskPositionModelTest.php
+++ b/tests/units/Model/TaskPositionModelTest.php
@@ -571,11 +571,11 @@ class TaskPositionModelTest extends Base
         $this->assertCount(2, $called);
 
         // Move to another swimlane
-        $this->assertTrue($taskPositionModel->movePosition(1, 1, 3, 1, 2));
+        $this->assertTrue($taskPositionModel->movePosition(1, 1, 2, 1, 2));
 
         $task = $taskFinderModel->getById(1);
         $this->assertEquals(1, $task['id']);
-        $this->assertEquals(3, $task['column_id']);
+        $this->assertEquals(2, $task['column_id']);
         $this->assertEquals(1, $task['position']);
         $this->assertEquals(2, $task['swimlane_id']);
 
@@ -621,7 +621,7 @@ class TaskPositionModelTest extends Base
         $this->assertNotEmpty($event_data);
         $this->assertEquals(1, $event_data['task_id']);
         $this->assertEquals(1, $event_data['position']);
-        $this->assertEquals(3, $event_data['column_id']);
+        $this->assertEquals(2, $event_data['column_id']);
         $this->assertEquals(1, $event_data['project_id']);
         $this->assertEquals(2, $event_data['swimlane_id']);
     }


### PR DESCRIPTION
Fixes #4581

Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I have updated the unit tests and integration tests accordingly
- [X] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

