### PR TITLE
Tweak Sqlite connection settings to reduce database locked errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.sqlite
 *.sqlite-journal
+*.sqlite-shm
+*.sqlite-wal
 .buildpath
 .project
 /.settings/

--- a/app/Controller/ConfigController.php
+++ b/app/Controller/ConfigController.php
@@ -20,6 +20,7 @@ class ConfigController extends BaseController
         $this->response->html($this->helper->layout->config('config/about', array(
             'db_size' => $this->configModel->getDatabaseSize(),
             'db_version' => $this->db->getDriver()->getDatabaseVersion(),
+            'db_options' => $this->configModel->getDatabaseOptions(),
             'user_agent' => $this->request->getServerVariable('HTTP_USER_AGENT'),
             'title' => t('Settings').' &gt; '.t('About'),
         )));

--- a/app/Model/ConfigModel.php
+++ b/app/Model/ConfigModel.php
@@ -73,6 +73,26 @@ class ConfigModel extends SettingModel
     }
 
     /**
+     * Get database extra options
+     *
+     * @access public
+     * @return array
+     */
+    public function getDatabaseOptions()
+    {
+        if (DB_DRIVER === 'sqlite') {
+            return [
+                'journal_mode' => $this->db->getConnection()->query('PRAGMA journal_mode')->fetchColumn(),
+                'wal_autocheckpoint' => $this->db->getConnection()->query('PRAGMA wal_autocheckpoint')->fetchColumn(),
+                'synchronous' => $this->db->getConnection()->query('PRAGMA synchronous')->fetchColumn(),
+                'busy_timeout' => $this->db->getConnection()->query('PRAGMA busy_timeout')->fetchColumn(),
+            ];
+        }
+
+        return [];
+    }
+
+    /**
      * Regenerate a token
      *
      * @access public

--- a/app/Template/config/about.php
+++ b/app/Template/config/about.php
@@ -79,6 +79,9 @@
                 <?= $this->url->link(t('Optimize the database'), 'ConfigController', 'optimizeDb', array(), true) ?>&nbsp;
                 <?= t('(VACUUM command)') ?>
             </li>
+            <?php foreach ($db_options as $option => $value): ?>
+                <li><strong><?= $this->text->e($option) ?></strong> = <?= $this->text->e($value) ?></li>
+            <?php endforeach ?>
         </ul>
     </div>
 <?php endif ?>

--- a/libs/picodb/lib/PicoDb/Driver/Sqlite.php
+++ b/libs/picodb/lib/PicoDb/Driver/Sqlite.php
@@ -29,17 +29,19 @@ class Sqlite extends Base
      */
     public function createConnection(array $settings)
     {
-        $options = array();
+        $options = [];
 
-        if (! empty($settings['timeout'])) {
-            $options[PDO::ATTR_TIMEOUT] = $settings['timeout'];
-        }
+        // Set a default timeout of 30 seconds to reduce "database is locked" errors.
+        $options[PDO::ATTR_TIMEOUT] = (! empty($settings['timeout'])) ? $settings['timeout'] : 30;
 
         $this->pdo = new PDO('sqlite:'.$settings['filename'], null, null, $options);
 
+        // Enabling WAL mode by default should also reduce the "database is locked" errors.
         // Official docs: https://sqlite.org/wal.html
         if (isset($settings['wal_mode']) && $settings['wal_mode'] === true) {
             $this->pdo->exec('PRAGMA journal_mode=wal');
+            $this->pdo->exec('PRAGMA wal_autocheckpoint = 0');
+            $this->pdo->exec('PRAGMA synchronous=NORMAL');
         }
 
         $this->enableForeignKeys();


### PR DESCRIPTION
Related resources:
- https://litestream.io/tips/
- https://unixsheikh.com/articles/sqlite-the-only-database-you-will-ever-need-in-most-cases.html

Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I have updated the unit tests and integration tests accordingly
- [X] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

