### PR TITLE
feat: show CAPTCHA on login form regardless of user existence

### DIFF
--- a/app/Controller/AuthController.php
+++ b/app/Controller/AuthController.php
@@ -22,8 +22,14 @@ class AuthController extends BaseController
         if ($this->userSession->isLogged()) {
             $this->response->redirect($this->helper->url->to('DashboardController', 'show'));
         } else {
+            $showCaptcha = false;
+            if (! empty($values['username']) && $this->userLockingModel->hasCaptcha($values['username'])) {
+                $showCaptcha = true;
+            } elseif ($this->captchaModel->isLocked($this->request->getIpAddress())) {
+                $showCaptcha = true;
+            }
             $this->response->html($this->helper->layout->app('auth/index', array(
-                'captcha' => ! empty($values['username']) && $this->userLockingModel->hasCaptcha($values['username']),
+                'captcha' => $showCaptcha,
                 'errors' => $errors,
                 'values' => $values,
                 'no_layout' => true,

--- a/app/Core/Base.php
+++ b/app/Core/Base.php
@@ -87,6 +87,7 @@ use Pimple\Container;
  * @property \Kanboard\Model\ActionParameterModel                    $actionParameterModel
  * @property \Kanboard\Model\AvatarFileModel                         $avatarFileModel
  * @property \Kanboard\Model\BoardModel                              $boardModel
+ * @property \Kanboard\Model\CaptchaModel                            $captchaModel
  * @property \Kanboard\Model\CategoryModel                           $categoryModel
  * @property \Kanboard\Model\ColorModel                              $colorModel
  * @property \Kanboard\Model\ColumnModel                             $columnModel

--- a/app/Model/CaptchaModel.php
+++ b/app/Model/CaptchaModel.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Kanboard\Model;
+
+use Kanboard\Core\Base;
+
+/**
+ * Captcha model
+ *
+ * @package  Kanboard\Model
+ *
+ * {"<IP_ADDRESS>": {"failed_login": <COUNT>, "expiration_date": <TIMESTAMP>}}
+ */
+class CaptchaModel extends Base
+{
+    public function incrementFailedLogin($ipAddress)
+    {
+        $data = $this->getCaptchaData();
+        if (!isset($data[$ipAddress])) {
+            $data[$ipAddress] = ['failed_login' => 0, 'expiration_date' => 0];
+        }
+
+        $data[$ipAddress]['failed_login']++;
+        if ($data[$ipAddress]['failed_login'] >= BRUTEFORCE_CAPTCHA) {
+            $data[$ipAddress]['lock_expiration_date'] = time() + BRUTEFORCE_LOCKDOWN_DURATION;
+        }
+
+        $this->setCaptchaData($data);
+    }
+
+    public function resetFailedLogin($ipAddress)
+    {
+        $data = $this->getCaptchaData();
+        if (isset($data[$ipAddress])) {
+            unset($data[$ipAddress]);
+            $this->setCaptchaData($data);
+        }
+    }
+
+    public function isLocked($ipAddress)
+    {
+        $data = $this->getCaptchaData();
+        if (isset($data[$ipAddress]) && isset($data[$ipAddress]['lock_expiration_date'])) {
+            return $data[$ipAddress]['lock_expiration_date'] > time();
+        }
+        return false;
+    }
+
+    protected function getCaptchaData()
+    {
+        $rawData = $this->configModel->getOption('captcha_data', '{}');
+        $data = json_decode($rawData, true);
+        if (!is_array($data)) {
+            $data = [];
+        }
+        return $data;
+    }
+
+    protected function setCaptchaData(array $data)
+    {
+        $this->configModel->save(['captcha_data' => json_encode($data)]);
+    }
+}

--- a/app/ServiceProvider/ClassProvider.php
+++ b/app/ServiceProvider/ClassProvider.php
@@ -31,6 +31,7 @@ class ClassProvider implements ServiceProviderInterface
             'ActionParameterModel',
             'AvatarFileModel',
             'BoardModel',
+            'CaptchaModel',
             'CategoryModel',
             'ColorModel',
             'ColumnModel',

--- a/app/Subscriber/AuthSubscriber.php
+++ b/app/Subscriber/AuthSubscriber.php
@@ -46,6 +46,7 @@ class AuthSubscriber extends BaseSubscriber implements EventSubscriberInterface
         $ipAddress = $this->request->getIpAddress();
 
         $this->userLockingModel->resetFailedLogin($this->userSession->getUsername());
+        $this->captchaModel->resetFailedLogin($ipAddress);
 
         $this->lastLoginModel->create(
             $event->getAuthType(),
@@ -96,7 +97,10 @@ class AuthSubscriber extends BaseSubscriber implements EventSubscriberInterface
         $this->logger->debug('Subscriber executed: '.__METHOD__);
         $username = $event->getUsername();
         $ipAddress = $this->request->getIpAddress();
-        
+
+        // IP-based captcha
+        $this->captchaModel->incrementFailedLogin($ipAddress);
+
         if (! empty($username)) {
             // log login failure in web server log to allow fail2ban usage
             error_log('Kanboard: user '.$username.' authentication failure with IP address: '.$ipAddress);

--- a/app/Validator/AuthValidator.php
+++ b/app/Validator/AuthValidator.php
@@ -100,7 +100,7 @@ class AuthValidator extends BaseValidator
         $result = true;
         $errors = array();
 
-        if ($this->userLockingModel->hasCaptcha($values['username'])) {
+        if ($this->userLockingModel->hasCaptcha($values['username']) || $this->captchaModel->isLocked($this->request->getIpAddress())) {
             if (! session_exists('captcha')) {
                 $result = false;
             } else {
@@ -109,7 +109,7 @@ class AuthValidator extends BaseValidator
                 $result = $builder->testPhrase(isset($values['captcha']) ? $values['captcha'] : '');
 
                 if (! $result) {
-                    $errors['login'] = t('Invalid captcha');
+                    $errors['login'] = t('Bad username or password');
                 }
             }
         }


### PR DESCRIPTION
Previously, the CAPTCHA challenge was only displayed if the submitted username matched an existing user. This change ensures that a CAPTCHA is shown even when the user does not exist, adding an extra layer of protection against user enumeration.
