### PR TITLE
fix: prevent duplicated columns when enabling per-swimlane column task limits

### DIFF
--- a/app/Formatter/BoardColumnFormatter.php
+++ b/app/Formatter/BoardColumnFormatter.php
@@ -16,6 +16,7 @@ class BoardColumnFormatter extends BaseFormatter implements FormatterInterface
     protected $columns = array();
     protected $tasks = array();
     protected $tags = array();
+    protected $taskCountBySwimlaneAndColumn = array();
 
     /**
      * Set swimlaneId
@@ -70,6 +71,19 @@ class BoardColumnFormatter extends BaseFormatter implements FormatterInterface
     }
 
     /**
+     * Set task count by swimlane and column
+     *
+     * @access public
+     * @param  array $taskCountBySwimlaneAndColumn
+     * @return $this
+     */
+    public function withTaskCountBySwimlaneAndColumn(array $taskCountBySwimlaneAndColumn)
+    {
+        $this->taskCountBySwimlaneAndColumn = $taskCountBySwimlaneAndColumn;
+        return $this;
+    }
+
+    /**
      * Apply formatter
      *
      * @access public
@@ -88,6 +102,12 @@ class BoardColumnFormatter extends BaseFormatter implements FormatterInterface
 
             $column['nb_tasks'] = count($column['tasks']);
             $column['score'] = (int) array_column_sum($column['tasks'], 'score');
+
+            if (empty($this->taskCountBySwimlaneAndColumn)) {
+                $column['column_nb_open_tasks'] = $column['nb_open_tasks'];
+            } else {
+                $column['column_nb_open_tasks'] = isset($this->taskCountBySwimlaneAndColumn[$this->swimlaneId][$column['id']]) ? $this->taskCountBySwimlaneAndColumn[$this->swimlaneId][$column['id']] : 0;
+            }
         }
 
         return $this->columns;

--- a/app/Formatter/BoardFormatter.php
+++ b/app/Formatter/BoardFormatter.php
@@ -46,13 +46,13 @@ class BoardFormatter extends BaseFormatter implements FormatterInterface
     {
         $project = $this->projectModel->getById($this->projectId);
         $swimlanes = $this->swimlaneModel->getAllByStatus($this->projectId, SwimlaneModel::ACTIVE);
+        $columns = $this->columnModel->getAllWithOpenedTaskCount($this->projectId);
+        $task_count_by_swimlanes_and_columns = [];
+
         if ($project['per_swimlane_task_limits']) {
-            $columns = array();
-            foreach ($swimlanes as $swimlane) {
-                $columns = array_merge($columns, $this->columnModel->getAllWithPerSwimlaneTaskCount($this->projectId, $swimlane['id']));
+            foreach ($this->taskModel->getOpenTaskCountBySwimlaneAndColumn($this->projectId) as $task_count) {
+                $task_count_by_swimlanes_and_columns[$task_count['swimlane_id']][$task_count['column_id']] = $task_count['nb_open_tasks'];
             }
-        } else {
-            $columns = $this->columnModel->getAllWithOpenedTaskCount($this->projectId);
         }
 
         if (empty($swimlanes) || empty($columns)) {
@@ -74,6 +74,7 @@ class BoardFormatter extends BaseFormatter implements FormatterInterface
             ->withColumns($columns)
             ->withTasks($tasks)
             ->withTags($tags)
+            ->withTaskCountBySwimlaneAndColumn($task_count_by_swimlanes_and_columns)
             ->format();
     }
 }

--- a/app/Formatter/BoardSwimlaneFormatter.php
+++ b/app/Formatter/BoardSwimlaneFormatter.php
@@ -16,6 +16,7 @@ class BoardSwimlaneFormatter extends BaseFormatter implements FormatterInterface
     protected $columns = array();
     protected $tasks = array();
     protected $tags = array();
+    protected $taskCountBySwimlaneAndColumn = array();
 
     /**
      * Set swimlanes
@@ -70,6 +71,19 @@ class BoardSwimlaneFormatter extends BaseFormatter implements FormatterInterface
     }
 
     /**
+     * Set task count by swimlane and column
+     *
+     * @access public
+     * @param  array $taskCountBySwimlaneAndColumn
+     * @return $this
+     */
+    public function withTaskCountBySwimlaneAndColumn(array $taskCountBySwimlaneAndColumn)
+    {
+        $this->taskCountBySwimlaneAndColumn = $taskCountBySwimlaneAndColumn;
+        return $this;
+    }
+
+    /**
      * Apply formatter
      *
      * @access public
@@ -96,6 +110,7 @@ class BoardSwimlaneFormatter extends BaseFormatter implements FormatterInterface
                 ->withColumns($this->columns)
                 ->withTasks($this->tasks)
                 ->withTags($this->tags)
+                ->withTaskCountBySwimlaneAndColumn($this->taskCountBySwimlaneAndColumn)
                 ->format();
 
             $swimlane['nb_swimlanes'] = $nb_swimlanes;
@@ -112,9 +127,9 @@ class BoardSwimlaneFormatter extends BaseFormatter implements FormatterInterface
 
         foreach ($this->swimlanes as &$swimlane) {
             foreach ($swimlane['columns'] as &$column) {
-                $column['column_nb_tasks'] = $tasks_stats_by_column_across_swimlanes[$column['id']]['nb_visible_tasks_across_swimlane'];
-                $column['column_nb_open_tasks'] = $tasks_stats_by_column_across_swimlanes[$column['id']]['nb_unfiltered_tasks_across_swimlane'];
-                $column['column_score'] = $tasks_stats_by_column_across_swimlanes[$column['id']]['cumulative_score_across_swimlane'];
+                $column['nb_visible_tasks_across_swimlane'] = $tasks_stats_by_column_across_swimlanes[$column['id']]['nb_visible_tasks_across_swimlane'];
+                $column['nb_unfiltered_tasks_across_swimlane'] = $tasks_stats_by_column_across_swimlanes[$column['id']]['nb_unfiltered_tasks_across_swimlane'];
+                $column['cumulative_score_across_swimlane'] = $tasks_stats_by_column_across_swimlanes[$column['id']]['cumulative_score_across_swimlane'];
             }
         }
 

--- a/app/Model/ColumnModel.php
+++ b/app/Model/ColumnModel.php
@@ -137,7 +137,6 @@ class ColumnModel extends Base
             ->findAll();
     }
 
-
     /**
      * Get all columns with task count
      *
@@ -151,24 +150,6 @@ class ColumnModel extends Base
             ->columns('id', 'title', 'position', 'task_limit', 'description', 'hide_in_dashboard', 'project_id')
             ->subquery("SELECT COUNT(*) FROM ".TaskModel::TABLE." WHERE column_id=".self::TABLE.".id AND is_active='1'", 'nb_open_tasks')
             ->subquery("SELECT COUNT(*) FROM ".TaskModel::TABLE." WHERE column_id=".self::TABLE.".id AND is_active='0'", 'nb_closed_tasks')
-            ->eq('project_id', $project_id)
-            ->asc('position')
-            ->findAll();
-    }
-
-    /**
-     * Get all columns with task count
-     *
-     * @access public
-     * @param  integer  $project_id   Project id
-     * @return array
-     */
-    public function getAllWithPerSwimlaneTaskCount($project_id, $swimlane_id)
-    {
-        return $this->db->table(self::TABLE)
-            ->columns('id', 'title', 'position', 'task_limit', 'description', 'hide_in_dashboard', 'project_id', $swimlane_id.' AS swimlane_id')
-            ->subquery("SELECT COUNT(*) FROM ".TaskModel::TABLE." WHERE column_id=".self::TABLE.".id AND swimlane_id=".$swimlane_id." AND is_active='1'", 'nb_open_tasks')
-            ->subquery("SELECT COUNT(*) FROM ".TaskModel::TABLE." WHERE column_id=".self::TABLE.".id AND swimlane_id=".$swimlane_id." AND is_active='0'", 'nb_closed_tasks')
             ->eq('project_id', $project_id)
             ->asc('position')
             ->findAll();

--- a/app/Model/TaskModel.php
+++ b/app/Model/TaskModel.php
@@ -143,4 +143,14 @@ class TaskModel extends Base
 
         return round(($position * 100) / count($columns), 1);
     }
