### PR TITLE
Avoid PHP warning caused by session_regenerate_id()

### DIFF
--- a/app/Core/User/UserSession.php
+++ b/app/Core/User/UserSession.php
@@ -45,7 +45,8 @@ class UserSession extends Base
         $user['twofactor_activated'] = isset($user['twofactor_activated']) ? (bool) $user['twofactor_activated'] : false;
 
         if (session_status() === PHP_SESSION_ACTIVE) {
-            session_regenerate_id(true);
+            // Note: Do not delete the old session to avoid possible race condition and a PHP warning.
+            session_regenerate_id(false);
         }
 
         session_set('user', $user);


### PR DESCRIPTION
Fixes #5268

Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I have updated the unit tests and integration tests accordingly
- [X] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

