### PR TITLE
Block private network access for external web link (configurable)

### DIFF
--- a/app/ExternalLink/WebLink.php
+++ b/app/ExternalLink/WebLink.php
@@ -20,6 +20,11 @@ class WebLink extends BaseLink implements ExternalLinkInterface
      */
     public function getTitle()
     {
+        if (! EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS && $this->httpClient->isPrivateURL($this->url)) {
+            $this->logger->info('Blocked attempt to fetch URL from private network: '.$this->url);
+            return $this->url;
+        }
+
         $html = $this->httpClient->get($this->url);
 
         if (preg_match('/<title>(.*)<\/title>/siU', $html, $matches)) {
@@ -32,6 +37,6 @@ class WebLink extends BaseLink implements ExternalLinkInterface
             return $components['host'].$components['path'];
         }
 
-        return t('Title not found');
+        return $this->url;
     }
 }

--- a/app/Locale/ar_SY/translations.php
+++ b/app/Locale/ar_SY/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'تلقائي',
     'Related' => 'مرتبط',
     'Attachment' => 'مرفق',
-    'Title not found' => 'العنوان غير موجود',
     'Web Link' => 'رابط ويب',
     'External links' => 'روابط خارجية',
     'Add external link' => 'إضافة رابط خارجي',

--- a/app/Locale/bg_BG/translations.php
+++ b/app/Locale/bg_BG/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Авто',
     'Related' => 'Свързано',
     'Attachment' => 'Прикачен файл',
-    'Title not found' => 'Заглавието не е намерено',
     'Web Link' => 'Препратка в Интернет',
     'External links' => 'Външна връзка',
     'Add external link' => 'Добавяне на външна връзка',

--- a/app/Locale/bs_BA/translations.php
+++ b/app/Locale/bs_BA/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Automatski',
     'Related' => 'Povezani',
     'Attachment' => 'Dodijeljeni',
-    'Title not found' => 'Bez naslova',
     'Web Link' => 'Web veza',
     'External links' => 'Vanjska veza',
     'Add external link' => 'Dodaj vanjsku vezu',

--- a/app/Locale/ca_ES/translations.php
+++ b/app/Locale/ca_ES/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Auto',
     'Related' => 'Relacionat',
     'Attachment' => 'Adjunt',
-    'Title not found' => 'Títol no trobat',
     'Web Link' => 'Enllaç web',
     'External links' => 'Enllaços externs',
     'Add external link' => 'Afegeix un enllaç extern',

--- a/app/Locale/cs_CZ/translations.php
+++ b/app/Locale/cs_CZ/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Auto',
     'Related' => 'Související',
     'Attachment' => 'Příloha',
-    'Title not found' => 'Název nenalezen',
     'Web Link' => 'Webový odkaz',
     'External links' => 'Externí odkazy',
     'Add external link' => 'Přidat externí odkaz',

--- a/app/Locale/da_DK/translations.php
+++ b/app/Locale/da_DK/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Auto',
     'Related' => 'Relateret',
     'Attachment' => 'Vedhæftning',
-    'Title not found' => 'Titel ikke fundet',
     'Web Link' => 'Net henvisning',
     'External links' => 'Eksterne henvisninger',
     'Add external link' => 'Tilføj ekstern henvisning',

--- a/app/Locale/de_DE/translations.php
+++ b/app/Locale/de_DE/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Auto',
     'Related' => 'Verbunden',
     'Attachment' => 'Anhang',
-    'Title not found' => 'Titel nicht gefunden',
     'Web Link' => 'Weblink',
     'External links' => 'Externe Verbindungen',
     'Add external link' => 'Externe Verbindung hinzufügen',

--- a/app/Locale/de_DE_du/translations.php
+++ b/app/Locale/de_DE_du/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Auto',
     'Related' => 'Verbunden',
     'Attachment' => 'Anhang',
-    'Title not found' => 'Titel nicht gefunden',
     'Web Link' => 'Weblink',
     'External links' => 'Externe Verbindungen',
     'Add external link' => 'Externe Verbindung hinzufügen',

--- a/app/Locale/el_GR/translations.php
+++ b/app/Locale/el_GR/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Αυτόματο',
     'Related' => 'Σχετίζεται',
     'Attachment' => 'Συνημμένο',
