### PR TITLE
fix(docker): legacy key/value format with whitespace separator should not be used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
 FROM alpine:3.21
 
-LABEL org.opencontainers.image.source https://github.com/kanboard/kanboard
-LABEL org.opencontainers.image.title=Kanboard
-LABEL org.opencontainers.image.description="Kanboard is project management software that focuses on the Kanban methodology"
-LABEL org.opencontainers.image.vendor=Kanboard
-LABEL org.opencontainers.image.licenses=MIT
-LABEL org.opencontainers.image.url=https://kanboard.org
-LABEL org.opencontainers.image.documentation=https://docs.kanboard.org
+LABEL org.opencontainers.image.source="https://github.com/kanboard/kanboard" \
+    org.opencontainers.image.title="Kanboard" \
+    org.opencontainers.image.description="Kanboard is project management software that focuses on the Kanban methodology" \
+    org.opencontainers.image.vendor="Kanboard" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://kanboard.org" \
+    org.opencontainers.image.documentation="https://docs.kanboard.org"
 
-VOLUME /var/www/app/data
-VOLUME /var/www/app/plugins
-VOLUME /etc/nginx/ssl
+VOLUME ["/var/www/app/data", "/var/www/app/plugins", "/etc/nginx/ssl"]
 
 EXPOSE 80 443
 


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking change
- [x] There is no regression
- [x] I have updated the unit tests and integration tests accordingly
- [x] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