+
+    public function getOpenTaskCountBySwimlaneAndColumn($project_id)
+    {
+        return $this->db->table(self::TABLE)
+            ->columns('swimlane_id', 'column_id', 'COUNT(*) AS nb_open_tasks')
+            ->eq('project_id', $project_id)
+            ->eq('is_active', 1)
+            ->groupBy('swimlane_id', 'column_id')
+            ->findAll();
+    }
 }

--- a/app/Template/board/table_column.php
+++ b/app/Template/board/table_column.php
@@ -92,9 +92,9 @@
                     </span>
                 <?php endif ?>
 
-                <?php if ($swimlane['nb_swimlanes'] > 1 && ! empty($column['column_score'])): ?>
+                <?php if ($swimlane['nb_swimlanes'] > 1 && ! empty($column['cumulative_score_across_swimlane'])): ?>
                     <span title="<?= t('Total score in this column across all swimlanes') ?>">
-                        (<span><span class="ui-helper-hidden-accessible"><?= t('Total score in this column across all swimlanes') ?> </span><?= $column['column_score'] ?></span>)&nbsp;
+                        (<span><span class="ui-helper-hidden-accessible"><?= t('Total score in this column across all swimlanes') ?> </span><?= $column['cumulative_score_across_swimlane'] ?></span>)&nbsp;
                     </span>
                 <?php endif ?>
 
