### PR TITLE
Update images.php to sort images-attachements by date in task view

### DIFF
--- a/app/Template/task_file/images.php
+++ b/app/Template/task_file/images.php
@@ -1,5 +1,13 @@
 <?php if (! empty($images)): ?>
     <div class="file-thumbnails">
+        <?php  
+        if (! empty($images)) {  
+            foreach ($images as $key => $row) {  
+                $dates[$key] = $row['date'];  
+            }  
+            array_multisort($dates, SORT_DESC, $images);  
+        }   
+        ?>
         <?php foreach ($images as $file): ?>
             <div class="file-thumbnail">
                 <?= $this->app->component('image-slideshow', array(


### PR DESCRIPTION
This update sorts the images-attachements' preview in a task in descending order by date (from newest to oldest). It is based on the recommendation from [this discussion](https://kanboard.discourse.group/t/quick-workaround-to-sort-attachments-of-a-task-by-date/2735) and has been successfully used in our company for some time.