-    'Title not found' => 'Ο τίτλος δεν βρέθηκε',
     'Web Link' => 'Σύνδεσμος web',
     'External links' => 'Εξωτερικοί σύνδεσμοι',
     'Add external link' => 'Προσθήκη εξωτερικού συνδέσμου',

--- a/app/Locale/es_ES/translations.php
+++ b/app/Locale/es_ES/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Auto',
     'Related' => 'Relacionado',
     'Attachment' => 'Archivo adjunto',
-    'Title not found' => 'Título no encontrado',
     'Web Link' => 'Enlace web',
     'External links' => 'Enlaces externos',
     'Add external link' => 'Añadir enlace externo',

--- a/app/Locale/es_VE/translations.php
+++ b/app/Locale/es_VE/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Auto',
     'Related' => 'Relacionado',
     'Attachment' => 'Archivo adjunto',
-    'Title not found' => 'Título no encontrado',
     'Web Link' => 'Enlace web',
     'External links' => 'Enlaces externos',
     'Add external link' => 'Añadir enlace externo',

--- a/app/Locale/fa_IR/translations.php
+++ b/app/Locale/fa_IR/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'خودکار',
     'Related' => 'مرتبط',
     'Attachment' => 'پیوست',
-    'Title not found' => 'عنوان یافت نشد',
     'Web Link' => 'پیوند وب',
     'External links' => 'پیوند های خارجی',
     'Add external link' => 'افزودن پیوند خارجی',

--- a/app/Locale/fi_FI/translations.php
+++ b/app/Locale/fi_FI/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Auto',
     'Related' => 'Liittyvät',
     'Attachment' => 'Liite',
-    'Title not found' => 'Otsikkoa ei löydy',
     'Web Link' => 'Web-linkki',
     'External links' => 'Ulkoiset linkit',
     'Add external link' => 'Lisää ulkoinen linkki',

--- a/app/Locale/fr_FR/translations.php
+++ b/app/Locale/fr_FR/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Auto',
     'Related' => 'Relié',
     'Attachment' => 'Pièce-jointe',
-    'Title not found' => 'Titre non trouvé',
     'Web Link' => 'Lien web',
     'External links' => 'Liens externes',
     'Add external link' => 'Ajouter un lien externe',

--- a/app/Locale/hr_HR/translations.php
+++ b/app/Locale/hr_HR/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Automatski',
     'Related' => 'Povezan',
     'Attachment' => 'Privitak',
-    'Title not found' => 'Naslov nije pronađen',
     'Web Link' => 'Web link',
     'External links' => 'Vanjske veze',
     'Add external link' => 'Dodaj vanjsku vezu',

--- a/app/Locale/hu_HU/translations.php
+++ b/app/Locale/hu_HU/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Automatikus',
     'Related' => 'Kapcsolódó',
     'Attachment' => 'Melléklet',
-    'Title not found' => 'A cím nem található',
     'Web Link' => 'Webes hivatkozás',
     'External links' => 'Külső hivatkozások',
     'Add external link' => 'Külső hivatkozás hozzáadása',

--- a/app/Locale/id_ID/translations.php
+++ b/app/Locale/id_ID/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Otomatis',
     'Related' => 'Terkait',
     'Attachment' => 'Lampiran',
-    'Title not found' => 'Judul tidak ditemukan',
     'Web Link' => 'Tautan web',
     'External links' => 'Tautan eksternal',
     'Add external link' => 'Tambah tautan eksternal',

--- a/app/Locale/it_IT/translations.php
+++ b/app/Locale/it_IT/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Automatico',
     'Related' => 'Correlato',
     'Attachment' => 'Allegato',
-    'Title not found' => 'Titolo non trovato',
     'Web Link' => 'Link Web',
     'External links' => 'Link esterni',
     'Add external link' => 'Aggiungi link esterno',

--- a/app/Locale/ja_JP/translations.php
+++ b/app/Locale/ja_JP/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => '自動',
     'Related' => '関連',
     'Attachment' => '添付',
-    'Title not found' => 'タイトルが見つかりません',
     'Web Link' => 'Webリンク',
     'External links' => '外部リンク',
     'Add external link' => '外部リンクを追加',

