### PR TITLE
Add "apple-mobile-web-app-capable" meta tag

### DIFF
--- a/app/Template/layout.php
+++ b/app/Template/layout.php
@@ -4,6 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
         <meta name="mobile-web-app-capable" content="yes">
+        <meta name="apple-mobile-web-app-capable" content="yes">
         <meta name="robots" content="noindex,nofollow">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="referrer" content="no-referrer">


### PR DESCRIPTION
This PR adds a new meta tag called "apple-mobile-web-app-capable" which allows the iPhone and iPad to render Kanboard without the browser UI components when added to the home screen. Fixes #5379

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I have updated the unit tests and integration tests accordingly
- [X] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)
