### PR TITLE
feat!: support RTL

### DIFF
--- a/app/Helper/AppHelper.php
+++ b/app/Helper/AppHelper.php
@@ -131,6 +131,17 @@ class AppHelper extends Base
     }
 
     /**
+     * Check if current language requires RTL direction
+     *
+     * @access public
+     * @return bool
+     */
+    public function isRtlLanguage()
+    {
+        return $this->languageModel->isRtlLanguage();
+    }
+
+    /**
      * Get date format for Jquery DatePicker
      *
      * @access public

--- a/app/Model/LanguageModel.php
+++ b/app/Model/LanguageModel.php
@@ -194,6 +194,24 @@ class LanguageModel extends Base
     }
 
     /**
+     * Check if current language requires RTL direction
+     *
+     * @access public
+     * @return bool
+     */
+    public function isRtlLanguage()
+    {
+        $rtlJsLanguageCodes = array(
+            'ar',
+            'fa',
+        );
+
+        $lang = $this->getJsLanguageCode();
+
+        return in_array($lang, $rtlJsLanguageCodes);
+    }
+
+    /**
      * Get current language
      *
      * @access public

--- a/app/Template/layout.php
+++ b/app/Template/layout.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<?= $this->app->jsLang() ?>">
+<html lang="<?= $this->app->jsLang() ?>"<?php if ($this->app->isRtlLanguage()): ?> dir="rtl"<?php endif; ?>>
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">

--- a/tests/units/Helper/AppHelperTest.php
+++ b/tests/units/Helper/AppHelperTest.php
@@ -14,6 +14,12 @@ class AppHelperTest extends Base
         $this->assertEquals('en', $h->jsLang());
     }
 
+    public function testIsRtlLanguage()
+    {
+        $h = new AppHelper($this->container);
+        $this->assertFalse($h->isRtlLanguage());
+    }
+
     public function testTimezone()
     {
         $h = new AppHelper($this->container);

--- a/tests/units/Model/LanguageTest.php
+++ b/tests/units/Model/LanguageTest.php
@@ -35,6 +35,18 @@ class LanguageTest extends Base
         $this->assertEquals('en', $languageModel->getJsLanguageCode());
     }
 
+    public function testIsRtlLanguage()
+    {
+        $languageModel = new LanguageModel($this->container);
+        $this->assertFalse($languageModel->isRtlLanguage());
+
+        $_SESSION['user'] = array('language' => 'ar_SY');
+        $this->assertTrue($languageModel->isRtlLanguage());
+
+        $_SESSION['user'] = array('language' => 'en_GB');
+        $this->assertFalse($languageModel->isRtlLanguage());
+    }
+
     public function testGetCurrentLanguage()
     {
         $languageModel = new LanguageModel($this->container);


### PR DESCRIPTION
This pull request introduces basic support for right-to-left (RTL) languages in Kanboard.
Users selecting Arabic or Farsi will now see the interface rendered in right-to-left mode, improving usability and readability. I have marked this PR as a breaking change since it alters the rendering for these languages.

This lays the groundwork for enhanced RTL support across the application and future contributions.
Non-RTL languages remain unaffected.

Please confirm that you've completed the following before submitting:

- [X] I have tested my changes thoroughly
- [ ] No breaking changes were introduced
- [X] No regressions were observed
- [X] I have updated the unit tests and integration tests accordingly
- [X] I follow the existing [coding standards](https://docs.kanboard.org/v1/dev/coding_standards/)
- [X] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
