### PR TITLE
Put the 2FA-form into the center of the browser viewport

### DIFF
--- a/app/Template/twofactor/check.php
+++ b/app/Template/twofactor/check.php
@@ -1,4 +1,4 @@
-<section class="page">
+<section class="form-login">
     <div class="page-header">
         <h2><?= t('Two factor authentication') ?></h2>
     </div>


### PR DESCRIPTION
During login it is a bit irritating, to see the login form in the center of the browser viewport and to have to search for the two factor authentication form in the left upper corner of the viewport afterwards. Because of that I searched for a way to center the 2FA-form in the same way as the login form and found it by simply replacing the class for the complete container of the form with the same value as the one for the login form. This makes the two factor authentication form appearing in the middle of the screen like the login form does.

I left the similar form in `app/Template/twofactor/show.php` unchanged because AFAIK this is the form in the user settings, that is part of a more complex structure. (IMHO) That structure doesn't need to be changed.

This solves #4963.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression
- [ ] ~~I have updated the unit tests and integration tests accordingly~~ (AFAIK there is no need)
- [x] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