--- a/app/Locale/ko_KR/translations.php
+++ b/app/Locale/ko_KR/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => '자동',
     'Related' => '연관된',
     'Attachment' => '첨부',
-    'Title not found' => '제목이 없습니다',
     'Web Link' => '웹 링크',
     'External links' => '외부 링크',
     'Add external link' => '외부 링크 추가',

--- a/app/Locale/mk_MK/translations.php
+++ b/app/Locale/mk_MK/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Автоматски',
     'Related' => 'Поврзан',
     'Attachment' => 'Прилог',
-    'Title not found' => 'Без наслов',
     'Web Link' => 'Веб линк',
     'External links' => 'Надворешни врски',
     'Add external link' => 'Додадете надворешен линк',

--- a/app/Locale/my_MY/translations.php
+++ b/app/Locale/my_MY/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Auto',
     'Related' => 'Berkaitan',
     'Attachment' => 'Lampiran',
-    'Title not found' => 'Tajuk tidak dijumpai',
     'Web Link' => 'Pautan Web',
     'External links' => 'Pautan luaran',
     'Add external link' => 'Tambah pautan luaran',

--- a/app/Locale/nb_NO/translations.php
+++ b/app/Locale/nb_NO/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Auto',
     'Related' => 'Relasjon',
     'Attachment' => 'Vedlegg',
-    'Title not found' => 'Finner ingen tittel',
     'Web Link' => 'Web-lenke',
     'External links' => 'Eksterne lenker',
     'Add external link' => 'Ny ekstern lenke',

--- a/app/Locale/nl_NL/translations.php
+++ b/app/Locale/nl_NL/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Auto',
     'Related' => 'Gerelateerd',
     'Attachment' => 'Bijlage',
-    'Title not found' => 'Titel niet gevonden',
     'Web Link' => 'Weblink',
     'External links' => 'Externe links',
     'Add external link' => 'Externe link toevoegen',

--- a/app/Locale/pl_PL/translations.php
+++ b/app/Locale/pl_PL/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Automatyczny',
     'Related' => 'Powiązanie',
     'Attachment' => 'Załącznik',
-    'Title not found' => 'Nie odnaleziono tytułu',
     'Web Link' => 'Link URL',
     'External links' => 'Linki zewnętrzne',
     'Add external link' => 'Dodaj link zewnętrzny',

--- a/app/Locale/pt_BR/translations.php
+++ b/app/Locale/pt_BR/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Auto',
     'Related' => 'Relacionado',
     'Attachment' => 'Anexo',
-    'Title not found' => 'Título não encontrado',
     'Web Link' => 'Link web',
     'External links' => 'Links externos',
     'Add external link' => 'Adicionar um link externo',

--- a/app/Locale/pt_PT/translations.php
+++ b/app/Locale/pt_PT/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Auto',
     'Related' => 'Relacionado',
     'Attachment' => 'Anexo',
-    'Title not found' => 'Titulo não encontrado',
     'Web Link' => 'Ligação Web',
     'External links' => 'Ligações externas',
     'Add external link' => 'Adicionar ligação externa',

--- a/app/Locale/ro_RO/translations.php
+++ b/app/Locale/ro_RO/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Auto',
     'Related' => 'Asociat',
     'Attachment' => 'Atașament',
-    'Title not found' => 'Titlul nu a fost găsit',
     'Web Link' => 'Link web',
     'External links' => 'Legături externe',
     'Add external link' => 'Adaugă legătură externă',

--- a/app/Locale/ru_RU/translations.php
+++ b/app/Locale/ru_RU/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Авто',
     'Related' => 'Связано',
     'Attachment' => 'Вложение',
-    'Title not found' => 'Заголовок не найден',
     'Web Link' => 'Web-ссылка',
     'External links' => 'Внешние ссылки',
     'Add external link' => 'Добавить внешнюю ссылку',

--- a/app/Locale/sk_SK/translations.php
+++ b/app/Locale/sk_SK/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Auto',
     'Related' => 'Súvisí',
     'Attachment' => 'Prílohy',
-    'Title not found' => 'Názov nenájdený',
     'Web Link' => 'Webový odkaz',
     'External links' => 'Externé odkazy',
     'Add external link' => 'Pridať externý odkaz',

