### PR TITLE
refactor: add namespace to test files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         ],
         "psr-4": {
             "Kanboard\\": "app/",
+            "KanboardTests\\": "tests/",
             "MatthiasMullie\\Minify\\": "libs/minify/src/",
             "MatthiasMullie\\PathConverter\\": "libs/path-converter/src/",
             "Gregwar\\Captcha\\": "libs/Captcha",

--- a/tests/configtest/DefaultConfigFileTest.php
+++ b/tests/configtest/DefaultConfigFileTest.php
@@ -1,6 +1,10 @@
 <?php
 
-class DefaultConfigFileTest extends PHPUnit\Framework\TestCase
+namespace KanboardTests\configtest;
+
+use PHPUnit\Framework\TestCase;
+
+class DefaultConfigFileTest extends TestCase
 {
     public function testThatFileCanBeImported()
     {

--- a/tests/integration/ActionProcedureTest.php
+++ b/tests/integration/ActionProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class ActionProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/AppProcedureTest.php
+++ b/tests/integration/AppProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class AppProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/BaseProcedureTest.php
+++ b/tests/integration/BaseProcedureTest.php
@@ -1,8 +1,11 @@
 <?php
 
-require_once __DIR__.'/../../vendor/autoload.php';
+namespace KanboardTests\integration;
 
-abstract class BaseProcedureTest extends PHPUnit\Framework\TestCase
+use JsonRPC\Client;
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseProcedureTest extends TestCase
 {
     protected $app = null;
     protected $admin = null;
@@ -37,7 +40,7 @@ abstract class BaseProcedureTest extends PHPUnit\Framework\TestCase
 
     public function setUpAppClient()
     {
-        $this->app = new JsonRPC\Client(API_URL);
+        $this->app = new Client(API_URL);
         $this->app->authentication('jsonrpc', API_KEY);
         $this->app->getHttpClient()->withDebug()->withTimeout(10);
     }
@@ -51,7 +54,7 @@ abstract class BaseProcedureTest extends PHPUnit\Framework\TestCase
             $this->assertNotFalse($this->adminUserId);
         }
 
-        $this->admin = new JsonRPC\Client(API_URL);
+        $this->admin = new Client(API_URL);
         $this->admin->authentication('superuser', 'password');
         $this->admin->getHttpClient()->withDebug();
     }
@@ -65,7 +68,7 @@ abstract class BaseProcedureTest extends PHPUnit\Framework\TestCase
             $this->assertNotFalse($this->managerUserId);
         }
 
-        $this->manager = new JsonRPC\Client(API_URL);
+        $this->manager = new Client(API_URL);
         $this->manager->authentication('manager', 'password');
         $this->manager->getHttpClient()->withDebug();
     }
@@ -79,7 +82,7 @@ abstract class BaseProcedureTest extends PHPUnit\Framework\TestCase
             $this->assertNotFalse($this->userUserId);
         }
 
-        $this->user = new JsonRPC\Client(API_URL);
+        $this->user = new Client(API_URL);
         $this->user->authentication('user', 'password');
         $this->user->getHttpClient()->withDebug();
     }

--- a/tests/integration/BoardProcedureTest.php
+++ b/tests/integration/BoardProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class BoardProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/CategoryProcedureTest.php
+++ b/tests/integration/CategoryProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class CategoryProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/ColumnProcedureTest.php
+++ b/tests/integration/ColumnProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class ColumnProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/CommentProcedureTest.php
+++ b/tests/integration/CommentProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 use Kanboard\Core\Security\Role;
 

