### PR TITLE
Use SESSION_DURATION option to define the session lifetime stored in the database

### DIFF
--- a/app/Core/Session/SessionHandler.php
+++ b/app/Core/Session/SessionHandler.php
@@ -58,7 +58,11 @@ class SessionHandler implements SessionHandlerInterface
     #[\ReturnTypeWillChange]
     public function write($sessionID, $data)
     {
-        $lifetime = time() + (ini_get('session.gc_maxlifetime') ?: 1440);
+        if (SESSION_DURATION > 0) {
+            $lifetime = time() + SESSION_DURATION;
+        } else {
+            $lifetime = time() + (ini_get('session.gc_maxlifetime') ?: 1440);
+        }
 
         $this->db->startTransaction();
 


### PR DESCRIPTION
The option `SESSION_DURATION` is used to define the cookie lifetime.

With this change, Kanboard will try to use first `SESSION_DURATION` instead of the default `session.gc_maxlifetime` value.

Fixes #4340

Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I have updated the unit tests and integration tests accordingly
- [X] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

