### PR TITLE
Add one-click deploy link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Table of Contents
     - [Installation instructions](https://docs.kanboard.org/v1/admin/installation/)
     - [Upgrade to a new version](https://docs.kanboard.org/v1/admin/upgrade/)
     - [Use Kanboard with Docker](https://docs.kanboard.org/v1/admin/docker/)
+    
+Deploy
+------
+
+- [Try Kanboard's one-click self-hosting option](https://app.trydome.io/signup?package=kanboard)
 
 Credits
 -------


### PR DESCRIPTION
Adds [one-click-deploy link](https://app.trydome.io/signup?package=kanboard) with Dome to the readme

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I have updated the unit tests and integration tests accordingly
- [X] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

