### PR TITLE
Add missing HTML escaping when showing group membership in user profile

### DIFF
--- a/app/Template/user_view/show.php
+++ b/app/Template/user_view/show.php
@@ -13,8 +13,8 @@
     <h2><?= t('Security') ?></h2>
 </div>
 <ul class="panel">
-    <li><?= t('Role:') ?> <strong><?= $this->user->getRoleName($user['role']) ?></strong></li>
-    <li><?= t('Group membership(s):') ?> <strong><?= implode(', ', $this->user->getUsersGroupNames($user['id'])['full_list']) ?></strong></li>
+    <li><?= t('Role:') ?> <strong><?= $this->text->e($this->user->getRoleName($user['role'])) ?></strong></li>
+    <li><?= t('Group membership(s):') ?> <strong><?= $this->text->e(implode(', ', $this->user->getUsersGroupNames($user['id'])['full_list'])) ?></strong></li>
     <li><?= t('Account type:') ?> <strong><?= $user['is_ldap_user'] ? t('Remote') : t('Local') ?></strong></li>
     <li><?= $user['twofactor_activated'] == 1 ? t('Two factor authentication enabled') :  t('Two factor authentication disabled') ?></li>
     <li><?= t('Number of failed login:') ?> <strong><?= $user['nb_failed_login'] ?></strong></li>


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I have updated the unit tests and integration tests accordingly
- [X] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