--- a/app/Locale/sr_Latn_RS/translations.php
+++ b/app/Locale/sr_Latn_RS/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Automatski',
     'Related' => 'Povezan',
     'Attachment' => 'Priložak',
-    'Title not found' => 'Bez naslova',
     'Web Link' => 'Veb link',
     'External links' => 'Spoljne veze',
     'Add external link' => 'Dodaj spoljnu vezu',

--- a/app/Locale/sv_SE/translations.php
+++ b/app/Locale/sv_SE/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Auto',
     'Related' => 'Relaterat',
     'Attachment' => 'Bilaga',
-    'Title not found' => 'Titel hittades inte',
     'Web Link' => 'Webblänk',
     'External links' => 'Externa länkar',
     'Add external link' => 'Skapa extern länk',

--- a/app/Locale/th_TH/translations.php
+++ b/app/Locale/th_TH/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'อัตโนมัติ',
     'Related' => 'ที่เกี่ยวข้อง',
     'Attachment' => 'แนบ',
-    'Title not found' => 'ไม่พบหัวเรื่อง',
     'Web Link' => 'เวบลิงค์',
     'External links' => 'เชื่อมโยงภายนอก',
     'Add external link' => 'เพิ่มการเชื่อมโยงภายนอก',

--- a/app/Locale/tr_TR/translations.php
+++ b/app/Locale/tr_TR/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Otomatik',
     'Related' => 'İlişkili',
     'Attachment' => 'Ek',
-    'Title not found' => 'Başlık bulunamadı',
     'Web Link' => 'Web Linki',
     'External links' => 'Harici linkler',
     'Add external link' => 'Harici link ekle',

--- a/app/Locale/uk_UA/translations.php
+++ b/app/Locale/uk_UA/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Авто',
     'Related' => 'Пов\'язаний',
     'Attachment' => 'Вкладення',
-    'Title not found' => 'Заголовок не знайдено',
     'Web Link' => 'Web-посилання',
     'External links' => 'Зовнішні посилання',
     'Add external link' => 'Додати зовнішнє посилання',

--- a/app/Locale/vi_VN/translations.php
+++ b/app/Locale/vi_VN/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => 'Tự động',
     'Related' => 'Liên quan',
     'Attachment' => 'Tập tin đính kèm',
-    'Title not found' => 'Tiêu đề không tìm thấy',
     'Web Link' => 'Liên kết Web',
     'External links' => 'Liện kết ngoại',
     'Add external link' => 'Thêm liên kết bên ngoài',

--- a/app/Locale/zh_CN/translations.php
+++ b/app/Locale/zh_CN/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => '自动',
     'Related' => '相关的',
     'Attachment' => '附件',
-    'Title not found' => '标题未找到',
     'Web Link' => '网页链接',
     'External links' => '外部关联',
     'Add external link' => '添加外部关联',