@@ -108,12 +108,12 @@
                 </span>
                 <?php endif ?>
 
-                <?php if (! empty($column['column_nb_open_tasks'])): ?>
+                <?php if (! empty($column['nb_unfiltered_tasks_across_swimlane'])): ?>
                 <span title="<?= t('Total number of tasks in this column across all swimlanes') ?>">
                     <?php if ($column['task_limit'] > 0): ?>
-                        (<span><span class="ui-helper-hidden-accessible"><?= t('Total number of tasks in this column across all swimlanes') ?> </span><?= $column['column_nb_open_tasks'] ?></span>/<span title="<?= t('Task limit') ?>"><span class="ui-helper-hidden-accessible"><?= t('Task limit') ?> </span><?= $this->text->e($column['task_limit']) ?></span>)
+                        (<span><span class="ui-helper-hidden-accessible"><?= t('Total number of tasks in this column across all swimlanes') ?> </span><?= $column['nb_unfiltered_tasks_across_swimlane'] ?></span>/<span title="<?= t('Task limit') ?>"><span class="ui-helper-hidden-accessible"><?= t('Task limit') ?> </span><?= $this->text->e($column['task_limit']) ?></span>)
                     <?php else: ?>
-                        (<span><span class="ui-helper-hidden-accessible"><?= t('Total number of tasks in this column across all swimlanes') ?> </span><?= $column['column_nb_open_tasks'] ?></span>)
+                        (<span><span class="ui-helper-hidden-accessible"><?= t('Total number of tasks in this column across all swimlanes') ?> </span><?= $column['nb_unfiltered_tasks_across_swimlane'] ?></span>)
                     <?php endif ?>
                 </span>
                 <?php endif ?>

--- a/tests/units/Formatter/BoardFormatterTest.php
+++ b/tests/units/Formatter/BoardFormatterTest.php
@@ -58,15 +58,15 @@ class BoardFormatterTest extends Base
         $this->assertSame(3, $board[0]['columns'][2]['id']);
         $this->assertSame(4, $board[0]['columns'][3]['id']);
 
