### PR TITLE
fix: add HTML escaping when displaying exception message in `index.php`

### DIFF
--- a/index.php
+++ b/index.php
@@ -8,5 +8,5 @@ try {
     $runner = new Runner($container);
     $runner->execute();
 } catch (Exception $e) {
-    echo 'Internal Error: '.$e->getMessage();
+    echo htmlspecialchars('Internal Error: '.$e->getMessage(), ENT_QUOTES, 'UTF-8', false);
 }


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking change
- [X] There is no regression
- [X] I have updated the unit tests and integration tests accordingly
- [X] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)
- [X] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
