### PR TITLE
Don't export-ignore the ChangeLog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,7 +16,6 @@ data/*.sqlite export-ignore
 tests export-ignore
 composer.json export-ignore
 composer.lock export-ignore
-ChangeLog export-ignore
 
 assets/css/src export-ignore
 assets/js/components export-ignore


### PR DESCRIPTION
It is useful to include the ChangeLog in the release tarballs.

Not only by the end users but also by packagers.