### PR TITLE
FIX: can't create comment with c shortcut

### DIFF
--- a/app/Template/comment/create.php
+++ b/app/Template/comment/create.php
@@ -1,3 +1,4 @@
+<?php use Kanboard\Core\Security\Role; ?>
 <div class="page-header">
     <h2><?= t('Add a comment') ?></h2>
     <ul>
@@ -11,5 +12,25 @@
 
     <?= $this->form->textEditor('comment', $values, $errors, array('autofocus' => true, 'required' => true, 'aria-label' => t('New comment'))) ?>
 
+    <?php
+    $formName = 'visibility';
+    $visibilityOptions['app-user'] = t('Standard users');
+    $attribute[] = ('hidden');
+    ?>
+
+    <?php if ($this->user->getRole() !== Role::APP_USER) {
+        echo $this->form->label(t('Visibility:'), $formName);
+        $attribute = [];
+        $visibilityOptions['app-user'] = t('Standard users');
+        $visibilityOptions['app-manager'] = t('Application managers or more');
+    }
+    ?>
+
+    <?php if ($this->user->getRole() === Role::APP_ADMIN) {
+        $visibilityOptions['app-admin'] = t('Administrators');
+    }
+    ?>
+
+    <?= $this->form->select($formName, $visibilityOptions, array(), array(), $attribute) ?>
     <?= $this->modal->submitButtons() ?>
 </form>


### PR DESCRIPTION
It was no longer possible to comment by pressing the 'c' shortcut in a task -> visibility was missing.
 
should fix #5463

- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression
- [x] I have updated the unit tests and integration tests accordingly
- [x] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

