### PR TITLE
Do not override the creator_id with the current logged user if the task is imported

### DIFF
--- a/app/Model/TaskCreationModel.php
+++ b/app/Model/TaskCreationModel.php
@@ -78,7 +78,8 @@ class TaskCreationModel extends Base
             $values['title'] = t('Untitled');
         }
 
-        if ($this->userSession->isLogged()) {
+        // Note: Do not override the creator_id if the task is imported
+        if (empty($values['creator_id']) && $this->userSession->isLogged()) {
             $values['creator_id'] = $this->userSession->getId();
         }
 


### PR DESCRIPTION
Fixes #5345

Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I have updated the unit tests and integration tests accordingly
- [X] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