-        $this->assertEquals(4, $board[0]['columns'][0]['column_nb_tasks']);
-        $this->assertEquals(1, $board[0]['columns'][1]['column_nb_tasks']);
-        $this->assertEquals(3, $board[0]['columns'][2]['column_nb_tasks']);
-        $this->assertEquals(0, $board[0]['columns'][3]['column_nb_tasks']);
+        $this->assertEquals(4, $board[0]['columns'][0]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(1, $board[0]['columns'][1]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(3, $board[0]['columns'][2]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][3]['nb_visible_tasks_across_swimlane']);
 
-        $this->assertEquals(9, $board[0]['columns'][0]['column_score']);
-        $this->assertEquals(0, $board[0]['columns'][1]['column_score']);
-        $this->assertEquals(6, $board[0]['columns'][2]['column_score']);
-        $this->assertEquals(0, $board[0]['columns'][3]['column_score']);
+        $this->assertEquals(9, $board[0]['columns'][0]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][1]['cumulative_score_across_swimlane']);
+        $this->assertEquals(6, $board[0]['columns'][2]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][3]['cumulative_score_across_swimlane']);
 
         $this->assertSame(9, $board[0]['columns'][0]['score']);
         $this->assertSame(0, $board[0]['columns'][1]['score']);
@@ -124,49 +124,184 @@ class BoardFormatterTest extends Base
 
         $this->assertEquals('Task 8', $board[2]['columns'][2]['tasks'][0]['title']);
         $this->assertArrayHasKey('is_draggable', $board[2]['columns'][2]['tasks'][0]);
+    }
 
-        // Assert the number of tasks in each column across swimlanes
+    public function testFormatWithSwimlanesAndTaskLimitAcrossSwimlane()
+    {
+        $projectModel = new ProjectModel($this->container);
+        $swimlaneModel = new SwimlaneModel($this->container);
+        $taskCreationModel = new TaskCreationModel($this->container);
+        $taskFinderModel = new TaskFinderModel($this->container);
+
+        $this->assertEquals(1, $projectModel->create(array('name' => 'Test')));
+        $this->assertEquals(2, $swimlaneModel->create(1, 'Swimlane 1'));
+        $this->assertEquals(3, $swimlaneModel->create(1, 'Swimlane 2'));
+
+        // 2 task within the same column but no score
+        $this->assertEquals(1, $taskCreationModel->create(array('title' => 'Task 1', 'project_id' => 1, 'swimlane_id' => 1, 'column_id' => 1)));
+        $this->assertEquals(2, $taskCreationModel->create(array('title' => 'Task 2', 'project_id' => 1, 'swimlane_id' => 1, 'column_id' => 1)));
+
+        // 2 tasks in the same column with score
+        $this->assertEquals(3, $taskCreationModel->create(array('title' => 'Task 3', 'project_id' => 1, 'swimlane_id' => 1, 'column_id' => 1, 'score' => 4)));
+        $this->assertEquals(4, $taskCreationModel->create(array('title' => 'Task 4', 'project_id' => 1, 'swimlane_id' => 1, 'column_id' => 1, 'score' => 5)));
+
+        // 1 task in 2nd column
+        $this->assertEquals(5, $taskCreationModel->create(array('title' => 'Task 5', 'project_id' => 1, 'swimlane_id' => 1, 'column_id' => 2)));
+
+        // tasks in same column but different swimlanes
+        $this->assertEquals(6, $taskCreationModel->create(array('title' => 'Task 6', 'project_id' => 1, 'swimlane_id' => 1, 'column_id' => 3, 'score' => 1)));
+        $this->assertEquals(7, $taskCreationModel->create(array('title' => 'Task 7', 'project_id' => 1, 'swimlane_id' => 2, 'column_id' => 3, 'score' => 2)));
+        $this->assertEquals(8, $taskCreationModel->create(array('title' => 'Task 8', 'project_id' => 1, 'swimlane_id' => 3, 'column_id' => 3, 'score' => 3)));
+
+        $board = BoardFormatter::getInstance($this->container)
+            ->withQuery($taskFinderModel->getExtendedQuery())
+            ->withProjectId(1)
+            ->format();
+
+        $this->assertCount(3, $board);
+
         $this->assertEquals("Default swimlane", $board[0]['name']);
-        $this->assertSame(1, $board[0]['columns'][0]['id']);
-        $this->assertSame(4, $board[0]['columns'][0]['column_nb_tasks']);
-        $this->assertSame(9, $board[0]['columns'][0]['column_score']);
-        $this->assertSame(2, $board[0]['columns'][1]['id']);
-        $this->assertSame(1, $board[0]['columns'][1]['column_nb_tasks']);
-        $this->assertSame(0, $board[0]['columns'][1]['column_score']);
-        $this->assertSame(3, $board[0]['columns'][2]['id']);
-        $this->assertSame(3, $board[0]['columns'][2]['column_nb_tasks']);
-        $this->assertSame(6, $board[0]['columns'][2]['column_score']);
-        $this->assertSame(4, $board[0]['columns'][3]['id']);
-        $this->assertSame(0, $board[0]['columns'][3]['column_nb_tasks']);
-        $this->assertSame(0, $board[0]['columns'][3]['column_score']);
+        $this->assertEquals(1, $board[0]['columns'][0]['id']);
+        $this->assertEquals(4, $board[0]['columns'][0]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(9, $board[0]['columns'][0]['cumulative_score_across_swimlane']);
+        $this->assertEquals(4, $board[0]['columns'][0]['column_nb_open_tasks']);
+        $this->assertEquals(2, $board[0]['columns'][1]['id']);
+        $this->assertEquals(1, $board[0]['columns'][1]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][1]['cumulative_score_across_swimlane']);
+        $this->assertEquals(1, $board[0]['columns'][1]['column_nb_open_tasks']);
+        $this->assertEquals(3, $board[0]['columns'][2]['id']);
+        $this->assertEquals(3, $board[0]['columns'][2]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(6, $board[0]['columns'][2]['cumulative_score_across_swimlane']);
+        $this->assertEquals(3, $board[0]['columns'][2]['column_nb_open_tasks']);
+        $this->assertEquals(4, $board[0]['columns'][3]['id']);
+        $this->assertEquals(0, $board[0]['columns'][3]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][3]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][3]['column_nb_open_tasks']);
 
         $this->assertEquals("Swimlane 1", $board[1]['name']);
