### PR TITLE
Extensible projects

### DIFF
--- a/app/Template/project_creation/create.php
+++ b/app/Template/project_creation/create.php
@@ -40,6 +40,8 @@
             <?= $this->form->checkbox('projectTaskDuplicationModel', t('Tasks'), 1, false) ?>
         </div>
 
+        <?= $this->hook->render('template:project:creation:form', array('values' => $values, 'errors' => $errors)) ?>
+
         <?= $this->modal->submitButtons() ?>
     </form>
     <?php if ($is_private): ?>

--- a/app/Template/project_edit/show.php
+++ b/app/Template/project_edit/show.php
@@ -27,6 +27,9 @@
         <?= $this->form->label(t('Description'), 'description') ?>
         <?= $this->form->textEditor('description', $values, $errors, array('tabindex' => 4)) ?>
 
+        <?= $this->hook->render('template:project:edit:form', array('values' => $values, 'errors' => $errors)) ?>
+
+
         <?= $this->form->checkbox('per_swimlane_task_limits', t('Task limits apply to each swimlane individually'), 1, $project['per_swimlane_task_limits'] == 1, '', array('tabindex' => 5)) ?>
 
         <?= $this->form->label(t('Task limit'), 'task_limit') ?>

--- a/app/Template/project_view/show.php
+++ b/app/Template/project_view/show.php
@@ -46,6 +46,9 @@
         <h2><?= t('Description') ?></h2>
     </div>
 
+    <?= $this->hook->render('template:project:view:form', array('values' => $values, 'errors' => $errors)) ?>
+
+
     <article class="markdown">
         <?= $this->text->markdown($project['description']) ?>
     </article>


### PR DESCRIPTION
Do you follow the guidelines?

[ x ] I have tested my changes
[ x ] There is no breaking change
[ x ] There is no regression
[ x ] I have updated the unit tests and integration tests accordingly
[ x ] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)
[ x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
Feature Request: Add hook to project_creation/create.php

I would like to request the addition of a hook in the project_creation/create.php template to allow plugins to inject custom fields or content into the project creation form.

The hook could be added as:

Feature Request: 

- Add hook to project_creation/create.php
- Add hook to project_edit/show.php
- Add hook to project_view/show.php

I would like to request the addition of a hook in the projects template to allow plugins to inject custom fields or content into the project creation form.

The hook could be added as:

php
Copiar código
<?= $this->hook->render('template:project:creation:form', array('values' => $values, 'errors' => $errors)) ?>
<?= $this->hook->render('template:project:creation:edit', array('values' => $values, 'errors' => $errors)) ?>
<?= $this->hook->render('template:project:creation:view', array('values' => $values, 'errors' => $errors)) ?>

This would allow plugin developers to easily extend the project creation form without needing to override the entire template file. This change would improve the extensibility of the Kanboard project for custom plugins.