### PR TITLE
Performance

### DIFF
--- a/app/Formatter/BoardFormatter.php
+++ b/app/Formatter/BoardFormatter.php
@@ -52,7 +52,7 @@ class BoardFormatter extends BaseFormatter implements FormatterInterface
                 $columns = array_merge($columns, $this->columnModel->getAllWithPerSwimlaneTaskCount($this->projectId, $swimlane['id']));
             }
         } else {
-            $columns = $this->columnModel->getAllWithTaskCount($this->projectId);
+            $columns = $this->columnModel->getAllWithOpenedTaskCount($this->projectId);
         }
 
         if (empty($swimlanes) || empty($columns)) {

--- a/app/Model/ColumnModel.php
+++ b/app/Model/ColumnModel.php
@@ -121,6 +121,24 @@ class ColumnModel extends Base
     }
 
     /**
+     * Get all columns with opened task count only
+     *
+     * @access public
+     * @param  integer  $project_id   Project id
+     * @return array
+     */
+    public function getAllWithOpenedTaskCount($project_id)
+    {
+        return $this->db->table(self::TABLE)
+            ->columns('id', 'title', 'position', 'task_limit', 'description', 'hide_in_dashboard', 'project_id')
+            ->subquery("SELECT COUNT(*) FROM ".TaskModel::TABLE." WHERE column_id=".self::TABLE.".id AND is_active='1'", 'nb_open_tasks')
+            ->eq('project_id', $project_id)
+            ->asc('position')
+            ->findAll();
+    }
+
+
+    /**
      * Get all columns with task count
      *
      * @access public

--- a/app/Model/ProjectUserRoleModel.php
+++ b/app/Model/ProjectUserRoleModel.php
@@ -71,6 +71,9 @@ class ProjectUserRoleModel extends Base
 
         if (empty($role)) {
             $role = $this->projectGroupRoleModel->getUserRole($project_id, $user_id);
+			if(empty($role)) {
+				$role = ""; // force use of the cache
+			}
         }
 
         return $role;

--- a/app/Template/board/task_private.php
+++ b/app/Template/board/task_private.php
@@ -38,7 +38,6 @@
             <div class="task-board-saving-icon" style="display: none;"><i class="fa fa-spinner fa-pulse fa-2x"></i></div>
             <div class="task-board-header">
                 <?php if ($this->user->hasProjectAccess('TaskModificationController', 'edit', $task['project_id'])): ?>
-                    <?= $this->render('task/dropdown', array('task' => $task, 'redirect' => 'board')) ?>
                     <?php if ($this->projectRole->canUpdateTask($task)): ?>
                         <?= $this->modal->large('edit', '', 'TaskModificationController', 'edit', array('task_id' => $task['id'])) ?>
                     <?php endif ?>


### PR DESCRIPTION
The last commit is obviously a breaking change / regression, but the way tasks dropdown are coded, we have are too many function calls. Very CPU consuming when you have hundred of tasks to display.
All actions can be accessed on the task itself, after clicking on it.

Maybe we can make this feature optional (with a setting for it), or maybe we can build a plugin to remove/add this feature.

On the overall, kanboard is really faster with all those changes !