### PR TITLE
API: Avoid PHP notice when searching for a project name that does not exist

### DIFF
--- a/app/Api/Procedure/ProjectProcedure.php
+++ b/app/Api/Procedure/ProjectProcedure.php
@@ -22,6 +22,11 @@ class ProjectProcedure extends BaseProcedure
     public function getProjectByName($name)
     {
         $project = $this->projectModel->getByName($name);
+
+        if (empty($project)) {
+            return false;
+        }
+
         ProjectAuthorization::getInstance($this->container)->check($this->getClassName(), 'getProjectByName', $project['id']);
         return $this->projectApiFormatter->withProject($project)->format();
     }
@@ -29,6 +34,11 @@ class ProjectProcedure extends BaseProcedure
     public function getProjectByIdentifier($identifier)
     {
         $project = $this->projectModel->getByIdentifier($identifier);
+
+        if (empty($project)) {
+            return false;
+        }
+
         ProjectAuthorization::getInstance($this->container)->check($this->getClassName(), 'getProjectByIdentifier', $project['id']);
         return $this->projectApiFormatter->withProject($project)->format();
     }
@@ -36,6 +46,11 @@ class ProjectProcedure extends BaseProcedure
     public function getProjectByEmail($email)
     {
         $project = $this->projectModel->getByEmail($email);
+
+        if (empty($project)) {
+            return false;
+        }
+
         ProjectAuthorization::getInstance($this->container)->check($this->getClassName(), 'getProjectByEmail', $project['id']);
         return $this->projectApiFormatter->withProject($project)->format();
     }

--- a/tests/integration/ProjectProcedureTest.php
+++ b/tests/integration/ProjectProcedureTest.php
@@ -11,6 +11,7 @@ class ProjectProcedureTest extends BaseProcedureTest
         $this->assertCreateTeamProject();
         $this->assertGetProjectById();
         $this->assertGetProjectByName();
+        $this->assertGetInexistingProjectByName();
         $this->assertGetAllProjects();
         $this->assertUpdateProject();
         $this->assertUpdateProjectIdentifier();
@@ -40,6 +41,12 @@ class ProjectProcedureTest extends BaseProcedureTest
         $this->assertEquals($this->projectId, $project['id']);
         $this->assertEquals($this->projectName, $project['name']);
         $this->assertEquals('Description', $project['description']);
+    }
+
+    public function assertGetInexistingProjectByName()
+    {
+        $project = $this->app->getProjectByName('inexisting project');
+        $this->assertFalse($project);
     }
 
     public function assertGetAllProjects()


### PR DESCRIPTION
Fixes #5383

Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I have updated the unit tests and integration tests accordingly
- [X] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

