### PR TITLE
fix: do not load `RememberMeAuth` provider when `REMEMBER_ME_AUTH` is `false`

### DIFF
--- a/app/Controller/AuthController.php
+++ b/app/Controller/AuthController.php
@@ -46,7 +46,11 @@ class AuthController extends BaseController
     public function check()
     {
         $values = $this->request->getValues();
-        session_set('hasRememberMe', ! empty($values['remember_me']));
+
+        if (REMEMBER_ME_AUTH) {
+            session_set('hasRememberMe', ! empty($values['remember_me']));
+        }
+
         list($valid, $errors) = $this->authValidator->validateForm($values);
 
         if ($valid) {

--- a/app/Controller/TwoFactorController.php
+++ b/app/Controller/TwoFactorController.php
@@ -156,7 +156,7 @@ class TwoFactorController extends UserViewController
             $this->userSession->setPostAuthenticationAsValidated();
             $this->flash->success(t('The two factor authentication code is valid.'));
 
-            if (session_is_true('hasRememberMe')) {
+            if (REMEMBER_ME_AUTH && session_is_true('hasRememberMe')) {
                 $session = $this->rememberMeSessionModel->create($this->userSession->getId(), $this->request->getIpAddress(), $this->request->getUserAgent());
                 $this->rememberMeCookie->write($session['token'], $session['sequence'], $session['expiration']);
             }

--- a/app/Controller/UserViewController.php
+++ b/app/Controller/UserViewController.php
@@ -107,6 +107,11 @@ class UserViewController extends BaseController
      */
     public function sessions()
     {
+        if (! REMEMBER_ME_AUTH) {
+            $this->response->status(404);
+            return;
+        }
+
         $user = $this->getUser();
         $this->response->html($this->helper->layout->user('user_view/sessions', array(
             'sessions' => $this->rememberMeSessionModel->getAll($user['id']),

--- a/app/ServiceProvider/AuthenticationProvider.php
+++ b/app/ServiceProvider/AuthenticationProvider.php
@@ -34,7 +34,11 @@ class AuthenticationProvider implements ServiceProviderInterface
     {
         $container['authenticationManager'] = new AuthenticationManager($container);
         $container['authenticationManager']->register(new TotpAuth($container));
-        $container['authenticationManager']->register(new RememberMeAuth($container));
+
+        if (REMEMBER_ME_AUTH) {
+            $container['authenticationManager']->register(new RememberMeAuth($container));
+        }
+
         $container['authenticationManager']->register(new DatabaseAuth($container));
 
         if (REVERSE_PROXY_AUTH) {
@@ -42,7 +46,7 @@ class AuthenticationProvider implements ServiceProviderInterface
         }
 
         $container['authenticationManager']->register(new ApiAccessTokenAuth($container));
-        
+
         if (LDAP_AUTH) {
             $container['authenticationManager']->register(new LdapAuth($container));
         }

--- a/app/Subscriber/AuthSubscriber.php
+++ b/app/Subscriber/AuthSubscriber.php
@@ -59,7 +59,7 @@ class AuthSubscriber extends BaseSubscriber implements EventSubscriberInterface
             $this->userSession->setPostAuthenticationAsValidated();
         }
 
-        if (session_is_true('hasRememberMe') && ! $this->userSession->hasPostAuthentication()) {
+        if (REMEMBER_ME_AUTH && session_is_true('hasRememberMe') && ! $this->userSession->hasPostAuthentication()) {
             $session = $this->rememberMeSessionModel->create($this->userSession->getId(), $ipAddress, $userAgent);
             $this->rememberMeCookie->write($session['token'], $session['sequence'], $session['expiration']);
         }

--- a/app/Template/user_list/dropdown.php
+++ b/app/Template/user_list/dropdown.php
@@ -69,7 +69,7 @@
                     <?= $this->modal->medium('id-badge', t('Last logins'), 'UserViewController', 'lastLogin', array('user_id' => $user['id'])) ?>
                 </li>
             <?php endif ?>
-            <?php if ($this->user->hasAccess('UserViewController', 'sessions')): ?>
+            <?php if ($this->user->hasAccess('UserViewController', 'sessions') && REMEMBER_ME_AUTH): ?>
                 <li>
                     <?= $this->modal->medium('database', t('Persistent connections'), 'UserViewController', 'sessions', array('user_id' => $user['id'])) ?>
                 </li>

--- a/app/Template/user_view/sidebar.php
+++ b/app/Template/user_view/sidebar.php
@@ -24,7 +24,7 @@
                     <?= $this->url->link(t('Last logins'), 'UserViewController', 'lastLogin', array('user_id' => $user['id'])) ?>
                 </li>
             <?php endif ?>
-            <?php if ($this->user->hasAccess('UserViewController', 'sessions')): ?>
+            <?php if ($this->user->hasAccess('UserViewController', 'sessions') && REMEMBER_ME_AUTH): ?>
                 <li <?= $this->app->checkMenuSelection('UserViewController', 'sessions') ?>>
                     <?= $this->url->link(t('Persistent connections'), 'UserViewController', 'sessions', array('user_id' => $user['id'])) ?>
                 </li>


### PR DESCRIPTION
Previously, only the checkbox on the login form was hidden.