-        $this->assertSame(1, $board[1]['columns'][0]['id']);
-        $this->assertSame(4, $board[1]['columns'][0]['column_nb_tasks']);
-        $this->assertSame(9, $board[1]['columns'][0]['column_score']);
-        $this->assertSame(2, $board[1]['columns'][1]['id']);
-        $this->assertSame(1, $board[1]['columns'][1]['column_nb_tasks']);
-        $this->assertSame(0, $board[1]['columns'][3]['column_score']);
-        $this->assertSame(3, $board[1]['columns'][2]['id']);
-        $this->assertSame(3, $board[1]['columns'][2]['column_nb_tasks']);
-        $this->assertSame(6, $board[1]['columns'][2]['column_score']);
-        $this->assertSame(4, $board[1]['columns'][3]['id']);
-        $this->assertSame(0, $board[1]['columns'][3]['column_nb_tasks']);
-        $this->assertSame(0, $board[1]['columns'][3]['column_score']);
+        $this->assertEquals(1, $board[1]['columns'][0]['id']);
+        $this->assertEquals(4, $board[1]['columns'][0]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(9, $board[1]['columns'][0]['cumulative_score_across_swimlane']);
+        $this->assertEquals(4, $board[1]['columns'][0]['column_nb_open_tasks']);
+        $this->assertEquals(2, $board[1]['columns'][1]['id']);
+        $this->assertEquals(1, $board[1]['columns'][1]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[1]['columns'][3]['cumulative_score_across_swimlane']);
+        $this->assertEquals(1, $board[1]['columns'][1]['column_nb_open_tasks']);
+        $this->assertEquals(3, $board[1]['columns'][2]['id']);
+        $this->assertEquals(3, $board[1]['columns'][2]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(6, $board[1]['columns'][2]['cumulative_score_across_swimlane']);
+        $this->assertEquals(3, $board[1]['columns'][2]['column_nb_open_tasks']);
+        $this->assertEquals(4, $board[1]['columns'][3]['id']);
+        $this->assertEquals(0, $board[1]['columns'][3]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[1]['columns'][3]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[1]['columns'][3]['column_nb_open_tasks']);
 
         $this->assertEquals("Swimlane 2", $board[2]['name']);
-        $this->assertSame(1, $board[2]['columns'][0]['id']);
-        $this->assertSame(4, $board[2]['columns'][0]['column_nb_tasks']);
-        $this->assertSame(9, $board[2]['columns'][0]['column_score']);
-        $this->assertSame(2, $board[2]['columns'][1]['id']);
-        $this->assertSame(1, $board[2]['columns'][1]['column_nb_tasks']);
-        $this->assertSame(0, $board[2]['columns'][1]['column_score']);
-        $this->assertSame(3, $board[2]['columns'][2]['id']);
-        $this->assertSame(3, $board[2]['columns'][2]['column_nb_tasks']);
-        $this->assertSame(6, $board[2]['columns'][2]['column_score']);
-        $this->assertSame(4, $board[2]['columns'][3]['id']);
-        $this->assertSame(0, $board[2]['columns'][3]['column_nb_tasks']);
-        $this->assertSame(0, $board[2]['columns'][3]['column_score']);
+        $this->assertEquals(1, $board[2]['columns'][0]['id']);
+        $this->assertEquals(4, $board[2]['columns'][0]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(9, $board[2]['columns'][0]['cumulative_score_across_swimlane']);
+        $this->assertEquals(4, $board[1]['columns'][0]['column_nb_open_tasks']);
+        $this->assertEquals(2, $board[2]['columns'][1]['id']);
+        $this->assertEquals(1, $board[2]['columns'][1]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[2]['columns'][1]['cumulative_score_across_swimlane']);
+        $this->assertEquals(1, $board[1]['columns'][1]['column_nb_open_tasks']);
+        $this->assertEquals(3, $board[2]['columns'][2]['id']);
+        $this->assertEquals(3, $board[2]['columns'][2]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(6, $board[2]['columns'][2]['cumulative_score_across_swimlane']);
+        $this->assertEquals(3, $board[1]['columns'][2]['column_nb_open_tasks']);
+        $this->assertEquals(4, $board[2]['columns'][3]['id']);
+        $this->assertEquals(0, $board[2]['columns'][3]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[2]['columns'][3]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[1]['columns'][3]['column_nb_open_tasks']);
+    }
+
+    public function testFormatWithSwimlanesAndTaskLimitPerSwimlane()
+    {
+        $projectModel = new ProjectModel($this->container);
+        $swimlaneModel = new SwimlaneModel($this->container);
+        $taskCreationModel = new TaskCreationModel($this->container);
+        $taskFinderModel = new TaskFinderModel($this->container);
+
+        $this->assertEquals(1, $projectModel->create(array('name' => 'Test', 'per_swimlane_task_limits' => 1)));
+        $this->assertEquals(2, $swimlaneModel->create(1, 'Swimlane 1'));
+        $this->assertEquals(3, $swimlaneModel->create(1, 'Swimlane 2'));
+
+        // 2 task within the same column but no score
+        $this->assertEquals(1, $taskCreationModel->create(array('title' => 'Task 1', 'project_id' => 1, 'swimlane_id' => 1, 'column_id' => 1)));
+        $this->assertEquals(2, $taskCreationModel->create(array('title' => 'Task 2', 'project_id' => 1, 'swimlane_id' => 1, 'column_id' => 1)));
+
+        // 2 tasks in the same column with score
+        $this->assertEquals(3, $taskCreationModel->create(array('title' => 'Task 3', 'project_id' => 1, 'swimlane_id' => 1, 'column_id' => 1, 'score' => 4)));
+        $this->assertEquals(4, $taskCreationModel->create(array('title' => 'Task 4', 'project_id' => 1, 'swimlane_id' => 1, 'column_id' => 1, 'score' => 5)));
+
+        // 1 task in 2nd column
+        $this->assertEquals(5, $taskCreationModel->create(array('title' => 'Task 5', 'project_id' => 1, 'swimlane_id' => 1, 'column_id' => 2)));
+
+        // tasks in same column but different swimlanes
+        $this->assertEquals(6, $taskCreationModel->create(array('title' => 'Task 6', 'project_id' => 1, 'swimlane_id' => 1, 'column_id' => 3, 'score' => 1)));
+        $this->assertEquals(7, $taskCreationModel->create(array('title' => 'Task 7', 'project_id' => 1, 'swimlane_id' => 2, 'column_id' => 3, 'score' => 2)));
+        $this->assertEquals(8, $taskCreationModel->create(array('title' => 'Task 8', 'project_id' => 1, 'swimlane_id' => 3, 'column_id' => 3, 'score' => 3)));
+
+        $board = BoardFormatter::getInstance($this->container)
+            ->withQuery($taskFinderModel->getExtendedQuery())
+            ->withProjectId(1)
+            ->format();
+
+        $this->assertCount(3, $board);
+
+        $this->assertEquals("Default swimlane", $board[0]['name']);
+        $this->assertEquals(1, $board[0]['columns'][0]['id']);
+        $this->assertEquals(4, $board[0]['columns'][0]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(9, $board[0]['columns'][0]['cumulative_score_across_swimlane']);
+        $this->assertEquals(4, $board[0]['columns'][0]['column_nb_open_tasks']);
+        $this->assertEquals(2, $board[0]['columns'][1]['id']);
+        $this->assertEquals(1, $board[0]['columns'][1]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][1]['cumulative_score_across_swimlane']);
+        $this->assertEquals(1, $board[0]['columns'][1]['column_nb_open_tasks']);
+        $this->assertEquals(3, $board[0]['columns'][2]['id']);
+        $this->assertEquals(3, $board[0]['columns'][2]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(6, $board[0]['columns'][2]['cumulative_score_across_swimlane']);
+        $this->assertEquals(1, $board[0]['columns'][2]['column_nb_open_tasks']);
+        $this->assertEquals(4, $board[0]['columns'][3]['id']);
+        $this->assertEquals(0, $board[0]['columns'][3]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][3]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][3]['column_nb_open_tasks']);
+
+        $this->assertEquals("Swimlane 1", $board[1]['name']);
+        $this->assertEquals(1, $board[1]['columns'][0]['id']);
+        $this->assertEquals(4, $board[1]['columns'][0]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(9, $board[1]['columns'][0]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[1]['columns'][0]['column_nb_open_tasks']);
+        $this->assertEquals(2, $board[1]['columns'][1]['id']);
+        $this->assertEquals(1, $board[1]['columns'][1]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[1]['columns'][3]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[1]['columns'][1]['column_nb_open_tasks']);
+        $this->assertEquals(3, $board[1]['columns'][2]['id']);
+        $this->assertEquals(3, $board[1]['columns'][2]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(6, $board[1]['columns'][2]['cumulative_score_across_swimlane']);
+        $this->assertEquals(1, $board[1]['columns'][2]['column_nb_open_tasks']);
+        $this->assertEquals(4, $board[1]['columns'][3]['id']);
+        $this->assertEquals(0, $board[1]['columns'][3]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[1]['columns'][3]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[1]['columns'][3]['column_nb_open_tasks']);
+
+        $this->assertEquals("Swimlane 2", $board[2]['name']);
+        $this->assertEquals(1, $board[2]['columns'][0]['id']);
+        $this->assertEquals(4, $board[2]['columns'][0]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(9, $board[2]['columns'][0]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[1]['columns'][0]['column_nb_open_tasks']);
+        $this->assertEquals(2, $board[2]['columns'][1]['id']);
+        $this->assertEquals(1, $board[2]['columns'][1]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[2]['columns'][1]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[1]['columns'][1]['column_nb_open_tasks']);
+        $this->assertEquals(3, $board[2]['columns'][2]['id']);
+        $this->assertEquals(3, $board[2]['columns'][2]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(6, $board[2]['columns'][2]['cumulative_score_across_swimlane']);
+        $this->assertEquals(1, $board[1]['columns'][2]['column_nb_open_tasks']);
+        $this->assertEquals(4, $board[2]['columns'][3]['id']);
+        $this->assertEquals(0, $board[2]['columns'][3]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[2]['columns'][3]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[1]['columns'][3]['column_nb_open_tasks']);
     }
 
     public function testFormatWithoutDefaultSwimlane()
@@ -200,15 +335,15 @@ class BoardFormatterTest extends Base
         $this->assertEquals(2, $board[0]['nb_tasks']);
         $this->assertEquals(1, $board[0]['score']);
 
-        $this->assertEquals(2, $board[0]['columns'][0]['column_nb_tasks']);
-        $this->assertEquals(2, $board[0]['columns'][1]['column_nb_tasks']);
-        $this->assertEquals(0, $board[0]['columns'][2]['column_nb_tasks']);
-        $this->assertEquals(0, $board[0]['columns'][3]['column_nb_tasks']);
+        $this->assertEquals(2, $board[0]['columns'][0]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(2, $board[0]['columns'][1]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][2]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][3]['nb_visible_tasks_across_swimlane']);
 
-        $this->assertEquals(0, $board[0]['columns'][0]['column_score']);
-        $this->assertEquals(1, $board[0]['columns'][1]['column_score']);
-        $this->assertEquals(0, $board[0]['columns'][2]['column_score']);
-        $this->assertEquals(0, $board[0]['columns'][3]['column_score']);
+        $this->assertEquals(0, $board[0]['columns'][0]['cumulative_score_across_swimlane']);
+        $this->assertEquals(1, $board[0]['columns'][1]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][2]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][3]['cumulative_score_across_swimlane']);
 
         $this->assertSame(0, $board[0]['columns'][0]['score']);
         $this->assertSame(1, $board[0]['columns'][1]['score']);
@@ -305,15 +440,15 @@ class BoardFormatterTest extends Base
         $this->assertEquals(0, $board[0]['nb_tasks']);
         $this->assertEquals(0, $board[0]['score']);
 
-        $this->assertEquals(0, $board[0]['columns'][0]['column_nb_tasks']);
-        $this->assertEquals(0, $board[0]['columns'][1]['column_nb_tasks']);
-        $this->assertEquals(0, $board[0]['columns'][2]['column_nb_tasks']);
-        $this->assertEquals(0, $board[0]['columns'][3]['column_nb_tasks']);
+        $this->assertEquals(0, $board[0]['columns'][0]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][1]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][2]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][3]['nb_visible_tasks_across_swimlane']);
 
