### PR TITLE
Enable notifications by default

### DIFF
--- a/app/Controller/UserCreationController.php
+++ b/app/Controller/UserCreationController.php
@@ -70,6 +70,14 @@ class UserCreationController extends BaseController
             if (! empty($values['notifications_enabled'])) {
                 $this->userNotificationTypeModel->saveSelectedTypes($user_id, array(MailNotification::TYPE));
             }
+			
+			if (ENABLE_NOTIFICATIONS) {
+				$this->userNotificationModel->enableNotification($user_id);	
+				$this->userNotificationTypeModel->saveSelectedTypes($user_id, array(MailNotification::TYPE,WebNotification::TYPE));
+				if (NOTIFICATION_FILTER >= 1 && NOTIFICATION_FILTER <= 4) {
+					$this->userNotificationFilterModel->saveFilter($user_id, NOTIFICATION_FILTER);
+				}
+			}
 
             $this->flash->success(t('User created successfully.'));
             $this->response->redirect($this->helper->url->to('UserViewController', 'show', array('user_id' => $user_id)));

--- a/app/Core/User/UserSync.php
+++ b/app/Core/User/UserSync.php
@@ -70,6 +70,16 @@ class UserSync extends Base
             $this->logger->error('Unable to create user profile: '.$user->getExternalId());
             return array();
         }
+		else
+		{
+			if (ENABLE_NOTIFICATIONS) {
+			    $this->userNotificationModel->enableNotification($userId);	
+			    $this->userNotificationTypeModel->saveSelectedTypes($userId, array(MailNotification::TYPE,WebNotification::TYPE));
+			    if (NOTIFICATION_FILTER >= 1 && NOTIFICATION_FILTER <= 4) {
+				    $this->userNotificationFilterModel->saveFilter($userId, NOTIFICATION_FILTER);
+			    }
+			}
+		}
 
         return $this->userModel->getById($userId);
     }

--- a/app/constants.php
+++ b/app/constants.php
@@ -182,3 +182,7 @@ defined('DOCUMENTATION_URL_PATTERN') or define('DOCUMENTATION_URL_PATTERN', gete
 
 // Dashboard settings
 defined('DASHBOARD_MAX_PROJECTS') or define('DASHBOARD_MAX_PROJECTS', getenv('DASHBOARD_MAX_PROJECTS') ?: 10);
+
+//Notification Settings
+defined('ENABLE_NOTIFICATIONS') or define('ENABLE_NOTIFICATIONS', getenv('ENABLE_NOTIFICATIONS') ?: false);
+defined('NOTIFICATION_FILTER') or define('NOTIFICATION_FILTER', getenv('NOTIFICATION_FILTER') ?: 4);

--- a/config.default.php
+++ b/config.default.php
@@ -291,7 +291,7 @@ define('SHOW_GROUP_MEMBERSHIPS_IN_USERLIST_WITH_LIMIT', 7);
 define('DASHBOARD_MAX_PROJECTS', 10);
 
 //Enable notifications by default
-define('ENABLE_NOTIFICATIONS',true);
+define('ENABLE_NOTIFICATIONS',false);
 
 //Default notification filter 1=All tasks, 2=Tasks assigned to User, 3=Tasks created by User, 4=Tasks created by User and tasks assigned to User
-define('NOTIFICATION_FILTER',2);
+define('NOTIFICATION_FILTER',4);

--- a/config.default.php
+++ b/config.default.php
@@ -289,3 +289,9 @@ define('SHOW_GROUP_MEMBERSHIPS_IN_USERLIST_WITH_LIMIT', 7);
 
 // Dashboard settings
 define('DASHBOARD_MAX_PROJECTS', 10);
+
+//Enable notifications by default
+define('ENABLE_NOTIFICATIONS',true);
+
+//Default notification filter 1=All tasks, 2=Tasks assigned to User, 3=Tasks created by User, 4=Tasks created by User and tasks assigned to User
+define('NOTIFICATION_FILTER',2);


### PR DESCRIPTION
Add the option to enable notificiations by default. See issue #4997 

- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression
- [ ] I have updated the unit tests and integration tests accordingly
- [x] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)