--- a/app/Locale/zh_TW/translations.php
+++ b/app/Locale/zh_TW/translations.php
@@ -923,7 +923,6 @@ return [
     'Auto' => '自動',
     'Related' => '相關的',
     'Attachment' => '附件',
-    'Title not found' => '標題未找到',
     'Web Link' => '網頁連結',
     'External links' => '外部連結',
     'Add external link' => '增加外部連結',

--- a/app/constants.php
+++ b/app/constants.php
@@ -182,3 +182,6 @@ defined('DASHBOARD_MAX_PROJECTS') or define('DASHBOARD_MAX_PROJECTS', getenv('DA
 
 // Comma separated list of trusted proxy headers, for example: "HTTP_X_REAL_IP,HTTP_X_FORWARDED_FOR"
 defined('TRUSTED_PROXY_HEADERS') or define('TRUSTED_PROXY_HEADERS', getenv('TRUSTED_PROXY_HEADERS') ?: '');
+
+// Allow private network access when fetching metadata for external links
+defined('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS') or define('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS', getenv('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS') ? strtolower(getenv('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS')) === 'true' : false);

--- a/config.default.php
+++ b/config.default.php
@@ -289,3 +289,6 @@ define('DASHBOARD_MAX_PROJECTS', 10);
 
 // Comma separated list of trusted proxy headers, for example: "HTTP_X_REAL_IP,HTTP_X_FORWARDED_FOR"
 define('TRUSTED_PROXY_HEADERS', '');
+
+// Allow private network access when fetching metadata for external links
+define('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS', false);

--- a/docker/etc/php84/php-fpm.d/env.conf
+++ b/docker/etc/php84/php-fpm.d/env.conf
@@ -166,3 +166,6 @@ env[DASHBOARD_MAX_PROJECTS] = $DASHBOARD_MAX_PROJECTS
 
 ; Comma separated list of trusted proxy headers, for example: "HTTP_X_REAL_IP,HTTP_X_FORWARDED_FOR"
 env[TRUSTED_PROXY_HEADERS] = 'HTTP_X_REAL_IP,HTTP_X_FORWARDED_FOR'
+
+; Allow private network access when fetching metadata for external links
+env[EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS] = $EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS

--- a/tests/units/Core/Http/ClientTest.php
+++ b/tests/units/Core/Http/ClientTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace KanboardTests\units\Core\Http;
+
+use KanboardTests\units\Base;
+use Kanboard\Core\Http\Client;
+
+class ClientTest extends Base
+{
+    public function testIsPrivateIpAddressWithPrivateIPv4()
+    {
+        $client = new Client($this->container);
+
+        $this->assertTrue($client->isPrivateIpAddress('10.0.0.1'));
+        $this->assertTrue($client->isPrivateIpAddress('172.16.5.10'));
+        $this->assertTrue($client->isPrivateIpAddress('192.168.1.20'));
+        $this->assertTrue($client->isPrivateIpAddress('127.0.0.1'));
+    }
+
+    public function testIsPrivateIpAddressWithPrivateIPv6()
+    {
+        $client = new Client($this->container);
+
+        $this->assertTrue($client->isPrivateIpAddress('::1'));
+        $this->assertTrue($client->isPrivateIpAddress('fd12:3456:789a:1::1'));
+    }
+
+    public function testIsPrivateIpAddressWithPublicAndInvalidValues()
+    {
+        $client = new Client($this->container);
+
+        $this->assertFalse($client->isPrivateIpAddress('8.8.8.8'));
+        $this->assertFalse($client->isPrivateIpAddress('2607:f8b0:4005:805::200e'));
+        $this->assertFalse($client->isPrivateIpAddress('not-an-ip'));
+        $this->assertFalse($client->isPrivateIpAddress(''));
+    }
+
+    public function testIsPrivateUrlWithPrivateHostnames()
+    {
+        $client = new Client($this->container);
+
+        $this->assertTrue($client->isPrivateURL('http://localhost'));
+        $this->assertTrue($client->isPrivateURL('http://127.0.0.1/path'));
+        $this->assertTrue($client->isPrivateURL('http://10.0.0.15/api'));
+    }
+
+    public function testIsPrivateUrlWithPublicAddresses()
+    {
+        $client = new Client($this->container);
+
+        $this->assertFalse($client->isPrivateURL('http://8.8.8.8/data'));
+        $this->assertFalse($client->isPrivateURL('https://ipv6.google.com/test'));
+    }
+
+    public function testIsPrivateUrlWithUnsupportedScheme()
+    {
+        $client = new Client($this->container);
+
+        $this->assertFalse($client->isPrivateURL('ftp://127.0.0.1'));
+        $this->assertFalse($client->isPrivateURL('mailto:test@example.com'));
+    }
+}

--- a/tests/units/ExternalLink/WebLinkTest.php
+++ b/tests/units/ExternalLink/WebLinkTest.php
@@ -43,4 +43,19 @@ class WebLinkTest extends Base
 
         $this->assertEquals('kanboard.org/something', $webLink->getTitle());
     }
+
+    public function testGetTitleFromPrivateNetworkUrl()
+    {
+        $url = 'http://192.168.0.1/test';
+
+        $webLink = new WebLink($this->container);
+        $webLink->setUrl($url);
+        $this->assertEquals($url, $webLink->getUrl());
+
+        $this->container['httpClient']
+            ->expects($this->never())
+            ->method('get');
+
+        $this->assertEquals($url, $webLink->getTitle());
+    }
 }


### PR DESCRIPTION
This pull request adds mitigations for potential SSRF issues in the external web link feature.

Since Kanboard is self-hosted and may be deployed within private networks, these restrictions are configurable and can be disabled if private network access is required.
