### PR TITLE
feat: display sub-tasks completion in numbers (x/y) alongside percentage

### DIFF
--- a/app/Template/board/task_footer.php
+++ b/app/Template/board/task_footer.php
@@ -95,7 +95,8 @@
         <?php endif ?>
 
         <?php if (! empty($task['nb_subtasks'])): ?>
-            <?= $this->app->tooltipLink('<i class="fa fa-bars fa-fw"></i>'.round($task['nb_completed_subtasks'] / $task['nb_subtasks'] * 100, 0).'%', $this->url->href('BoardTooltipController', 'subtasks', array('task_id' => $task['id']))) ?>
+            <?php $nb_subtasks = (int) $task['nb_subtasks']; $nb_completed = (int) $task['nb_completed_subtasks']; $percentage = $nb_subtasks > 0 ? round($nb_completed / $nb_subtasks * 100, 0) : 0; ?>
+            <?= $this->app->tooltipLink('<i class="fa fa-bars fa-fw"></i>'.$percentage.'% ('.$nb_completed.'/'.$nb_subtasks.')', $this->url->href('BoardTooltipController', 'subtasks', array('task_id' => $task['id']))) ?>
         <?php endif ?>
 
         <?php if (! empty($task['nb_files'])): ?>

--- a/app/Template/task_list/task_icons.php
+++ b/app/Template/task_list/task_icons.php
@@ -60,7 +60,8 @@
     <?php endif ?>
 
     <?php if (! empty($task['nb_subtasks'])): ?>
-        <?= $this->app->tooltipLink('<i class="fa fa-bars fa-fw"></i>'.round($task['nb_completed_subtasks'] / $task['nb_subtasks'] * 100, 0).'%', $this->url->href('BoardTooltipController', 'subtasks', array('task_id' => $task['id']))) ?>
+        <?php $nb_subtasks = (int) $task['nb_subtasks']; $nb_completed = (int) $task['nb_completed_subtasks']; $percentage = $nb_subtasks > 0 ? round($nb_completed / $nb_subtasks * 100, 0) : 0; ?>
+        <?= $this->app->tooltipLink('<i class="fa fa-bars fa-fw"></i>'.$percentage.'% ('.$nb_completed.'/'.$nb_subtasks.')', $this->url->href('BoardTooltipController', 'subtasks', array('task_id' => $task['id']))) ?>
     <?php endif ?>
 
     <?php if (! empty($task['nb_files'])): ?>


### PR DESCRIPTION
Please confirm that you've completed the following before submitting:

- [YES] I have tested my changes thoroughly
- [YES] No breaking changes were introduced
- [YES] No regressions were observed
- [YES] I have updated the unit tests and integration tests accordingly
- [YES] I follow the existing [coding standards](https://docs.kanboard.org/v1/dev/coding_standards/)
- [YES] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)

This will display the completion of sub-tasks in this format: (x/y), where x is completed and y is the total. So if there are 14 sub-tasks and all are uncompleted, then the percentage would be 0% and **just aside that** it would show (0/14).