### PR TITLE
Fix various action executions failing if the duration parameter isn't set

### DIFF
--- a/app/Action/TaskCloseNoActivity.php
+++ b/app/Action/TaskCloseNoActivity.php
@@ -68,7 +68,7 @@ class TaskCloseNoActivity extends Base
     public function doAction(array $data)
     {
         $results = array();
-        $max = $this->getParam('duration') * 86400;
+        $max = (int)$this->getParam('duration') * 86400;
 
         foreach ($data['tasks'] as $task) {
             $duration = time() - $task['date_modification'];

--- a/app/Action/TaskCloseNoActivityColumn.php
+++ b/app/Action/TaskCloseNoActivityColumn.php
@@ -69,7 +69,7 @@ class TaskCloseNoActivityColumn extends Base
     public function doAction(array $data)
     {
         $results = array();
-        $max = $this->getParam('duration') * 86400;
+        $max = (int)$this->getParam('duration') * 86400;
 
         foreach ($data['tasks'] as $task) {
             $duration = time() - $task['date_modification'];

--- a/app/Action/TaskCloseNotMovedColumn.php
+++ b/app/Action/TaskCloseNotMovedColumn.php
@@ -69,7 +69,7 @@ class TaskCloseNotMovedColumn extends Base
     public function doAction(array $data)
     {
         $results = array();
-        $max = $this->getParam('duration') * 86400;
+        $max = (int)$this->getParam('duration') * 86400;
 
         foreach ($data['tasks'] as $task) {
             $duration = time() - $task['date_moved'];

--- a/app/Action/TaskEmailNoActivity.php
+++ b/app/Action/TaskEmailNoActivity.php
@@ -84,7 +84,7 @@ class TaskEmailNoActivity extends Base
     public function doAction(array $data)
     {
         $results = array();
-        $max = $this->getParam('duration') * 86400;
+        $max = (int)$this->getParam('duration') * 86400;
         $user = $this->userModel->getById($this->getParam('user_id'));
 
         if (! empty($user['email'])) {

--- a/app/Action/TaskMoveColumnNotMovedPeriod.php
+++ b/app/Action/TaskMoveColumnNotMovedPeriod.php
@@ -70,7 +70,7 @@ class TaskMoveColumnNotMovedPeriod extends Base
     public function doAction(array $data)
     {
         $results = array();
-        $max = $this->getParam('duration') * 86400;
+        $max = (int)$this->getParam('duration') * 86400;
 
         foreach ($data['tasks'] as $task) {
             $duration = time() - $task['date_moved'];

--- a/app/Action/TaskMoveColumnOnDueDate.php
+++ b/app/Action/TaskMoveColumnOnDueDate.php
@@ -69,7 +69,7 @@ class TaskMoveColumnOnDueDate extends Base
     public function doAction(array $data)
     {
         $results = array();
-        $min = $this->getParam('duration') * 86400;
+        $min = (int)$this->getParam('duration') * 86400;
 
         foreach ($data['tasks'] as $task) {
             $duration = $task['date_due'] - time();


### PR DESCRIPTION
It's easy to create an action that has nothing set for the duration by just going "next" in the UI. This results in an empty string being stored in the DB for the duration, which with PHP 8 fails as it is multiplied by an integer during the action execution, resulting in:

TypeError: Unsupported operand types: string * int

With older PHP this resulted in a warning and "0" as a result. By casting to int explicitely we restore that behaviour and we get 0 if the string can't be converted.

Fixes #5454

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression
- [x] I have updated the unit tests and integration tests accordingly
- [x] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