-        $this->assertEquals(0, $board[0]['columns'][0]['column_score']);
-        $this->assertEquals(0, $board[0]['columns'][1]['column_score']);
-        $this->assertEquals(0, $board[0]['columns'][2]['column_score']);
-        $this->assertEquals(0, $board[0]['columns'][3]['column_score']);
+        $this->assertEquals(0, $board[0]['columns'][0]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][1]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][2]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][3]['cumulative_score_across_swimlane']);
 
         $this->assertSame(0, $board[0]['columns'][0]['score']);
         $this->assertSame(0, $board[0]['columns'][1]['score']);
@@ -389,15 +524,15 @@ class BoardFormatterTest extends Base
         $this->assertEquals(3, $board[0]['nb_tasks']);
         $this->assertEquals(0, $board[0]['score']);
 
-        $this->assertEquals(2, $board[0]['columns'][0]['column_nb_tasks']);
-        $this->assertEquals(0, $board[0]['columns'][1]['column_nb_tasks']);
-        $this->assertEquals(1, $board[0]['columns'][2]['column_nb_tasks']);
-        $this->assertEquals(0, $board[0]['columns'][3]['column_nb_tasks']);
+        $this->assertEquals(2, $board[0]['columns'][0]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][1]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(1, $board[0]['columns'][2]['nb_visible_tasks_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][3]['nb_visible_tasks_across_swimlane']);
 
-        $this->assertEquals(0, $board[0]['columns'][0]['column_score']);
-        $this->assertEquals(0, $board[0]['columns'][1]['column_score']);
-        $this->assertEquals(0, $board[0]['columns'][2]['column_score']);
-        $this->assertEquals(0, $board[0]['columns'][3]['column_score']);
+        $this->assertEquals(0, $board[0]['columns'][0]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][1]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][2]['cumulative_score_across_swimlane']);
+        $this->assertEquals(0, $board[0]['columns'][3]['cumulative_score_across_swimlane']);
 
         $this->assertSame(0, $board[0]['columns'][0]['score']);
         $this->assertSame(0, $board[0]['columns'][1]['score']);


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I have updated the unit tests and integration tests accordingly
- [X] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

