### PR TITLE
fix: avoid path traversal in `FileStorage`

### DIFF
--- a/app/Core/ObjectStorage/FileStorage.php
+++ b/app/Core/ObjectStorage/FileStorage.php
@@ -11,22 +11,32 @@ namespace Kanboard\Core\ObjectStorage;
 class FileStorage implements ObjectStorageInterface
 {
     /**
-     * Base path
+     * Base directory
      *
      * @access private
      * @var string
      */
-    private $path = '';
+    private $baseDir = '';
 
     /**
      * Constructor
      *
      * @access public
-     * @param  string  $path
+     * @param  string  $baseDir
      */
-    public function __construct($path)
+    public function __construct($baseDir)
     {
-        $this->path = $path;
+        $realBaseDir = realpath($baseDir);
+
+        if ($realBaseDir === false) {
+            throw new ObjectStorageException('Invalid base folder: '.$baseDir);
+        }
+
+        if (! is_dir($realBaseDir)) {
+            throw new ObjectStorageException('Base folder is not a directory: '.$baseDir);
+        }
+
+        $this->baseDir = $realBaseDir;
     }
 
     /**
@@ -39,13 +49,7 @@ class FileStorage implements ObjectStorageInterface
      */
     public function get($key)
     {
-        $filename = $this->path.DIRECTORY_SEPARATOR.$key;
-
-        if (! file_exists($filename)) {
-            throw new ObjectStorageException('File not found: '.$filename);
-        }
-
-        return file_get_contents($filename);
+        return file_get_contents($this->getRealFilePath($key));
     }
 
     /**
@@ -60,8 +64,8 @@ class FileStorage implements ObjectStorageInterface
     {
         $this->createFolder($key);
 
-        if (file_put_contents($this->path.DIRECTORY_SEPARATOR.$key, $blob) === false) {
-            throw new ObjectStorageException('Unable to write the file: '.$this->path.DIRECTORY_SEPARATOR.$key);
+        if (file_put_contents($this->baseDir.DIRECTORY_SEPARATOR.$key, $blob) === false) {
+            throw new ObjectStorageException('Unable to write the file: '.$this->baseDir.DIRECTORY_SEPARATOR.$key);
         }
     }
 
@@ -74,13 +78,7 @@ class FileStorage implements ObjectStorageInterface
      */
     public function output($key)
     {
-        $filename = $this->path.DIRECTORY_SEPARATOR.$key;
-
-        if (! file_exists($filename)) {
-            throw new ObjectStorageException('File not found: '.$filename);
-        }
-
-        readfile($filename);
+        readfile($this->getRealFilePath($key));
     }
 
     /**
@@ -95,7 +93,7 @@ class FileStorage implements ObjectStorageInterface
     public function moveFile($src_filename, $key)
     {
         $this->createFolder($key);
-        $dst_filename = $this->path.DIRECTORY_SEPARATOR.$key;
+        $dst_filename = $this->baseDir.DIRECTORY_SEPARATOR.$key;
 
         if (! rename($src_filename, $dst_filename)) {
             throw new ObjectStorageException('Unable to move the file: '.$src_filename.' to '.$dst_filename);
@@ -115,7 +113,7 @@ class FileStorage implements ObjectStorageInterface
     public function moveUploadedFile($filename, $key)
     {
         $this->createFolder($key);
-        return move_uploaded_file($filename, $this->path.DIRECTORY_SEPARATOR.$key);
+        return move_uploaded_file($filename, $this->baseDir.DIRECTORY_SEPARATOR.$key);
     }
 
     /**
@@ -127,19 +125,15 @@ class FileStorage implements ObjectStorageInterface
      */
     public function remove($key)
     {
-        $filename = $this->path.DIRECTORY_SEPARATOR.$key;
-        $result = false;
+        $filename = $this->getRealFilePath($key);
+        $result = unlink($filename);
 
-        if (file_exists($filename)) {
-            $result = unlink($filename);
+        // Remove parent folder if empty
+        $parentFolder = dirname($filename);
+        $files = glob($parentFolder.DIRECTORY_SEPARATOR.'*');
 
-            // Remove parent folder if empty
-            $parentFolder = dirname($filename);
-            $files = glob($parentFolder.DIRECTORY_SEPARATOR.'*');
-
-            if ($files !== false && is_dir($parentFolder) && count($files) === 0) {
-                rmdir($parentFolder);
-            }
+        if ($files !== false && is_dir($parentFolder) && count($files) === 0) {
+            rmdir($parentFolder);
         }
 
         return $result;
@@ -154,10 +148,37 @@ class FileStorage implements ObjectStorageInterface
      */
     private function createFolder($key)
     {
-        $folder = strpos($key, DIRECTORY_SEPARATOR) !== false ? $this->path.DIRECTORY_SEPARATOR.dirname($key) : $this->path;
+        $folder = strpos($key, DIRECTORY_SEPARATOR) !== false ? $this->baseDir.DIRECTORY_SEPARATOR.dirname($key) : $this->baseDir;
 
         if (! is_dir($folder) && ! mkdir($folder, 0755, true)) {
             throw new ObjectStorageException('Unable to create folder: '.$folder);
         }
+    }
+
+    /**
+     * Get real file path
+     *
+     * @access private
+     * @throws ObjectStorageException
+     * @param  string  $key
+     * @return string
+     */
+    private function getRealFilePath($key)
+    {
+        $realFilePath = realpath($this->baseDir.DIRECTORY_SEPARATOR.$key);
+
+        if ($realFilePath === false) {
+            throw new ObjectStorageException('Invalid path: '.$key);
+        }
+
+        if (strpos($realFilePath, $this->baseDir) !== 0) {
+            throw new ObjectStorageException('File is not in base directory: '.$realFilePath);
+        }
+
+        if (! file_exists($realFilePath)) {
+            throw new ObjectStorageException('File not found: '.$realFilePath);
+        }
+
+        return $realFilePath;
     }
 }

--- a/tests/units/Base.php
+++ b/tests/units/Base.php
@@ -7,7 +7,6 @@ use Composer\Autoload\ClassLoader;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
 use Symfony\Component\Stopwatch\Stopwatch;
-use Kanboard\Core\Log\Logger;
 use Kanboard\Core\Session\FlashMessage;
 use Kanboard\ServiceProvider\ActionProvider;
 
@@ -95,25 +94,25 @@ abstract class Base extends PHPUnit\Framework\TestCase
         $this->container['httpClient'] = $this
             ->getMockBuilder('\Kanboard\Core\Http\Client')
             ->setConstructorArgs(array($this->container))
-            ->setMethods(array('get', 'getJson', 'postJson', 'postJsonAsync', 'postForm', 'postFormAsync'))
+            ->onlyMethods(array('get', 'getJson', 'postJson', 'postJsonAsync', 'postForm', 'postFormAsync'))
             ->getMock();
 
         $this->container['emailClient'] = $this
             ->getMockBuilder('\Kanboard\Core\Mail\Client')
             ->setConstructorArgs(array($this->container))
-            ->setMethods(array('send'))
+            ->onlyMethods(array('send'))
             ->getMock();
 
         $this->container['userNotificationTypeModel'] = $this
             ->getMockBuilder('\Kanboard\Model\UserNotificationTypeModel')
             ->setConstructorArgs(array($this->container))
-            ->setMethods(array('getType', 'getSelectedTypes'))
+            ->onlyMethods(array('getType', 'getSelectedTypes'))
             ->getMock();
 
         $this->container['objectStorage'] = $this
             ->getMockBuilder('\Kanboard\Core\ObjectStorage\FileStorage')
-            ->setConstructorArgs(array($this->container))
-            ->setMethods(array('put', 'moveFile', 'remove', 'moveUploadedFile'))
+            ->setConstructorArgs([sys_get_temp_dir()])
+            ->onlyMethods(array('put', 'moveFile', 'remove', 'moveUploadedFile'))
             ->getMock();
 
         $this->container->register(new ActionProvider);


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression
- [x] I have updated the unit tests and integration tests accordingly
- [x] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
