### PR TITLE
Made the max projects number configurable via config.php

### DIFF
--- a/app/Controller/DashboardController.php
+++ b/app/Controller/DashboardController.php
@@ -23,7 +23,7 @@ class DashboardController extends BaseController
             'title'              => t('Dashboard for %s', $this->helper->user->getFullname($user)),
             'user'               => $user,
             'overview_paginator' => $this->dashboardPagination->getOverview($user['id']),
-            'project_paginator'  => $this->projectPagination->getDashboardPaginator($user['id'], 'show', 10),
+            'project_paginator'  => $this->projectPagination->getDashboardPaginator($user['id'], 'show', DASHBOARD_MAX_PROJECTS),
         )));
     }
 

--- a/config.default.php
+++ b/config.default.php
@@ -286,3 +286,6 @@ define('SHOW_GROUP_MEMBERSHIPS_IN_USERLIST', true);
 // ... when hovering the mouse over the group-icon of a given user!)
 // If set to 0 ALL group-memberships will be listed (7 by default)
 define('SHOW_GROUP_MEMBERSHIPS_IN_USERLIST_WITH_LIMIT', 7);
+
+// dashboard settings
+define('DASHBOARD_MAX_PROJECTS', 10);


### PR DESCRIPTION
I wanted to extend the number of projects shown on the dashboard, yet was not able to write a plugin for it, since it would require to overwrite the _DashboardController_, which - AFAIK - is not possible. So I thought I add global variable to make use of the `max` argument of the `getDashboardPaginator()` method and make a PR, in case you might find it usefull. It's just a very tiny change, I would say. Thanks for reading!

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression
- [x] I have updated the unit tests and integration tests accordingly
- [x] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

