### PR TITLE
ci(docker): avoid using `set-output` deprecated command

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,32 +22,26 @@ jobs:
           push: false
 
   multiplatform-build:
+    if: ${{ ! github.event.pull_request }}
     permissions:
       packages: write
-    if: ${{ ! github.event.pull_request }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Generate Docker tag
-        id: docker_tag
-        run: |
-          SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`
-          APP_VERSION="main.${SHORT_SHA}"
-          DOCKER_IMAGE=kanboard/kanboard
-          DOCKER_VERSION=dev
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-          DOCKER_VERSION="nightly"
-          TAGS="docker.io/${DOCKER_IMAGE}:${DOCKER_VERSION},ghcr.io/${DOCKER_IMAGE}:${DOCKER_VERSION},quay.io/${DOCKER_IMAGE}:${DOCKER_VERSION}"
-          elif [[ $GITHUB_REF == refs/tags/* ]]; then
-          DOCKER_VERSION=${GITHUB_REF#refs/tags/}
-          APP_VERSION=$DOCKER_VERSION
-          TAGS="docker.io/${DOCKER_IMAGE}:${DOCKER_VERSION},ghcr.io/${DOCKER_IMAGE}:${DOCKER_VERSION},quay.io/${DOCKER_IMAGE}:${DOCKER_VERSION},docker.io/${DOCKER_IMAGE}:latest,ghcr.io/${DOCKER_IMAGE}:latest,quay.io/${DOCKER_IMAGE}:latest"
-          fi
-          echo ::set-output name=version::${APP_VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      - name: Generate Docker Metadata
+        id: docker_metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            docker.io/${{ github.repository_owner }}/kanboard
+            ghcr.io/${{ github.repository_owner }}/kanboard
+            quay.io/${{ github.repository_owner }}/kanboard
+          tags: |
+            type=ref,event=pr
+            type=schedule,pattern=nightly
+            type=semver,pattern={{raw}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -81,7 +75,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           build-args: |
-            VERSION=${{ steps.docker_tag.outputs.version }}
-          tags: ${{ steps.docker_tag.outputs.tags }}
+            VERSION=${{ steps.docker_metadata.outputs.version }}
+          tags: ${{ steps.docker_metadata.outputs.tags }}


### PR DESCRIPTION
Please confirm that you've completed the following before submitting:

- [x] I have tested my changes thoroughly
- [x] No breaking changes were introduced
- [x] No regressions were observed
- [x] I have updated the unit tests and integration tests accordingly
- [x] I follow the existing [coding standards](https://docs.kanboard.org/v1/dev/coding_standards/)
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
