### PR TITLE
fix: avoid warning from libpng when loading PNG image with incorrect iCCP profiles

### DIFF
--- a/app/Core/Thumbnail.php
+++ b/app/Core/Thumbnail.php
@@ -55,7 +55,7 @@ class Thumbnail
     public function fromFile($filename)
     {
         $this->metadata = getimagesize($filename);
-        $this->srcImage = imagecreatefromstring(file_get_contents($filename));
+        $this->srcImage = @imagecreatefromstring(file_get_contents($filename));
         return $this;
     }
 
@@ -75,7 +75,8 @@ class Thumbnail
             $this->metadata = getimagesizefromstring($blob);
         }
 
-        $this->srcImage = imagecreatefromstring($blob);
+        // Avoid warning from libpng when loading PNG image with obscure or incorrect iCCP profiles
+        $this->srcImage = @imagecreatefromstring($blob);
         return $this;
     }
 


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I have updated the unit tests and integration tests accordingly
- [X] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

