### PR TITLE
Update files.php to sort files by date in task view

### DIFF
--- a/app/Template/task_file/files.php
+++ b/app/Template/task_file/files.php
@@ -6,6 +6,12 @@
             <th class="column-15"><?= t('Creator') ?></th>
             <th class="column-10"><?= t('Date') ?></th>
         </tr>
+        <?php  
+        foreach ($files as $key => $row) {  
+            $dates[$key] = $row['date'];  
+        }  
+        array_multisort($dates, SORT_DESC, $files);  
+        ?>        
         <?php foreach ($files as $file): ?>
             <tr>
                 <td>


### PR DESCRIPTION
This update sorts the files-attachements in a task in descending order by date (from newest to oldest). It is based on the recommendation from [this discussion](https://kanboard.discourse.group/t/quick-workaround-to-sort-attachments-of-a-task-by-date/2735) and has been successfully used in our company for some time.
