### PR TITLE
a fix for the plugin directory

### DIFF
--- a/app/Template/plugin/directory.php
+++ b/app/Template/plugin/directory.php
@@ -11,7 +11,7 @@
 <?php if (empty($available_plugins)): ?>
     <p class="alert"><?= t('There is no plugin available.') ?></p>
 <?php else: ?>
-    <?php foreach ($available_plugins as $plugin): ?>
+    <?php foreach ($available_plugins as $plugin_name => $plugin): ?>
     <table>
         <tr>
             <th colspan="3">
@@ -27,9 +27,9 @@
             </td>
             <td>
                 <?php if ($is_configured): ?>
-                    <?php if (! isset($installed_plugins[$plugin['title']])): ?>
+                    <?php if (! isset($installed_plugins[$plugin_name])): ?>
                         <?= $this->url->icon('cloud-download', t('Install'), 'PluginController', 'install', array('archive_url' => urlencode($plugin['download'])), true) ?>
-                    <?php elseif ($installed_plugins[$plugin['title']] < $plugin['version']): ?>
+                    <?php elseif ($installed_plugins[$plugin_name] < $plugin['version']): ?>
                         <?= $this->url->icon('refresh', t('Update'), 'PluginController', 'update', array('archive_url' => urlencode($plugin['download'])), true) ?>
                     <?php else: ?>
                         <i class="fa fa-check-circle-o" aria-hidden="true"></i>


### PR DESCRIPTION
* using the actual plugin_name for checks vs installed_plugins instead of plugin['title']

- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression

The `title` is supposed to be an entirely UI concept and binding logic to it just asks for trouble.
Since we **DO** have the `name` of each plugin it is best to use that for logic, and the `title` should appear in UI elements only.

The [Kanboard Website](https://github.com/kanboard/website) never mentions in the README or elsewhere that the `title` field of a plugin entry in `plugins.json` must be **explicitly the same as the `name`** of the plugin. Furthermore, it doesn't make any sense having an explicit `title` if it would always duplicate the `name`. So, let's just consider that in the common case `title != name` and not rely on the subtle assumption that they are commutable.

