### PR TITLE
Add link to "Add a comment" in the comments section before the "Change sorting"

### DIFF
--- a/app/Template/task_comments/show.php
+++ b/app/Template/task_comments/show.php
@@ -4,6 +4,9 @@
         <?php if (!isset($is_public) || !$is_public): ?>
             <div class="comment-sorting">
                 <small>
+                    <?php if ($editable): ?>
+                        <?= $this->modal->medium('comment', t('Add a comment'), 'CommentController', 'create', array('task_id' => $task['id'])) ?>
+                    <?php endif ?>
                     <?= $this->url->icon('sort', t('Change sorting'), 'CommentController', 'toggleSorting', array('task_id' => $task['id'], 'csrf_token' => $this->app->getToken()->getReusableCSRFToken())) ?>
                     <?php if ($editable): ?>
                         <?= $this->modal->medium('paper-plane', t('Send by email'), 'CommentMailController', 'create', array('task_id' => $task['id'])) ?>


### PR DESCRIPTION
1. It helps when the comment input field is far away (after several comments).
2. It's intuitively easier than searching for an item in the left panel.
3. It's convenient specifically in combination with "Sorting": you look at the first/last and then write.