### PR TITLE
Add support for task links in Markdown headings

### DIFF
--- a/app/Core/Markdown.php
+++ b/app/Core/Markdown.php
@@ -41,9 +41,31 @@ class Markdown extends Parsedown
     {
         $this->isPublicLink = $isPublicLink;
         $this->container = $container;
+        $this->BlockTypes['#'][0] = 'CustomHeader';
         $this->InlineTypes['#'][] = 'TaskLink';
         $this->InlineTypes['@'][] = 'UserLink';
         $this->inlineMarkerList .= '#@';
+    }
+
+    protected function blockCustomHeader($Line)
+    {
+        if (preg_match('!#(\d+)!i', $Line['text'], $matches))
+        {
+            $link = $this->buildTaskLink($matches[1]);
+
+            if (! empty($link)) {
+                return [
+                    'extent' => strlen($matches[0]),
+                    'element' => [
+                        'name' => 'a',
+                        'text' => $matches[0],
+                        'attributes' => ['href' => $link],
+                    ],
+                ];
+            }
+        }
+
+        return $this->blockHeader($Line);
     }
 
     /**

--- a/tests/units/Helper/TextHelperTest.php
+++ b/tests/units/Helper/TextHelperTest.php
@@ -30,6 +30,16 @@ class TextHelperTest extends Base
         $this->assertEquals('<p>Test</p>', $textHelper->markdown('Test'));
 
         $this->assertEquals(
+            '<a href="?controller=TaskViewController&amp;action=show&amp;task_id=123">#123</a>',
+            $textHelper->markdown('#123')
+        );
+
+        $this->assertEquals(
+            "<h1>Heading 1</h1>\n<p>Task <a href=\"?controller=TaskViewController&amp;action=show&amp;task_id=123\">#123</a></p>\n<h2>Heading 2</h2>",
+            $textHelper->markdown("# Heading 1\r\n\r\nTask #123\r\n\r\n## Heading 2")
+        );
+
+        $this->assertEquals(
             '<p>Task <a href="?controller=TaskViewController&amp;action=show&amp;task_id=123">#123</a></p>',
             $textHelper->markdown('Task #123')
         );


### PR DESCRIPTION
If a text block matches `#(\d+)` it will be interpreted as a task link instead of a heading.

Closes #5017

Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I have updated the unit tests and integration tests accordingly
- [X] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