--- a/tests/integration/GroupMemberProcedureTest.php
+++ b/tests/integration/GroupMemberProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class GroupMemberProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/GroupProcedureTest.php
+++ b/tests/integration/GroupProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class GroupProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/LinkProcedureTest.php
+++ b/tests/integration/LinkProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class LinkProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/MeProcedureTest.php
+++ b/tests/integration/MeProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class MeProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/OverdueTaskProcedureTest.php
+++ b/tests/integration/OverdueTaskProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class OverdueTaskProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/ProcedureAuthorizationTest.php
+++ b/tests/integration/ProcedureAuthorizationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class ProcedureAuthorizationTest extends BaseProcedureTest
 {

--- a/tests/integration/ProjectFileProcedureTest.php
+++ b/tests/integration/ProjectFileProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class ProjectFileProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/ProjectPermissionProcedureTest.php
+++ b/tests/integration/ProjectPermissionProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class ProjectPermissionProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/ProjectProcedureTest.php
+++ b/tests/integration/ProjectProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class ProjectProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/SubtaskProcedureTest.php
+++ b/tests/integration/SubtaskProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class SubtaskProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/SubtaskTimeTrackingProcedureTest.php
+++ b/tests/integration/SubtaskTimeTrackingProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class SubtaskTimeTrackingProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/SwimlaneProcedureTest.php
+++ b/tests/integration/SwimlaneProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class SwimlaneProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/TagProcedureTest.php
+++ b/tests/integration/TagProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class TagProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/TaskExternalLinkProcedureTest.php
+++ b/tests/integration/TaskExternalLinkProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class TaskExternalLinkProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/TaskFileProcedureTest.php
+++ b/tests/integration/TaskFileProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class TaskFileProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/TaskLinkProcedureTest.php
+++ b/tests/integration/TaskLinkProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class TaskLinkProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/TaskMetadataProcedureTest.php
+++ b/tests/integration/TaskMetadataProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class TaskMetadataProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/TaskProcedureTest.php
+++ b/tests/integration/TaskProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class TaskProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/TaskTagProcedureTest.php
+++ b/tests/integration/TaskTagProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class TaskTagProcedureTest extends BaseProcedureTest
 {

--- a/tests/integration/UserProcedureTest.php
+++ b/tests/integration/UserProcedureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/BaseProcedureTest.php';
+namespace KanboardTests\integration;
 
 class UserProcedureTest extends BaseProcedureTest
 {

--- a/tests/units/Action/BaseActionTest.php
+++ b/tests/units/Action/BaseActionTest.php
@@ -1,10 +1,11 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\GenericEvent;
 
-class DummyAction extends Kanboard\Action\Base
+class DummyAction extends \Kanboard\Action\Base
 {
     public function getDescription()
     {
@@ -42,7 +43,7 @@ class BaseActionTest extends Base
     public function testGetName()
     {
         $dummyAction = new DummyAction($this->container);
-        $this->assertEquals('\\DummyAction', $dummyAction->getName());
+        $this->assertEquals('\\' . __NAMESPACE__ . '\\DummyAction', $dummyAction->getName());
     }
 
     public function testGetDescription()
@@ -80,14 +81,14 @@ class BaseActionTest extends Base
     public function testProjectId()
     {
         $dummyAction = new DummyAction($this->container);
-        $this->assertInstanceOf('DummyAction', $dummyAction->setProjectId(123));
+        $this->assertInstanceOf(__NAMESPACE__ . '\\DummyAction', $dummyAction->setProjectId(123));
         $this->assertEquals(123, $dummyAction->getProjectId());
     }
 
     public function testParam()
     {
         $dummyAction = new DummyAction($this->container);
-        $this->assertInstanceOf('DummyAction', $dummyAction->setParam('p1', 123));
+        $this->assertInstanceOf(__NAMESPACE__ . '\\DummyAction', $dummyAction->setParam('p1', 123));
         $this->assertEquals(123, $dummyAction->getParam('p1'));
     }
 

--- a/tests/units/Action/CommentCreationMoveTaskColumnTest.php
+++ b/tests/units/Action/CommentCreationMoveTaskColumnTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\TaskModel;
 use Kanboard\Model\TaskCreationModel;

--- a/tests/units/Action/CommentCreationTest.php
+++ b/tests/units/Action/CommentCreationTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\GenericEvent;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\CommentModel;

--- a/tests/units/Action/TaskAssignCategoryColorTest.php
+++ b/tests/units/Action/TaskAssignCategoryColorTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\CategoryModel;
 use Kanboard\Model\TaskCreationModel;

--- a/tests/units/Action/TaskAssignCategoryLabelTest.php
+++ b/tests/units/Action/TaskAssignCategoryLabelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\GenericEvent;
 use Kanboard\Model\CategoryModel;
 use Kanboard\Model\TaskCreationModel;

--- a/tests/units/Action/TaskAssignCategoryLinkTest.php
+++ b/tests/units/Action/TaskAssignCategoryLinkTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\EventBuilder\TaskLinkEventBuilder;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskAssignColorCategoryTest.php
+++ b/tests/units/Action/TaskAssignColorCategoryTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\CategoryModel;
 use Kanboard\Model\TaskCreationModel;

--- a/tests/units/Action/TaskAssignColorColumnTest.php
+++ b/tests/units/Action/TaskAssignColorColumnTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskAssignColorLinkTest.php
+++ b/tests/units/Action/TaskAssignColorLinkTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\EventBuilder\TaskLinkEventBuilder;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskAssignColorOnDueDateTest.php
+++ b/tests/units/Action/TaskAssignColorOnDueDateTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Action\TaskAssignColorOnDueDate;
 use Kanboard\Event\TaskListEvent;
 use Kanboard\Model\TaskCreationModel;

--- a/tests/units/Action/TaskAssignColorPriorityTest.php
+++ b/tests/units/Action/TaskAssignColorPriorityTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\CategoryModel;
 use Kanboard\Model\TaskCreationModel;

--- a/tests/units/Action/TaskAssignColorSwimlaneTest.php
+++ b/tests/units/Action/TaskAssignColorSwimlaneTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskAssignColorUserTest.php
+++ b/tests/units/Action/TaskAssignColorUserTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskAssignCreatorTest.php
+++ b/tests/units/Action/TaskAssignCreatorTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Action\TaskAssignCreator;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\TaskCreationModel;

--- a/tests/units/Action/TaskAssignCurrentUserColumnTest.php
+++ b/tests/units/Action/TaskAssignCurrentUserColumnTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskAssignCurrentUserTest.php
+++ b/tests/units/Action/TaskAssignCurrentUserTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\GenericEvent;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskAssignDueDateOnCreationTest.php
+++ b/tests/units/Action/TaskAssignDueDateOnCreationTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Action;
+
+use KanboardTests\units\Base;
 use Kanboard\Action\TaskAssignDueDateOnCreation;
 use Kanboard\EventBuilder\TaskEventBuilder;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskAssignDueDateOnCreationTest extends Base
 {

--- a/tests/units/Action/TaskAssignPrioritySwimlaneTest.php
+++ b/tests/units/Action/TaskAssignPrioritySwimlaneTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskAssignSpecificUserTest.php
+++ b/tests/units/Action/TaskAssignSpecificUserTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskAssignUserTest.php
+++ b/tests/units/Action/TaskAssignUserTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\GenericEvent;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskCloseColumnTest.php
+++ b/tests/units/Action/TaskCloseColumnTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskCloseNoActivityColumnTest.php
+++ b/tests/units/Action/TaskCloseNoActivityColumnTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Action\TaskCloseNoActivityColumn;
 use Kanboard\Event\TaskListEvent;
 use Kanboard\Model\TaskCreationModel;

--- a/tests/units/Action/TaskCloseNoActivityTest.php
+++ b/tests/units/Action/TaskCloseNoActivityTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskListEvent;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskCloseNotMovedColumnTest.php
+++ b/tests/units/Action/TaskCloseNotMovedColumnTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Action\TaskCloseNotMovedColumn;
 use Kanboard\Event\TaskListEvent;
 use Kanboard\Model\TaskCreationModel;

--- a/tests/units/Action/TaskCloseTest.php
+++ b/tests/units/Action/TaskCloseTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskCreationTest.php
+++ b/tests/units/Action/TaskCreationTest.php
@@ -1,13 +1,14 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\GenericEvent;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Action\TaskCreation as TaskCreationAction;
 
-class TaskCreationActionTest extends Base
+class TaskCreationTest extends Base
 {
     public function testSuccess()
     {

--- a/tests/units/Action/TaskDuplicateAnotherProjectTest.php
+++ b/tests/units/Action/TaskDuplicateAnotherProjectTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\TaskModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskEmailNoActivityTest.php
+++ b/tests/units/Action/TaskEmailNoActivityTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskListEvent;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskEmailTest.php
+++ b/tests/units/Action/TaskEmailTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskModel;

--- a/tests/units/Action/TaskMoveAnotherProjectTest.php
+++ b/tests/units/Action/TaskMoveAnotherProjectTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\GenericEvent;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\TaskModel;

--- a/tests/units/Action/TaskMoveColumnAssignedTest.php
+++ b/tests/units/Action/TaskMoveColumnAssignedTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\TaskModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskMoveColumnCategoryChangeTest.php
+++ b/tests/units/Action/TaskMoveColumnCategoryChangeTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\CategoryModel;
 use Kanboard\Model\TaskModel;

--- a/tests/units/Action/TaskMoveColumnClosedTest.php
+++ b/tests/units/Action/TaskMoveColumnClosedTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Action;
+
+use KanboardTests\units\Base;
 use Kanboard\Action\TaskMoveColumnClosed;
 use Kanboard\EventBuilder\TaskEventBuilder;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskMoveColumnClosedTest extends Base
 {

--- a/tests/units/Action/TaskMoveColumnNotMovedPeriodTest.php
+++ b/tests/units/Action/TaskMoveColumnNotMovedPeriodTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Action;
+
+use KanboardTests\units\Base;
 use Kanboard\Action\TaskMoveColumnNotMovedPeriod;
 use Kanboard\Event\TaskListEvent;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskMoveColumnNotMovedPeriodTest extends Base
 {

--- a/tests/units/Action/TaskMoveColumnOnDueDateTest.php
+++ b/tests/units/Action/TaskMoveColumnOnDueDateTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Action;
+
+use KanboardTests\units\Base;
 use Kanboard\Action\TaskMoveColumnOnDueDate;
 use Kanboard\Event\TaskListEvent;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskMoveColumnOnDueDateTest extends Base
 {

--- a/tests/units/Action/TaskMoveColumnUnAssignedTest.php
+++ b/tests/units/Action/TaskMoveColumnUnAssignedTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\TaskModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskOpenTest.php
+++ b/tests/units/Action/TaskOpenTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskUpdateStartDateOnMoveColumnTest.php
+++ b/tests/units/Action/TaskUpdateStartDateOnMoveColumnTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Action/TaskUpdateStartDateTest.php
+++ b/tests/units/Action/TaskUpdateStartDateTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Analytic/AverageLeadCycleTimeAnalyticTest.php
+++ b/tests/units/Analytic/AverageLeadCycleTimeAnalyticTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Analytic;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskModel;

--- a/tests/units/Analytic/AverageTimeSpentColumnAnalyticTest.php
+++ b/tests/units/Analytic/AverageTimeSpentColumnAnalyticTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Analytic;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TransitionModel;

--- a/tests/units/Analytic/EstimatedTimeComparisonAnalyticTest.php
+++ b/tests/units/Analytic/EstimatedTimeComparisonAnalyticTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Analytic;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Analytic\EstimatedTimeComparisonAnalytic;

--- a/tests/units/Analytic/TaskDistributionAnalyticTest.php
+++ b/tests/units/Analytic/TaskDistributionAnalyticTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Analytic;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Analytic\TaskDistributionAnalytic;

--- a/tests/units/Analytic/UserDistributionAnalyticTest.php
+++ b/tests/units/Analytic/UserDistributionAnalyticTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Analytic;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectUserRoleModel;

--- a/tests/units/Auth/ApiAccessTokenAuthTest.php
+++ b/tests/units/Auth/ApiAccessTokenAuthTest.php
@@ -1,9 +1,10 @@
 <?php
 
+namespace KanboardTests\units\Auth;
+
+use KanboardTests\units\Base;
 use Kanboard\Auth\ApiAccessTokenAuth;
 use Kanboard\Model\UserModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ApiAccessTokenAuthTest extends Base
 {

--- a/tests/units/Auth/DatabaseAuthTest.php
+++ b/tests/units/Auth/DatabaseAuthTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Auth;
 
+use KanboardTests\units\Base;
 use Kanboard\Auth\DatabaseAuth;
 use Kanboard\Model\UserModel;
 

--- a/tests/units/Auth/ReverseProxyAuthTest.php
+++ b/tests/units/Auth/ReverseProxyAuthTest.php
@@ -1,10 +1,11 @@
 <?php
 
+namespace KanboardTests\units\Auth;
+
+use KanboardTests\units\Base;
 use Kanboard\Auth\ReverseProxyAuth;
 use Kanboard\Core\Security\Role;
 use Kanboard\Model\UserModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ReverseProxyAuthTest extends Base
 {

--- a/tests/units/Auth/TotpAuthTest.php
+++ b/tests/units/Auth/TotpAuthTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Auth;
 
+use KanboardTests\units\Base;
 use Kanboard\Auth\TotpAuth;
 
 class TotpAuthTest extends Base

--- a/tests/units/Base.php
+++ b/tests/units/Base.php
@@ -1,16 +1,35 @@
 <?php
 
-require __DIR__.'/../../vendor/autoload.php';
+namespace KanboardTests\units;
+
 require __DIR__.'/../../app/constants.php';
 
 use Composer\Autoload\ClassLoader;
+use Kanboard\ServiceProvider\AuthenticationProvider;
+use Kanboard\ServiceProvider\AvatarProvider;
+use Kanboard\ServiceProvider\CacheProvider;
+use Kanboard\ServiceProvider\ClassProvider;
+use Kanboard\ServiceProvider\DatabaseProvider;
+use Kanboard\ServiceProvider\ExternalTaskProvider;
+use Kanboard\ServiceProvider\FilterProvider;
+use Kanboard\ServiceProvider\FormatterProvider;
+use Kanboard\ServiceProvider\HelperProvider;
+use Kanboard\ServiceProvider\JobProvider;
+use Kanboard\ServiceProvider\LoggingProvider;
+use Kanboard\ServiceProvider\NotificationProvider;
+use Kanboard\ServiceProvider\QueueProvider;
+use Kanboard\ServiceProvider\RouteProvider;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Pimple\Container;
+use Symfony\Component\Console\Application;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Kanboard\Core\Session\FlashMessage;
 use Kanboard\ServiceProvider\ActionProvider;
 
-abstract class Base extends PHPUnit\Framework\TestCase
+abstract class Base extends TestCase
 {
     protected $container;
 
@@ -62,21 +81,21 @@ abstract class Base extends PHPUnit\Framework\TestCase
             $pdo = null;
         }
 
-        $this->container = new Pimple\Container;
-        $this->container->register(new Kanboard\ServiceProvider\CacheProvider());
-        $this->container->register(new Kanboard\ServiceProvider\HelperProvider());
-        $this->container->register(new Kanboard\ServiceProvider\AuthenticationProvider());
-        $this->container->register(new Kanboard\ServiceProvider\DatabaseProvider());
-        $this->container->register(new Kanboard\ServiceProvider\ClassProvider());
-        $this->container->register(new Kanboard\ServiceProvider\NotificationProvider());
-        $this->container->register(new Kanboard\ServiceProvider\RouteProvider());
-        $this->container->register(new Kanboard\ServiceProvider\AvatarProvider());
-        $this->container->register(new Kanboard\ServiceProvider\FilterProvider());
-        $this->container->register(new Kanboard\ServiceProvider\FormatterProvider());
-        $this->container->register(new Kanboard\ServiceProvider\JobProvider());
-        $this->container->register(new Kanboard\ServiceProvider\QueueProvider());
-        $this->container->register(new Kanboard\ServiceProvider\LoggingProvider());
-        $this->container->register(new Kanboard\ServiceProvider\ExternalTaskProvider());
+        $this->container = new Container;
+        $this->container->register(new CacheProvider());
+        $this->container->register(new HelperProvider());
+        $this->container->register(new AuthenticationProvider());
+        $this->container->register(new DatabaseProvider());
+        $this->container->register(new ClassProvider());
+        $this->container->register(new NotificationProvider());
+        $this->container->register(new RouteProvider());
+        $this->container->register(new AvatarProvider());
+        $this->container->register(new FilterProvider());
+        $this->container->register(new FormatterProvider());
+        $this->container->register(new JobProvider());
+        $this->container->register(new QueueProvider());
+        $this->container->register(new LoggingProvider());
+        $this->container->register(new ExternalTaskProvider());
 
         $this->container['dispatcher'] = new TraceableEventDispatcher(
             new EventDispatcher,
@@ -86,7 +105,7 @@ abstract class Base extends PHPUnit\Framework\TestCase
         $this->dispatcher = $this->container['dispatcher'];
 
         $this->container['db']->getStatementHandler()->withLogging();
-        $this->container['cli'] = new \Symfony\Component\Console\Application('Kanboard', 'test');
+        $this->container['cli'] = new Application('Kanboard', 'test');
 
         $this->container['externalLinkManager'] = $this
             ->getMockBuilder('Kanboard\Core\ExternalLink\ExternalLinkManager')

--- a/tests/units/Core/Action/ActionManagerTest.php
+++ b/tests/units/Core/Action/ActionManagerTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Action;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Action\ActionManager;
 use Kanboard\Action\TaskAssignColorColumn;
 use Kanboard\Action\TaskClose;

--- a/tests/units/Core/Cache/FileCacheTest.php
+++ b/tests/units/Core/Cache/FileCacheTest.php
@@ -2,7 +2,7 @@
 
 namespace Kanboard\Core\Cache;
 
-require_once __DIR__.'/../../Base.php';
+use KanboardTests\units\Core\Cache\FileCacheTest;
 
 function file_put_contents($filename, $data)
 {
@@ -34,7 +34,12 @@ function unlink($filename)
     return FileCacheTest::$functions->unlink($filename);
 }
 
-class FileCacheTest extends \Base
+namespace KanboardTests\units\Core\Cache;
+
+use Kanboard\Core\Cache\FileCache;
+use KanboardTests\units\Base;
+
+class FileCacheTest extends Base
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject

--- a/tests/units/Core/Cache/MemoryCacheTest.php
+++ b/tests/units/Core/Cache/MemoryCacheTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Cache;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Cache\MemoryCache;
 
 class MemoryCacheTest extends Base

--- a/tests/units/Core/CsvTest.php
+++ b/tests/units/Core/CsvTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Core;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Csv;
 
 class CsvTest extends Base

--- a/tests/units/Core/DateParserTest.php
+++ b/tests/units/Core/DateParserTest.php
@@ -1,7 +1,9 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Core;
 
+use DateTime;
+use KanboardTests\units\Base;
 use Kanboard\Core\DateParser;
 
 class DateParserTest extends Base

--- a/tests/units/Core/Event/EventManagerTest.php
+++ b/tests/units/Core/Event/EventManagerTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Event;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Event\EventManager;
 
 class EventManagerTest extends Base

--- a/tests/units/Core/ExternalLink/ExternalLinkManagerTest.php
+++ b/tests/units/Core/ExternalLink/ExternalLinkManagerTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\ExternalLink;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\ExternalLink\ExternalLinkManager;
 use Kanboard\ExternalLink\WebLinkProvider;
 use Kanboard\ExternalLink\AttachmentLinkProvider;

--- a/tests/units/Core/ExternalTask/ExternalTaskManagerTest.php
+++ b/tests/units/Core/ExternalTask/ExternalTaskManagerTest.php
@@ -1,8 +1,9 @@
 <?php
 
-use Kanboard\Core\ExternalTask\ExternalTaskManager;
+namespace KanboardTests\units\Core\ExternalTask;
 
-require_once __DIR__.'/../../Base.php';
+use KanboardTests\units\Base;
+use Kanboard\Core\ExternalTask\ExternalTaskManager;
 
 class ExternalTaskManagerTest extends Base
 {

--- a/tests/units/Core/Filter/LexerBuilderTest.php
+++ b/tests/units/Core/Filter/LexerBuilderTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Filter;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Filter\LexerBuilder;
 use Kanboard\Filter\TaskAssigneeFilter;
 use Kanboard\Filter\TaskTitleFilter;

--- a/tests/units/Core/Filter/LexerTest.php
+++ b/tests/units/Core/Filter/LexerTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Filter;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Filter\Lexer;
 
 class LexerTest extends Base

--- a/tests/units/Core/Filter/OrCriteriaTest.php
+++ b/tests/units/Core/Filter/OrCriteriaTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace KanboardTests\units\Core\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Core\Filter\OrCriteria;
 use Kanboard\Filter\TaskAssigneeFilter;
 use Kanboard\Filter\TaskTitleFilter;
@@ -7,8 +10,6 @@ use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\UserModel;
-
-require_once __DIR__.'/../../Base.php';
 
 class OrCriteriaTest extends Base
 {

--- a/tests/units/Core/Group/GroupManagerTest.php
+++ b/tests/units/Core/Group/GroupManagerTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Group;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\GroupModel;
 use Kanboard\Core\Group\GroupManager;
 use Kanboard\Group\DatabaseBackendGroupProvider;

--- a/tests/units/Core/HelperTest.php
+++ b/tests/units/Core/HelperTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Core;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Helper;
 
 class HelperTest extends Base

--- a/tests/units/Core/Http/OAuth2Test.php
+++ b/tests/units/Core/Http/OAuth2Test.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Http;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Http\OAuth2;
 
 class OAuth2Test extends Base

--- a/tests/units/Core/Http/RememberMeCookieTest.php
+++ b/tests/units/Core/Http/RememberMeCookieTest.php
@@ -2,14 +2,20 @@
 
 namespace Kanboard\Core\Http;
 
-require_once __DIR__.'/../../Base.php';
+use KanboardTests\units\Core\Http\RememberMeCookieTest;
 
 function setcookie($name, $value = "", $expire = 0, $path = "", $domain = "", $secure = false, $httponly = false)
 {
     return RememberMeCookieTest::$functions->setcookie($name, $value, $expire, $path, $domain, $secure, $httponly);
 }
 
-class RememberMeCookieTest extends \Base
+namespace KanboardTests\units\Core\Http;
+
+use Kanboard\Core\Http\RememberMeCookie;
+use Kanboard\Core\Http\Request;
+use KanboardTests\units\Base;
+
+class RememberMeCookieTest extends Base
 {
     public static $functions;
 

--- a/tests/units/Core/Http/RequestTest.php
+++ b/tests/units/Core/Http/RequestTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Http;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Http\Request;
 
 class RequestTest extends Base

--- a/tests/units/Core/Http/RouteTest.php
+++ b/tests/units/Core/Http/RouteTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Http;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Http\Route;
 use Kanboard\Core\Http\Router;
 

--- a/tests/units/Core/Http/RouterTest.php
+++ b/tests/units/Core/Http/RouterTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Http;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Http\Route;
 use Kanboard\Core\Http\Router;
 use Kanboard\Core\Http\Request;

--- a/tests/units/Core/Ldap/ClientTest.php
+++ b/tests/units/Core/Ldap/ClientTest.php
@@ -2,7 +2,7 @@
 
 namespace Kanboard\Core\Ldap;
 
-require_once __DIR__.'/../../Base.php';
+use KanboardTests\units\Core\Ldap\ClientTest;
 
 function ldap_connect($hostname, $port)
 {
@@ -38,7 +38,12 @@ function ldap_start_tls($link_identifier)
     return ClientTest::$functions->ldap_start_tls($link_identifier);
 }
 
-class ClientTest extends \Base
+namespace KanboardTests\units\Core\Ldap;
+
+use Kanboard\Core\Ldap\Client;
+use KanboardTests\units\Base;
+
+class ClientTest extends Base
 {
     public static $functions;
 

--- a/tests/units/Core/Ldap/EntriesTest.php
+++ b/tests/units/Core/Ldap/EntriesTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Ldap;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Ldap\Entries;
 
 class EntriesTest extends Base

--- a/tests/units/Core/Ldap/EntryTest.php
+++ b/tests/units/Core/Ldap/EntryTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Ldap;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Ldap\Entry;
 
 class EntryTest extends Base

--- a/tests/units/Core/Ldap/LdapGroupTest.php
+++ b/tests/units/Core/Ldap/LdapGroupTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Ldap;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Ldap\Group;
 use Kanboard\Core\Ldap\Entries;
 

--- a/tests/units/Core/Ldap/LdapUserTest.php
+++ b/tests/units/Core/Ldap/LdapUserTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Ldap;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Ldap\Query;
 use Kanboard\Core\Ldap\User;
 use Kanboard\Core\Ldap\Entries;

--- a/tests/units/Core/Ldap/QueryTest.php
+++ b/tests/units/Core/Ldap/QueryTest.php
@@ -2,7 +2,7 @@
 
 namespace Kanboard\Core\Ldap;
 
-require_once __DIR__.'/../../Base.php';
+use KanboardTests\units\Core\Ldap\QueryTest;
 
 function ldap_search($link_identifier, $base_dn, $filter, array $attributes)
 {
@@ -14,7 +14,12 @@ function ldap_get_entries($link_identifier, $result_identifier)
     return QueryTest::$functions->ldap_get_entries($link_identifier, $result_identifier);
 }
 
-class QueryTest extends \Base
+namespace KanboardTests\units\Core\Ldap;
+
+use Kanboard\Core\Ldap\Query;
+use KanboardTests\units\Base;
+
+class QueryTest extends Base
 {
     public static $functions;
     private $client;

--- a/tests/units/Core/ObjectStorage/FileStorageTest.php
+++ b/tests/units/Core/ObjectStorage/FileStorageTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\ObjectStorage;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\ObjectStorage\FileStorage;
 use Kanboard\Core\ObjectStorage\ObjectStorageException;
 

--- a/tests/units/Core/Plugin/DirectoryTest.php
+++ b/tests/units/Core/Plugin/DirectoryTest.php
@@ -1,8 +1,9 @@
 <?php
 
-use Kanboard\Core\Plugin\Directory;
+namespace KanboardTests\units\Core\Plugin;
 
-require_once __DIR__.'/../../Base.php';
+use KanboardTests\units\Base;
+use Kanboard\Core\Plugin\Directory;
 
 class DirectoryTest extends Base
 {

--- a/tests/units/Core/Plugin/HookTest.php
+++ b/tests/units/Core/Plugin/HookTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Plugin;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Plugin\Hook;
 
 class HookTest extends Base

--- a/tests/units/Core/Plugin/SchemaHandlerTest.php
+++ b/tests/units/Core/Plugin/SchemaHandlerTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Plugin;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Plugin\SchemaHandler;
 
 class SchemaHandlerTest extends Base

--- a/tests/units/Core/Plugin/VersionTest.php
+++ b/tests/units/Core/Plugin/VersionTest.php
@@ -1,8 +1,9 @@
 <?php
 
-use Kanboard\Core\Plugin\Version;
+namespace KanboardTests\units\Core\Plugin;
 
-require_once __DIR__.'/../../Base.php';
+use KanboardTests\units\Base;
+use Kanboard\Core\Plugin\Version;
 
 class VersionTest extends Base
 {

--- a/tests/units/Core/Security/AccessMapTest.php
+++ b/tests/units/Core/Security/AccessMapTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Security;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Security\AccessMap;
 
 class AccessMapTest extends Base

--- a/tests/units/Core/Security/AuthenticationManagerTest.php
+++ b/tests/units/Core/Security/AuthenticationManagerTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Security;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Http\Request;
 use Kanboard\Core\Security\AuthenticationManager;
 use Kanboard\Auth\DatabaseAuth;

--- a/tests/units/Core/Security/AuthorizationTest.php
+++ b/tests/units/Core/Security/AuthorizationTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Security;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Security\Role;
 use Kanboard\Core\Security\AccessMap;
 use Kanboard\Core\Security\Authorization;

--- a/tests/units/Core/Security/RoleTest.php
+++ b/tests/units/Core/Security/RoleTest.php
@@ -1,8 +1,9 @@
 <?php
 
-use Kanboard\Core\Security\Role;
+namespace KanboardTests\units\Core\Security;
 
-require_once __DIR__.'/../../Base.php';
+use KanboardTests\units\Base;
+use Kanboard\Core\Security\Role;
 
 class RoleTest extends Base
 {

--- a/tests/units/Core/Security/TokenTest.php
+++ b/tests/units/Core/Security/TokenTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Security;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Security\Token;
 
 class TokenTest extends Base

--- a/tests/units/Core/Session/FlashMessageTest.php
+++ b/tests/units/Core/Session/FlashMessageTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\Session;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Session\FlashMessage;
 
 class FlashMessageTest extends Base

--- a/tests/units/Core/TemplateTest.php
+++ b/tests/units/Core/TemplateTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Core;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Template;
 
 class TemplateTest extends Base

--- a/tests/units/Core/TranslatorTest.php
+++ b/tests/units/Core/TranslatorTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Core;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Translator;
 
 class TranslatorTest extends Base

--- a/tests/units/Core/User/GroupSyncTest.php
+++ b/tests/units/Core/User/GroupSyncTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\User;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\User\GroupSync;
 use Kanboard\Model\GroupModel;
 use Kanboard\Model\GroupMemberModel;

--- a/tests/units/Core/User/UserProfileTest.php
+++ b/tests/units/Core/User/UserProfileTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\User;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Security\Role;
 use Kanboard\Core\User\UserProfile;
 use Kanboard\User\LdapUserProvider;

--- a/tests/units/Core/User/UserPropertyTest.php
+++ b/tests/units/Core/User/UserPropertyTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\User;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Security\Role;
 use Kanboard\Core\User\UserProperty;
 use Kanboard\User\LdapUserProvider;

--- a/tests/units/Core/User/UserSessionTest.php
+++ b/tests/units/Core/User/UserSessionTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\User;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\User\UserSession;
 use Kanboard\Core\Security\Role;
 

--- a/tests/units/Core/User/UserSyncTest.php
+++ b/tests/units/Core/User/UserSyncTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\Core\User;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Security\Role;
 use Kanboard\Core\User\UserSync;
 use Kanboard\User\LdapUserProvider;

--- a/tests/units/Decorator/MetadataCacheDecoratorTest.php
+++ b/tests/units/Decorator/MetadataCacheDecoratorTest.php
@@ -1,8 +1,9 @@
 <?php
 
-use Kanboard\Decorator\MetadataCacheDecorator;
+namespace KanboardTests\units\Decorator;
 
-require_once __DIR__.'/../Base.php';
+use KanboardTests\units\Base;
+use Kanboard\Decorator\MetadataCacheDecorator;
 
 class MetadataCacheDecoratorTest extends Base
 {

--- a/tests/units/EventBuilder/CommentEventBuilderTest.php
+++ b/tests/units/EventBuilder/CommentEventBuilderTest.php
@@ -1,11 +1,12 @@
 <?php
 
+namespace KanboardTests\units\EventBuilder;
+
+use KanboardTests\units\Base;
 use Kanboard\EventBuilder\CommentEventBuilder;
 use Kanboard\Model\CommentModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
-
-require_once __DIR__.'/../Base.php';
 
 class CommentEventBuilderTest extends Base
 {

--- a/tests/units/EventBuilder/ProjectFileEventBuilderTest.php
+++ b/tests/units/EventBuilder/ProjectFileEventBuilderTest.php
@@ -1,10 +1,11 @@
 <?php
 
+namespace KanboardTests\units\EventBuilder;
+
+use KanboardTests\units\Base;
 use Kanboard\EventBuilder\ProjectFileEventBuilder;
 use Kanboard\Model\ProjectFileModel;
 use Kanboard\Model\ProjectModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ProjectFileEventBuilderTest extends Base
 {

--- a/tests/units/EventBuilder/SubtaskEventBuilderTest.php
+++ b/tests/units/EventBuilder/SubtaskEventBuilderTest.php
@@ -1,11 +1,12 @@
 <?php
 
+namespace KanboardTests\units\EventBuilder;
+
+use KanboardTests\units\Base;
 use Kanboard\EventBuilder\SubtaskEventBuilder;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\SubtaskModel;
 use Kanboard\Model\TaskCreationModel;
-
-require_once __DIR__.'/../Base.php';
 
 class SubtaskEventBuilderTest extends Base
 {

--- a/tests/units/EventBuilder/TaskEventBuilderTest.php
+++ b/tests/units/EventBuilder/TaskEventBuilderTest.php
@@ -1,10 +1,11 @@
 <?php
 
+namespace KanboardTests\units\EventBuilder;
+
+use KanboardTests\units\Base;
 use Kanboard\EventBuilder\TaskEventBuilder;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskEventBuilderTest extends Base
 {

--- a/tests/units/EventBuilder/TaskFileEventBuilderTest.php
+++ b/tests/units/EventBuilder/TaskFileEventBuilderTest.php
@@ -1,11 +1,12 @@
 <?php
 
+namespace KanboardTests\units\EventBuilder;
+
+use KanboardTests\units\Base;
 use Kanboard\EventBuilder\TaskFileEventBuilder;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFileModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskFileEventBuilderTest extends Base
 {

--- a/tests/units/EventBuilder/TaskLinkEventBuilderTest.php
+++ b/tests/units/EventBuilder/TaskLinkEventBuilderTest.php
@@ -1,11 +1,12 @@
 <?php
 
+namespace KanboardTests\units\EventBuilder;
+
+use KanboardTests\units\Base;
 use Kanboard\EventBuilder\TaskLinkEventBuilder;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskLinkModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskLinkEventBuilderTest extends Base
 {

--- a/tests/units/Export/TaskExportTest.php
+++ b/tests/units/Export/TaskExportTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__ . '/../Base.php';
+namespace KanboardTests\units\Export;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Export\TaskExport;
 use Kanboard\Model\ProjectModel;

--- a/tests/units/Export/TransitionExportTest.php
+++ b/tests/units/Export/TransitionExportTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__ . '/../Base.php';
+namespace KanboardTests\units\Export;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TransitionModel;
 use Kanboard\Export\TransitionExport;

--- a/tests/units/ExternalLink/AttachmentLinkProviderTest.php
+++ b/tests/units/ExternalLink/AttachmentLinkProviderTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\ExternalLink;
 
+use KanboardTests\units\Base;
 use Kanboard\ExternalLink\AttachmentLinkProvider;
 
 class AttachmentLinkProviderTest extends Base

--- a/tests/units/ExternalLink/AttachmentLinkTest.php
+++ b/tests/units/ExternalLink/AttachmentLinkTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\ExternalLink;
 
+use KanboardTests\units\Base;
 use Kanboard\ExternalLink\AttachmentLink;
 
 class AttachmentLinkTest extends Base

--- a/tests/units/ExternalLink/FileLinkProviderTest.php
+++ b/tests/units/ExternalLink/FileLinkProviderTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\ExternalLink;
 
+use KanboardTests\units\Base;
 use Kanboard\ExternalLink\FileLinkProvider;
 
 class FileLinkProviderTest extends Base

--- a/tests/units/ExternalLink/FileLinkTest.php
+++ b/tests/units/ExternalLink/FileLinkTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\ExternalLink;
 
+use KanboardTests\units\Base;
 use Kanboard\ExternalLink\FileLink;
 
 class FileLinkTest extends Base

--- a/tests/units/ExternalLink/WebLinkProviderTest.php
+++ b/tests/units/ExternalLink/WebLinkProviderTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\ExternalLink;
 
+use KanboardTests\units\Base;
 use Kanboard\ExternalLink\WebLinkProvider;
 
 class WebLinkProviderTest extends Base

--- a/tests/units/ExternalLink/WebLinkTest.php
+++ b/tests/units/ExternalLink/WebLinkTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\ExternalLink;
 
+use KanboardTests\units\Base;
 use Kanboard\ExternalLink\WebLink;
 
 class WebLinkTest extends Base

--- a/tests/units/Filter/ProjectActivityCreationDateFilterTest.php
+++ b/tests/units/Filter/ProjectActivityCreationDateFilterTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\ProjectActivityCreationDateFilter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectActivityModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ProjectActivityCreationDateFilterTest extends Base
 {

--- a/tests/units/Filter/ProjectActivityCreatorFilterTest.php
+++ b/tests/units/Filter/ProjectActivityCreatorFilterTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\ProjectActivityCreatorFilter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectActivityModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ProjectActivityCreatorFilterTest extends Base
 {

--- a/tests/units/Filter/ProjectActivityProjectIdFilterTest.php
+++ b/tests/units/Filter/ProjectActivityProjectIdFilterTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\ProjectActivityProjectIdFilter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectActivityModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ProjectActivityProjectIdFilterTest extends Base
 {

--- a/tests/units/Filter/ProjectActivityProjectIdsFilterTest.php
+++ b/tests/units/Filter/ProjectActivityProjectIdsFilterTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\ProjectActivityProjectIdsFilter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectActivityModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ProjectActivityProjectIdsFilterTest extends Base
 {

--- a/tests/units/Filter/ProjectActivityProjectNameFilterTest.php
+++ b/tests/units/Filter/ProjectActivityProjectNameFilterTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\ProjectActivityProjectNameFilter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectActivityModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ProjectActivityProjectNameFilterTest extends Base
 {

--- a/tests/units/Filter/ProjectActivityTaskIdFilterTest.php
+++ b/tests/units/Filter/ProjectActivityTaskIdFilterTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\ProjectActivityTaskIdFilter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectActivityModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ProjectActivityTaskIdFilterTest extends Base
 {

--- a/tests/units/Filter/ProjectActivityTaskStatusFilterTest.php
+++ b/tests/units/Filter/ProjectActivityTaskStatusFilterTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\ProjectActivityTaskStatusFilter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectActivityModel;
@@ -7,8 +10,6 @@ use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskModel;
 use Kanboard\Model\TaskStatusModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ProjectActivityTaskStatusFilterTest extends Base
 {

--- a/tests/units/Filter/ProjectActivityTaskTitleFilterTest.php
+++ b/tests/units/Filter/ProjectActivityTaskTitleFilterTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\ProjectActivityTaskTitleFilter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectActivityModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ProjectActivityTaskTitleFilterTest extends Base
 {

--- a/tests/units/Filter/TaskAssigneeFilterTest.php
+++ b/tests/units/Filter/TaskAssigneeFilterTest.php
@@ -1,12 +1,13 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\TaskAssigneeFilter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\UserModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskAssigneeFilterTest extends Base
 {

--- a/tests/units/Filter/TaskCategoryFilterTest.php
+++ b/tests/units/Filter/TaskCategoryFilterTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\TaskCategoryFilter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\CategoryModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskCategoryFilterTest extends Base
 {

--- a/tests/units/Filter/TaskCommentFilterTest.php
+++ b/tests/units/Filter/TaskCommentFilterTest.php
@@ -1,12 +1,13 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\TaskCommentFilter;
 use Kanboard\Model\CommentModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskCommentFilterTest extends Base
 {

--- a/tests/units/Filter/TaskCreatorFilterTest.php
+++ b/tests/units/Filter/TaskCreatorFilterTest.php
@@ -1,12 +1,13 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\TaskCreatorFilter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\UserModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskCreatorFilterTest extends Base
 {

--- a/tests/units/Filter/TaskLinkFilterTest.php
+++ b/tests/units/Filter/TaskLinkFilterTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\TaskLinkFilter;
 use Kanboard\Model\LinkModel;
 use Kanboard\Model\TaskLinkModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskLinkFilterTest extends Base
 {

--- a/tests/units/Filter/TaskMovedDateFilterTest.php
+++ b/tests/units/Filter/TaskMovedDateFilterTest.php
@@ -1,13 +1,13 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\TaskMovedDateFilter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskModificationModel;
 use Kanboard\Model\TaskFinderModel;
-use Kanboard\Model\UserModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskMovedDateFilterTest extends Base
 {

--- a/tests/units/Filter/TaskPriorityFilterTest.php
+++ b/tests/units/Filter/TaskPriorityFilterTest.php
@@ -1,11 +1,12 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\TaskPriorityFilter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskPriorityFilterTest extends Base
 {

--- a/tests/units/Filter/TaskReferenceFilterTest.php
+++ b/tests/units/Filter/TaskReferenceFilterTest.php
@@ -1,11 +1,12 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\TaskReferenceFilter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskReferenceFilterTest extends Base
 {

--- a/tests/units/Filter/TaskStartsWithIdFilterTest.php
+++ b/tests/units/Filter/TaskStartsWithIdFilterTest.php
@@ -1,11 +1,12 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\TaskStartsWithIdFilter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskStartsWithIdFilterTest extends Base
 {

--- a/tests/units/Filter/TaskStatusFilterTest.php
+++ b/tests/units/Filter/TaskStatusFilterTest.php
@@ -1,12 +1,13 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\TaskStatusFilter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskStatusFilterTest extends Base
 {

--- a/tests/units/Filter/TaskSubtaskAssigneeFilterTest.php
+++ b/tests/units/Filter/TaskSubtaskAssigneeFilterTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\TaskSubtaskAssigneeFilter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\SubtaskModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\UserModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskSubtaskAssigneeFilterTest extends Base
 {

--- a/tests/units/Filter/TaskTagFilterTest.php
+++ b/tests/units/Filter/TaskTagFilterTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Filter;
+
+use KanboardTests\units\Base;
 use Kanboard\Filter\TaskTagFilter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskModel;
 use Kanboard\Model\TaskTagModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskTagFilterTest extends Base
 {

--- a/tests/units/Formatter/BoardFormatterTest.php
+++ b/tests/units/Formatter/BoardFormatterTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace KanboardTests\units\Formatter;
+
+use KanboardTests\units\Base;
 use Kanboard\Formatter\BoardFormatter;
 use Kanboard\Model\ColumnModel;
 use Kanboard\Model\ProjectModel;
@@ -7,8 +10,6 @@ use Kanboard\Model\SwimlaneModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskTagModel;
-
-require_once __DIR__.'/../Base.php';
 
 class BoardFormatterTest extends Base
 {

--- a/tests/units/Formatter/TaskAutoCompleteFormatterTest.php
+++ b/tests/units/Formatter/TaskAutoCompleteFormatterTest.php
@@ -1,11 +1,12 @@
 <?php
 
+namespace KanboardTests\units\Formatter;
+
+use KanboardTests\units\Base;
 use Kanboard\Formatter\TaskAutoCompleteFormatter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskAutoCompleteFormatterTest extends Base
 {

--- a/tests/units/Formatter/TaskListFormatterTest.php
+++ b/tests/units/Formatter/TaskListFormatterTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Formatter;
+
+use KanboardTests\units\Base;
 use Kanboard\Formatter\TaskListFormatter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskModel;
 use Kanboard\Model\TaskTagModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskListFormatterTest extends Base
 {

--- a/tests/units/Formatter/TaskSuggestMenuFormatterTest.php
+++ b/tests/units/Formatter/TaskSuggestMenuFormatterTest.php
@@ -1,10 +1,11 @@
 <?php
 
+namespace KanboardTests\units\Formatter;
+
+use KanboardTests\units\Base;
 use Kanboard\Formatter\TaskSuggestMenuFormatter;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskSuggestMenuFormatterTest extends Base
 {

--- a/tests/units/Formatter/UserMentionFormatterTest.php
+++ b/tests/units/Formatter/UserMentionFormatterTest.php
@@ -1,8 +1,9 @@
 <?php
 
-use Kanboard\Formatter\UserMentionFormatter;
+namespace KanboardTests\units\Formatter;
 
-require_once __DIR__.'/../Base.php';
+use KanboardTests\units\Base;
+use Kanboard\Formatter\UserMentionFormatter;
 
 class UserMentionFormatterTest extends Base
 {

--- a/tests/units/FunctionTest.php
+++ b/tests/units/FunctionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/Base.php';
+namespace KanboardTests\units;
 
 class FunctionTest extends Base
 {

--- a/tests/units/Group/LdapBackendGroupProviderTest.php
+++ b/tests/units/Group/LdapBackendGroupProviderTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Group;
 
+use KanboardTests\units\Base;
 use Kanboard\Group\LdapBackendGroupProvider;
 
 class LdapBackendGroupProviderTest extends Base

--- a/tests/units/Helper/AppHelperTest.php
+++ b/tests/units/Helper/AppHelperTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Helper;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Session\FlashMessage;
 use Kanboard\Helper\AppHelper;
 

--- a/tests/units/Helper/AssetHelperTest.php
+++ b/tests/units/Helper/AssetHelperTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Helper;
 
+use KanboardTests\units\Base;
 use Kanboard\Helper\AssetHelper;
 use Kanboard\Model\ConfigModel;
 

--- a/tests/units/Helper/DatetimeHelperTest.php
+++ b/tests/units/Helper/DatetimeHelperTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Helper;
 
+use KanboardTests\units\Base;
 use Kanboard\Helper\DateHelper;
 
 class DatetimeHelperTest extends Base

--- a/tests/units/Helper/FileHelperTest.php
+++ b/tests/units/Helper/FileHelperTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Helper;
 
+use KanboardTests\units\Base;
 use Kanboard\Helper\FileHelper;
 
 class FileHelperTest extends Base

--- a/tests/units/Helper/HookHelperTest.php
+++ b/tests/units/Helper/HookHelperTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Helper;
 
+use KanboardTests\units\Base;
 use Kanboard\Helper\HookHelper;
 
 class HookHelperTest extends Base

--- a/tests/units/Helper/MailHelperTest.php
+++ b/tests/units/Helper/MailHelperTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Helper;
 
+use KanboardTests\units\Base;
 use Kanboard\Helper\MailHelper;
 
 class MailHelperTest extends Base

--- a/tests/units/Helper/ProjectActivityHelperTest.php
+++ b/tests/units/Helper/ProjectActivityHelperTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Helper;
+
+use KanboardTests\units\Base;
 use Kanboard\Helper\ProjectActivityHelper;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectActivityModel;
 use Kanboard\Model\TaskModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ProjectActivityHelperTest extends Base
 {

--- a/tests/units/Helper/ProjectRoleHelperTest.php
+++ b/tests/units/Helper/ProjectRoleHelperTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace KanboardTests\units\Helper;
+
+use KanboardTests\units\Base;
 use Kanboard\Core\Security\Role;
 use Kanboard\Core\User\UserSession;
 use Kanboard\Helper\ProjectRoleHelper;
@@ -13,8 +16,6 @@ use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskStatusModel;
 use Kanboard\Model\UserModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ProjectRoleHelperTest extends Base
 {

--- a/tests/units/Helper/TaskHelperTest.php
+++ b/tests/units/Helper/TaskHelperTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Helper;
 
+use KanboardTests\units\Base;
 use Kanboard\Helper\TaskHelper;
 
 class TaskHelperTest extends Base

--- a/tests/units/Helper/TextHelperTest.php
+++ b/tests/units/Helper/TextHelperTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Helper;
 
+use KanboardTests\units\Base;
 use Kanboard\Helper\TextHelper;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;

--- a/tests/units/Helper/UrlHelperTest.php
+++ b/tests/units/Helper/UrlHelperTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Helper;
 
+use KanboardTests\units\Base;
 use Kanboard\Helper\UrlHelper;
 use Kanboard\Model\ConfigModel;
 use Kanboard\Core\Http\Request;

--- a/tests/units/Helper/UserHelperTest.php
+++ b/tests/units/Helper/UserHelperTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Helper;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\User\UserSession;
 use Kanboard\Helper\UserHelper;
 use Kanboard\Model\ProjectModel;

--- a/tests/units/Job/CommentEventJobTest.php
+++ b/tests/units/Job/CommentEventJobTest.php
@@ -1,11 +1,12 @@
 <?php
 
+namespace KanboardTests\units\Job;
+
+use KanboardTests\units\Base;
 use Kanboard\Job\CommentEventJob;
 use Kanboard\Model\CommentModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
-
-require_once __DIR__.'/../Base.php';
 
 class CommentEventJobTest extends Base
 {

--- a/tests/units/Job/ProjectFileEventJobTest.php
+++ b/tests/units/Job/ProjectFileEventJobTest.php
@@ -1,10 +1,11 @@
 <?php
 
+namespace KanboardTests\units\Job;
+
+use KanboardTests\units\Base;
 use Kanboard\Job\ProjectFileEventJob;
 use Kanboard\Model\ProjectFileModel;
 use Kanboard\Model\ProjectModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ProjectFileEventJobTest extends Base
 {

--- a/tests/units/Job/ProjectMetricJobTest.php
+++ b/tests/units/Job/ProjectMetricJobTest.php
@@ -1,8 +1,9 @@
 <?php
 
-use Kanboard\Job\ProjectMetricJob;
+namespace KanboardTests\units\Job;
 
-require_once __DIR__.'/../Base.php';
+use KanboardTests\units\Base;
+use Kanboard\Job\ProjectMetricJob;
 
 class ProjectMetricJobTest extends Base
 {

--- a/tests/units/Job/SubtaskEventJobTest.php
+++ b/tests/units/Job/SubtaskEventJobTest.php
@@ -1,11 +1,12 @@
 <?php
 
+namespace KanboardTests\units\Job;
+
+use KanboardTests\units\Base;
 use Kanboard\Job\SubtaskEventJob;
 use Kanboard\Model\SubtaskModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
-
-require_once __DIR__.'/../Base.php';
 
 class SubtaskEventJobTest extends Base
 {

--- a/tests/units/Job/TaskEventJobTest.php
+++ b/tests/units/Job/TaskEventJobTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace KanboardTests\units\Job;
+
+use KanboardTests\units\Base;
 use Kanboard\Job\TaskEventJob;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\SwimlaneModel;
@@ -9,8 +12,6 @@ use Kanboard\Model\TaskModificationModel;
 use Kanboard\Model\TaskPositionModel;
 use Kanboard\Model\TaskProjectMoveModel;
 use Kanboard\Model\TaskStatusModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskEventJobTest extends Base
 {

--- a/tests/units/Job/TaskFileEventJobTest.php
+++ b/tests/units/Job/TaskFileEventJobTest.php
@@ -1,11 +1,12 @@
 <?php
 
+namespace KanboardTests\units\Job;
+
+use KanboardTests\units\Base;
 use Kanboard\Job\TaskFileEventJob;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFileModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskFileEventJobTest extends Base
 {

--- a/tests/units/Job/TaskLinkEventJobTest.php
+++ b/tests/units/Job/TaskLinkEventJobTest.php
@@ -1,11 +1,12 @@
 <?php
 
+namespace KanboardTests\units\Job;
+
+use KanboardTests\units\Base;
 use Kanboard\Job\TaskLinkEventJob;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskLinkModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskLinkEventJobTest extends Base
 {

--- a/tests/units/Job/UserMentionJobTest.php
+++ b/tests/units/Job/UserMentionJobTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace KanboardTests\units\Job;
+
+use KanboardTests\units\Base;
 use Kanboard\Core\Security\Role;
 use Kanboard\Event\TaskEvent;
 use Kanboard\Job\UserMentionJob;
@@ -7,8 +10,6 @@ use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectUserRoleModel;
 use Kanboard\Model\TaskModel;
 use Kanboard\Model\UserModel;
-
-require_once __DIR__.'/../Base.php';
 
 class UserMentionJobTest extends Base
 {

--- a/tests/units/Locale/LocaleTest.php
+++ b/tests/units/Locale/LocaleTest.php
@@ -1,6 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Locale;
+
+use KanboardTests\units\Base;
 
 class LocaleTest extends Base
 {

--- a/tests/units/Middleware/ApplicationAuthorizationMiddlewareTest.php
+++ b/tests/units/Middleware/ApplicationAuthorizationMiddlewareTest.php
@@ -1,10 +1,12 @@
 <?php
 
+namespace KanboardTests\units\Middleware;
+
+use KanboardTests\units\Base;
 use Kanboard\Middleware\ApplicationAuthorizationMiddleware;
+use stdClass;
 
-require_once __DIR__.'/../Base.php';
-
-class ApplicationAuthorizationMiddlewareMiddlewareTest extends Base
+class ApplicationAuthorizationMiddlewareTest extends Base
 {
     /**
      * @var ApplicationAuthorizationMiddleware

--- a/tests/units/Middleware/AuthenticationMiddlewareTest.php
+++ b/tests/units/Middleware/AuthenticationMiddlewareTest.php
@@ -1,8 +1,9 @@
 <?php
 
-use Kanboard\Middleware\AuthenticationMiddleware;
+namespace KanboardTests\units\Middleware;
 
-require_once __DIR__.'/../Base.php';
+use KanboardTests\units\Base;
+use Kanboard\Middleware\AuthenticationMiddleware;
 
 class AuthenticationMiddlewareTest extends Base
 {

--- a/tests/units/Middleware/ProjectAuthorizationMiddlewareTest.php
+++ b/tests/units/Middleware/ProjectAuthorizationMiddlewareTest.php
@@ -1,10 +1,12 @@
 <?php
 
+namespace KanboardTests\units\Middleware;
+
+use KanboardTests\units\Base;
 use Kanboard\Middleware\ProjectAuthorizationMiddleware;
+use stdClass;
 
-require_once __DIR__.'/../Base.php';
-
-class ProjectAuthorizationMiddlewareMiddlewareTest extends Base
+class ProjectAuthorizationMiddlewareTest extends Base
 {
     /**
      * @var ProjectAuthorizationMiddleware

--- a/tests/units/Model/ActionModelTest.php
+++ b/tests/units/Model/ActionModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ActionModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskModel;

--- a/tests/units/Model/BoardTest.php
+++ b/tests/units/Model/BoardTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ColumnModel;
 use Kanboard\Model\ConfigModel;

--- a/tests/units/Model/CategoryModelTest.php
+++ b/tests/units/Model/CategoryModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ConfigModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Model/ColorModelTest.php
+++ b/tests/units/Model/ColorModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ColorModel;
 use Kanboard\Model\ConfigModel;
 

--- a/tests/units/Model/ColumnModelTest.php
+++ b/tests/units/Model/ColumnModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ColumnModel;
 use Kanboard\Model\TaskCreationModel;

--- a/tests/units/Model/ColumnMoveRestrictionModelTest.php
+++ b/tests/units/Model/ColumnMoveRestrictionModelTest.php
@@ -1,10 +1,11 @@
 <?php
 
+namespace KanboardTests\units\Model;
+
+use KanboardTests\units\Base;
 use Kanboard\Model\ColumnMoveRestrictionModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectRoleModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ColumnMoveRestrictionModelTest extends Base
 {

--- a/tests/units/Model/ColumnRestrictionModelTest.php
+++ b/tests/units/Model/ColumnRestrictionModelTest.php
@@ -1,10 +1,11 @@
 <?php
 
+namespace KanboardTests\units\Model;
+
+use KanboardTests\units\Base;
 use Kanboard\Model\ColumnRestrictionModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectRoleModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ColumnRestrictionModelTest extends Base
 {

--- a/tests/units/Model/CommentModelTest.php
+++ b/tests/units/Model/CommentModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\CommentModel;

--- a/tests/units/Model/ConfigModelTest.php
+++ b/tests/units/Model/ConfigModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ConfigModel;
 
 class ConfigModelTest extends Base

--- a/tests/units/Model/CurrencyTest.php
+++ b/tests/units/Model/CurrencyTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\CurrencyModel;
 
 class CurrencyTest extends Base

--- a/tests/units/Model/CustomFilterTest.php
+++ b/tests/units/Model/CustomFilterTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\UserModel;
 use Kanboard\Model\CustomFilterModel;

--- a/tests/units/Model/GroupMemberTest.php
+++ b/tests/units/Model/GroupMemberTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\GroupModel;
 use Kanboard\Model\UserModel;
 use Kanboard\Model\GroupMemberModel;

--- a/tests/units/Model/GroupModelTest.php
+++ b/tests/units/Model/GroupModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\GroupModel;
 
 class GroupModelTest extends Base

--- a/tests/units/Model/InviteModelTest.php
+++ b/tests/units/Model/InviteModelTest.php
@@ -1,8 +1,9 @@
 <?php
 
-use Kanboard\Model\InviteModel;
+namespace KanboardTests\units\Model;
 
-require_once __DIR__.'/../Base.php';
+use KanboardTests\units\Base;
+use Kanboard\Model\InviteModel;
 
 class InviteModelTest extends Base
 {

--- a/tests/units/Model/LanguageTest.php
+++ b/tests/units/Model/LanguageTest.php
@@ -1,8 +1,9 @@
 <?php
 
-use Kanboard\Model\LanguageModel;
+namespace KanboardTests\units\Model;
 
-require_once __DIR__.'/../Base.php';
+use KanboardTests\units\Base;
+use Kanboard\Model\LanguageModel;
 
 class LanguageTest extends Base
 {

--- a/tests/units/Model/LastLoginTest.php
+++ b/tests/units/Model/LastLoginTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\LastLoginModel;
 
 class LastLoginTest extends Base

--- a/tests/units/Model/LinkTest.php
+++ b/tests/units/Model/LinkTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\LinkModel;
 
 class LinkTest extends Base

--- a/tests/units/Model/NotificationModelTest.php
+++ b/tests/units/Model/NotificationModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\SubtaskModel;

--- a/tests/units/Model/PasswordResetTest.php
+++ b/tests/units/Model/PasswordResetTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\UserModel;
 use Kanboard\Model\PasswordResetModel;
 

--- a/tests/units/Model/ProjectActivityTest.php
+++ b/tests/units/Model/ProjectActivityTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskCreationModel;

--- a/tests/units/Model/ProjectDailyColumnStatsTest.php
+++ b/tests/units/Model/ProjectDailyColumnStatsTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectDailyColumnStatsModel;
 use Kanboard\Model\ConfigModel;

--- a/tests/units/Model/ProjectDailyStatsTest.php
+++ b/tests/units/Model/ProjectDailyStatsTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectDailyStatsModel;
 use Kanboard\Model\TaskCreationModel;

--- a/tests/units/Model/ProjectDuplicationModelTest.php
+++ b/tests/units/Model/ProjectDuplicationModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ActionModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\CategoryModel;

--- a/tests/units/Model/ProjectFileTest.php
+++ b/tests/units/Model/ProjectFileTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectFileModel;
 use Kanboard\Model\ProjectModel;
 

--- a/tests/units/Model/ProjectGroupRoleTest.php
+++ b/tests/units/Model/ProjectGroupRoleTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\UserModel;
 use Kanboard\Model\GroupModel;

--- a/tests/units/Model/ProjectMetadataTest.php
+++ b/tests/units/Model/ProjectMetadataTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectMetadataModel;
 

--- a/tests/units/Model/ProjectModelTest.php
+++ b/tests/units/Model/ProjectModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Api\Procedure\ProjectPermissionProcedure;
 use Kanboard\Core\Security\Role;
 use Kanboard\Core\Translator;

--- a/tests/units/Model/ProjectNotificationTypeTest.php
+++ b/tests/units/Model/ProjectNotificationTypeTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectNotificationTypeModel;
 

--- a/tests/units/Model/ProjectPermissionModelTest.php
+++ b/tests/units/Model/ProjectPermissionModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectPermissionModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\UserModel;

--- a/tests/units/Model/ProjectRoleModelTest.php
+++ b/tests/units/Model/ProjectRoleModelTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace KanboardTests\units\Model;
+
+use KanboardTests\units\Base;
 use Kanboard\Core\Security\Role;
 use Kanboard\Model\GroupMemberModel;
 use Kanboard\Model\GroupModel;
@@ -7,8 +10,6 @@ use Kanboard\Model\ProjectGroupRoleModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectRoleModel;
 use Kanboard\Model\ProjectUserRoleModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ProjectRoleModelTest extends Base
 {

--- a/tests/units/Model/ProjectRoleRestrictionModelTest.php
+++ b/tests/units/Model/ProjectRoleRestrictionModelTest.php
@@ -1,10 +1,11 @@
 <?php
 
+namespace KanboardTests\units\Model;
+
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectRoleModel;
 use Kanboard\Model\ProjectRoleRestrictionModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ProjectRoleRestrictionModelTest extends Base
 {

--- a/tests/units/Model/ProjectTaskPriorityModelTest.php
+++ b/tests/units/Model/ProjectTaskPriorityModelTest.php
@@ -1,9 +1,10 @@
 <?php
 
+namespace KanboardTests\units\Model;
+
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectTaskPriorityModel;
-
-require_once __DIR__.'/../Base.php';
 
 class ProjectTaskPriorityModelTest extends Base
 {

--- a/tests/units/Model/ProjectUserRoleTest.php
+++ b/tests/units/Model/ProjectUserRoleTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\UserModel;
 use Kanboard\Model\GroupModel;

--- a/tests/units/Model/SubtaskModelTest.php
+++ b/tests/units/Model/SubtaskModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\SubtaskModel;
 use Kanboard\Model\ProjectModel;

--- a/tests/units/Model/SubtaskPositionModelTest.php
+++ b/tests/units/Model/SubtaskPositionModelTest.php
@@ -1,11 +1,12 @@
 <?php
 
+namespace KanboardTests\units\Model;
+
+use KanboardTests\units\Base;
 use Kanboard\Model\SubtaskPositionModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\SubtaskModel;
 use Kanboard\Model\ProjectModel;
-
-require_once __DIR__.'/../Base.php';
 
 class SubtaskPositionModelTest extends Base
 {

--- a/tests/units/Model/SubtaskStatusModelTest.php
+++ b/tests/units/Model/SubtaskStatusModelTest.php
@@ -1,11 +1,12 @@
 <?php
 
+namespace KanboardTests\units\Model;
+
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\SubtaskModel;
 use Kanboard\Model\SubtaskStatusModel;
 use Kanboard\Model\TaskCreationModel;
-
-require_once __DIR__.'/../Base.php';
 
 class SubtaskStatusModelTest extends Base
 {

--- a/tests/units/Model/SubtaskTaskConversionModelTest.php
+++ b/tests/units/Model/SubtaskTaskConversionModelTest.php
@@ -1,12 +1,13 @@
 <?php
 
+namespace KanboardTests\units\Model;
+
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\SubtaskModel;
 use Kanboard\Model\SubtaskTaskConversionModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
-
-require_once __DIR__.'/../Base.php';
 
 class SubtaskTaskConversionModelTest extends Base
 {

--- a/tests/units/Model/SubtaskTimeTrackingModelTest.php
+++ b/tests/units/Model/SubtaskTimeTrackingModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ConfigModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskCreationModel;

--- a/tests/units/Model/SwimlaneModelTest.php
+++ b/tests/units/Model/SwimlaneModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\SwimlaneModel;

--- a/tests/units/Model/TagDuplicationModelTest.php
+++ b/tests/units/Model/TagDuplicationModelTest.php
@@ -1,10 +1,11 @@
 <?php
 
+namespace KanboardTests\units\Model;
+
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TagDuplicationModel;
 use Kanboard\Model\TagModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TagDuplicationModelTest extends Base
 {

--- a/tests/units/Model/TagModelTest.php
+++ b/tests/units/Model/TagModelTest.php
@@ -1,9 +1,10 @@
 <?php
 
+namespace KanboardTests\units\Model;
+
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TagModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TagModelTest extends Base
 {

--- a/tests/units/Model/TaskCreationModelTest.php
+++ b/tests/units/Model/TaskCreationModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ConfigModel;
 use Kanboard\Model\TaskModel;
 use Kanboard\Model\TaskCreationModel;

--- a/tests/units/Model/TaskDuplicationModelTest.php
+++ b/tests/units/Model/TaskDuplicationModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskDuplicationModel;

--- a/tests/units/Model/TaskExternalLinkTest.php
+++ b/tests/units/Model/TaskExternalLinkTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskExternalLinkModel;

--- a/tests/units/Model/TaskFileModelTest.php
+++ b/tests/units/Model/TaskFileModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskFileModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\ProjectModel;

--- a/tests/units/Model/TaskFinderModelTest.php
+++ b/tests/units/Model/TaskFinderModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ColumnModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;

--- a/tests/units/Model/TaskLinkModelTest.php
+++ b/tests/units/Model/TaskLinkModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskLinkModel;
 use Kanboard\Model\TaskCreationModel;

--- a/tests/units/Model/TaskMetadataTest.php
+++ b/tests/units/Model/TaskMetadataTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskMetadataModel;

--- a/tests/units/Model/TaskModelTest.php
+++ b/tests/units/Model/TaskModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\ProjectModel;

--- a/tests/units/Model/TaskModificationModelTest.php
+++ b/tests/units/Model/TaskModificationModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskModificationModel;

--- a/tests/units/Model/TaskPositionModelTest.php
+++ b/tests/units/Model/TaskPositionModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskModel;
 use Kanboard\Model\ColumnModel;
 use Kanboard\Model\TaskStatusModel;

--- a/tests/units/Model/TaskProjectDuplicationModelTest.php
+++ b/tests/units/Model/TaskProjectDuplicationModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Security\Role;
 use Kanboard\Model\CategoryModel;
 use Kanboard\Model\ProjectModel;

--- a/tests/units/Model/TaskProjectMoveModelTest.php
+++ b/tests/units/Model/TaskProjectMoveModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\Security\Role;
 use Kanboard\Model\CategoryModel;
 use Kanboard\Model\ProjectModel;

--- a/tests/units/Model/TaskRecurrenceModelTest.php
+++ b/tests/units/Model/TaskRecurrenceModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Core\DateParser;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;

--- a/tests/units/Model/TaskStatusModelTest.php
+++ b/tests/units/Model/TaskStatusModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\SwimlaneModel;
 use Kanboard\Model\SubtaskModel;
 use Kanboard\Model\TaskModel;

--- a/tests/units/Model/TaskTagModelTest.php
+++ b/tests/units/Model/TaskTagModelTest.php
@@ -1,11 +1,12 @@
 <?php
 
+namespace KanboardTests\units\Model;
+
+use KanboardTests\units\Base;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TagModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskTagModel;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskTagModelTest extends Base
 {

--- a/tests/units/Model/TimezoneTest.php
+++ b/tests/units/Model/TimezoneTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TimezoneModel;
 
 class TimezoneTest extends Base

--- a/tests/units/Model/TransitionTest.php
+++ b/tests/units/Model/TransitionTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TransitionModel;
 use Kanboard\Model\ProjectModel;

--- a/tests/units/Model/UserLockingTest.php
+++ b/tests/units/Model/UserLockingTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\UserLockingModel;
 
 class UserLockingTest extends Base

--- a/tests/units/Model/UserMetadataTest.php
+++ b/tests/units/Model/UserMetadataTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\UserModel;
 use Kanboard\Model\UserMetadataModel;
 

--- a/tests/units/Model/UserModelTest.php
+++ b/tests/units/Model/UserModelTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\UserModel;
 use Kanboard\Model\SubtaskModel;
 use Kanboard\Model\CommentModel;

--- a/tests/units/Model/UserNotificationFilterTest.php
+++ b/tests/units/Model/UserNotificationFilterTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\UserModel;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\UserNotificationFilterModel;

--- a/tests/units/Model/UserNotificationTest.php
+++ b/tests/units/Model/UserNotificationTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\UserModel;

--- a/tests/units/Model/UserNotificationTypeTest.php
+++ b/tests/units/Model/UserNotificationTypeTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\UserNotificationTypeModel;
 
 class UserNotificationTypeTest extends Base

--- a/tests/units/Model/UserUnreadNotificationTest.php
+++ b/tests/units/Model/UserUnreadNotificationTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Model;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskModel;

--- a/tests/units/Notification/MailNotificationTest.php
+++ b/tests/units/Notification/MailNotificationTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Notification;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\SubtaskModel;

--- a/tests/units/Notification/WebhookNotificationTest.php
+++ b/tests/units/Notification/WebhookNotificationTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Notification;
 
+use KanboardTests\units\Base;
 use Kanboard\Model\ConfigModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\ProjectModel;

--- a/tests/units/Pagination/DashboardPaginationTest.php
+++ b/tests/units/Pagination/DashboardPaginationTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace KanboardTests\units\Pagination;
+
+use KanboardTests\units\Base;
 use Kanboard\Core\Security\Role;
 use Kanboard\Model\ColumnModel;
 use Kanboard\Model\ProjectModel;
@@ -8,8 +11,6 @@ use Kanboard\Model\SubtaskModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\UserModel;
 use Kanboard\Pagination\DashboardPagination;
-
-require_once __DIR__.'/../Base.php';
 
 class DashboardPaginationTest extends Base
 {

--- a/tests/units/Pagination/ProjectPaginationTest.php
+++ b/tests/units/Pagination/ProjectPaginationTest.php
@@ -1,12 +1,13 @@
 <?php
 
+namespace KanboardTests\units\Pagination;
+
+use KanboardTests\units\Base;
 use Kanboard\Core\Security\Role;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\ProjectUserRoleModel;
 use Kanboard\Model\UserModel;
 use Kanboard\Pagination\ProjectPagination;
-
-require_once __DIR__.'/../Base.php';
 
 class ProjectPaginationTest extends Base
 {

--- a/tests/units/Pagination/TaskPaginationTest.php
+++ b/tests/units/Pagination/TaskPaginationTest.php
@@ -1,12 +1,13 @@
 <?php
 
+namespace KanboardTests\units\Pagination;
+
+use KanboardTests\units\Base;
 use Kanboard\Core\Http\Request;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskModel;
 use Kanboard\Pagination\TaskPagination;
-
-require_once __DIR__.'/../Base.php';
 
 class TaskPaginationTest extends Base
 {

--- a/tests/units/Pagination/UserPaginationTest.php
+++ b/tests/units/Pagination/UserPaginationTest.php
@@ -1,9 +1,10 @@
 <?php
 
+namespace KanboardTests\units\Pagination;
+
+use KanboardTests\units\Base;
 use Kanboard\Model\UserModel;
 use Kanboard\Pagination\UserPagination;
-
-require_once __DIR__.'/../Base.php';
 
 class UserPaginationTest extends Base
 {

--- a/tests/units/ServiceProvider/FormatterProviderTest.php
+++ b/tests/units/ServiceProvider/FormatterProviderTest.php
@@ -1,9 +1,10 @@
 <?php
 
+namespace KanboardTests\units\ServiceProvider;
+
+use KanboardTests\units\Base;
 use Kanboard\ServiceProvider\FormatterProvider;
 use Pimple\Container;
-
-require_once __DIR__.'/../Base.php';
 
 class FormatterProviderTest extends Base
 {

--- a/tests/units/ServiceProvider/ModelProviderTest.php
+++ b/tests/units/ServiceProvider/ModelProviderTest.php
@@ -1,9 +1,10 @@
 <?php
 
+namespace KanboardTests\units\ServiceProvider;
+
+use KanboardTests\units\Base;
 use Kanboard\ServiceProvider\ClassProvider;
 use Pimple\Container;
-
-require_once __DIR__.'/../Base.php';
 
 class ModelProviderTest extends Base
 {

--- a/tests/units/Subscriber/LdapUserPhotoSubscriberTest.php
+++ b/tests/units/Subscriber/LdapUserPhotoSubscriberTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Subscriber;
+
+use KanboardTests\units\Base;
 use Kanboard\Core\Security\Role;
 use Kanboard\Event\UserProfileSyncEvent;
 use Kanboard\Model\UserModel;
 use Kanboard\Subscriber\LdapUserPhotoSubscriber;
 use Kanboard\User\DatabaseUserProvider;
 use Kanboard\User\LdapUserProvider;
-
-require_once __DIR__.'/../Base.php';
 
 class LdapUserPhotoSubscriberTest extends Base
 {

--- a/tests/units/Subscriber/RecurringTaskSubscriberTest.php
+++ b/tests/units/Subscriber/RecurringTaskSubscriberTest.php
@@ -1,13 +1,14 @@
 <?php
 
+namespace KanboardTests\units\Subscriber;
+
+use KanboardTests\units\Base;
 use Kanboard\EventBuilder\TaskEventBuilder;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskFinderModel;
 use Kanboard\Model\TaskModel;
 use Kanboard\Subscriber\RecurringTaskSubscriber;
-
-require_once __DIR__.'/../Base.php';
 
 class RecurringTaskSubscriberTest extends Base
 {

--- a/tests/units/User/Avatar/LetterAvatarProviderTest.php
+++ b/tests/units/User/Avatar/LetterAvatarProviderTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../../Base.php';
+namespace KanboardTests\units\User\Avatar;
 
+use KanboardTests\units\Base;
 use Kanboard\User\Avatar\LetterAvatarProvider;
 
 class LetterAvatarProviderTest extends Base

--- a/tests/units/User/DatabaseUserProviderTest.php
+++ b/tests/units/User/DatabaseUserProviderTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\User;
 
+use KanboardTests\units\Base;
 use Kanboard\User\DatabaseUserProvider;
 
 class DatabaseUserProviderTest extends Base

--- a/tests/units/Validator/CommentValidatorTest.php
+++ b/tests/units/Validator/CommentValidatorTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Validator;
 
+use KanboardTests\units\Base;
 use Kanboard\Validator\CommentValidator;
 use Kanboard\Core\Security\Role;
 

--- a/tests/units/Validator/ConfigValidatorTest.php
+++ b/tests/units/Validator/ConfigValidatorTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Validator;
 
+use KanboardTests\units\Base;
 use Kanboard\Validator\ConfigValidator;
 
 class ConfigValidatorTest extends Base

--- a/tests/units/Validator/CurrencyValidatorTest.php
+++ b/tests/units/Validator/CurrencyValidatorTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Validator;
 
+use KanboardTests\units\Base;
 use Kanboard\Validator\CurrencyValidator;
 
 class CurrencyValidatorTest extends Base

--- a/tests/units/Validator/CustomFilterValidatorTest.php
+++ b/tests/units/Validator/CustomFilterValidatorTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Validator;
 
+use KanboardTests\units\Base;
 use Kanboard\Validator\CustomFilterValidator;
 
 class CustomFilterValidatorTest extends Base

--- a/tests/units/Validator/ExternalLinkValidatorTest.php
+++ b/tests/units/Validator/ExternalLinkValidatorTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Validator;
 
+use KanboardTests\units\Base;
 use Kanboard\Validator\ExternalLinkValidator;
 
 class ExternalLinkValidatorTest extends Base

--- a/tests/units/Validator/GroupValidatorTest.php
+++ b/tests/units/Validator/GroupValidatorTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Validator;
 
+use KanboardTests\units\Base;
 use Kanboard\Validator\GroupValidator;
 
 class GroupValidatorTest extends Base

--- a/tests/units/Validator/LinkValidatorTest.php
+++ b/tests/units/Validator/LinkValidatorTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Validator;
 
+use KanboardTests\units\Base;
 use Kanboard\Validator\LinkValidator;
 
 class LinkValidatorTest extends Base

--- a/tests/units/Validator/PasswordResetValidatorTest.php
+++ b/tests/units/Validator/PasswordResetValidatorTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Validator;
 
+use KanboardTests\units\Base;
 use Kanboard\Validator\PasswordResetValidator;
 
 class PasswordResetValidatorTest extends Base

--- a/tests/units/Validator/ProjectValidatorTest.php
+++ b/tests/units/Validator/ProjectValidatorTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Validator;
 
+use KanboardTests\units\Base;
 use Kanboard\Validator\ProjectValidator;
 use Kanboard\Model\ProjectModel;
 

--- a/tests/units/Validator/TaskLinkValidatorTest.php
+++ b/tests/units/Validator/TaskLinkValidatorTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Validator;
 
+use KanboardTests\units\Base;
 use Kanboard\Validator\TaskLinkValidator;
 use Kanboard\Model\TaskLinkModel;
 use Kanboard\Model\TaskCreationModel;

--- a/tests/units/Validator/TaskValidatorTest.php
+++ b/tests/units/Validator/TaskValidatorTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Validator;
 
+use KanboardTests\units\Base;
 use Kanboard\Validator\TaskValidator;
 
 class TaskValidatorTest extends Base

--- a/tests/units/Validator/UserValidatorTest.php
+++ b/tests/units/Validator/UserValidatorTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__.'/../Base.php';
+namespace KanboardTests\units\Validator;
 
+use KanboardTests\units\Base;
 use Kanboard\Validator\UserValidator;
 use Kanboard\Core\Security\Role;
 


### PR DESCRIPTION
## Contents

This PR:
- adds namespaces to all test files
- fixes two non-PSR-4-compliant class names
  - `ApplicationAuthorizationMiddlewareMiddlewareTest` => `ApplicationAuthorizationMiddlewareTest`
  - `ProjectAuthorizationMiddlewareMiddlewareTest` => `ProjectAuthorizationMiddlewareTest`

## Motivation

Using namespaces for tests enables composer's default autoloader functionality, which is a prerequisite for future enhancements such as parallel test execution.

## Notes

I'm not sure whether/when to commit the generated composer autoloading files, so I left them out in the initial commit.

## Contributing Guideline

Please confirm that you've completed the following before submitting:

- [x] I have tested my changes thoroughly
- [x] No breaking changes were introduced
- [x] No regressions were observed
- [x] I have updated the unit tests and integration tests accordingly
- [x] I follow the existing [coding standards](https://docs.kanboard.org/v1/dev/coding_standards/)
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
