### PR TITLE
Fix incorrect parameter encoding when using URLs rewriting

### DIFF
--- a/app/Core/Http/Route.php
+++ b/app/Core/Http/Route.php
@@ -101,7 +101,7 @@ class Route extends Base
 
                 for ($i = 0; $i < $count; $i++) {
                     if ($route['items'][$i][0] === ':') {
-                        $params[substr($route['items'][$i], 1)] = $items[$i];
+                        $params[substr($route['items'][$i], 1)] = urldecode($items[$i]);
                     } elseif ($route['items'][$i] !== $items[$i]) {
                         break;
                     }
@@ -152,6 +152,7 @@ class Route extends Base
                 $i = 0;
 
                 foreach ($params as $variable => $value) {
+                    $value = urlencode($value);
                     $url = str_replace(':'.$variable, $value, $url);
                     $i++;
                 }

--- a/tests/units/Core/Http/RouteTest.php
+++ b/tests/units/Core/Http/RouteTest.php
@@ -55,6 +55,14 @@ class RouteTest extends Base
 
         $this->assertEquals('v1', $this->container['request']->getStringParam('p1'));
         $this->assertEquals('v2', $this->container['request']->getStringParam('p2'));
+
+        $route->addRoute('/search/:query', 'searchcontroller', 'searchaction');
+        $this->assertEquals(
+            array('controller' => 'searchcontroller', 'action' => 'searchaction', 'plugin' => ''),
+            $route->findRoute('/search/modified%3A%22%3E%3D2023-04-01%22')
+        );
+
+        $this->assertEquals('modified:">=2023-04-01"', $this->container['request']->getStringParam('query'));
     }
 
     public function testFindUrl()
@@ -76,5 +84,6 @@ class RouteTest extends Base
         $this->assertEquals('something', $route->findUrl('controller1', 'action1', array(), 'myplugin'));
         $this->assertEquals('foo/123', $route->findUrl('controller1', 'action3', array('myvar' => 123), 'myplugin'));
         $this->assertEquals('foo/123', $route->findUrl('controller1', 'action3', array('myvar' => 123, 'plugin' => 'myplugin')));
+        $this->assertEquals('foo/modified%3A%22%3E%3D2023-04-01%22', $route->findUrl('controller1', 'action3', array('myvar' => 'modified:">=2023-04-01"', 'plugin' => 'myplugin')));
     }
 }


### PR DESCRIPTION
A parameter with quotes or other special characters should be url encoded.

Incorrect encoding could happen when using search queries like this one:

modified:">=2023-04-01"

Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I have updated the unit tests and integration tests accordingly
- [X] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

