### PR TITLE
fix(security): prevent potential `Host` header injection via `SERVER_NAME`

### DIFF
--- a/app/Helper/UrlHelper.php
+++ b/app/Helper/UrlHelper.php
@@ -148,7 +148,7 @@ class UrlHelper extends Base
     public function base()
     {
         if (empty($this->base)) {
-            $this->base = $this->configModel->get('application_url') ?: $this->server();
+            $this->base = $this->configModel->get('application_url') ?: 'http://localhost/';
         }
 
         return $this->base;
@@ -173,26 +173,6 @@ class UrlHelper extends Base
         }
 
         return $this->directory;
-    }
-
-    /**
-     * Get current server base url
-     *
-     * @access public
-     * @return string
-     */
-    public function server()
-    {
-        if ($this->request->getServerVariable('SERVER_NAME') === '') {
-            return 'http://localhost/';
-        }
-
-        $url = $this->request->isHTTPS() ? 'https://' : 'http://';
-        $url .= $this->request->getServerVariable('SERVER_NAME');
-        $url .= $this->request->getServerVariable('SERVER_PORT') == 80 || $this->request->getServerVariable('SERVER_PORT') == 443 ? '' : ':'.$this->request->getServerVariable('SERVER_PORT');
-        $url .= $this->dir() ?: '/';
-
-        return $url;
     }
 
     /**

--- a/tests/units/Helper/UrlHelperTest.php
+++ b/tests/units/Helper/UrlHelperTest.php
@@ -77,43 +77,10 @@ class UrlHelperTest extends Base
         $this->assertEquals('/', $h->dir());
     }
 
-    public function testServer()
-    {
-        $this->container['request'] = new Request($this->container, array(
-                'PHP_SELF' => '/index.php',
-                'REQUEST_METHOD' => 'GET',
-                'SERVER_NAME' => 'localhost',
-                'SERVER_PORT' => 80,
-            )
-        );
-
-        $h = new UrlHelper($this->container);
-        $this->assertEquals('http://localhost/', $h->server());
-
-        $this->container['request'] = new Request($this->container, array(
-                'PHP_SELF' => '/index.php',
-                'REQUEST_METHOD' => 'GET',
-                'SERVER_NAME' => 'kb',
-                'SERVER_PORT' => 1234,
-            )
-        );
-
-        $h = new UrlHelper($this->container);
-        $this->assertEquals('http://kb:1234/', $h->server());
-    }
-
     public function testBase()
     {
-        $this->container['request'] = new Request($this->container, array(
-                'PHP_SELF' => '/index.php',
-                'REQUEST_METHOD' => 'GET',
-                'SERVER_NAME' => 'kb',
-                'SERVER_PORT' => 1234,
-            )
-        );
-
         $h = new UrlHelper($this->container);
-        $this->assertEquals('http://kb:1234/', $h->base());
+        $this->assertEquals('http://localhost/', $h->base());
 
         $c = new ConfigModel($this->container);
         $c->save(array('application_url' => 'https://mykanboard/'));


### PR DESCRIPTION
PHP's `SERVER_NAME` is commonly derived from the `Host` header, which can be manipulated by clients and lead to header injection vulnerabilities.

This change removes all usage of `SERVER_NAME` for generating absolute URLs and falls back to `http://localhost/` when the application URL is not explicitly configured.