### PR TITLE
feat: add `TRUSTED_PROXY_NETWORKS` config option

### DIFF
--- a/app/Auth/ReverseProxyAuth.php
+++ b/app/Auth/ReverseProxyAuth.php
@@ -3,6 +3,7 @@
 namespace Kanboard\Auth;
 
 use Kanboard\Core\Base;
+use Kanboard\Core\Security\OptionalAuthenticationProviderInterface;
 use Kanboard\Core\Security\PreAuthenticationProviderInterface;
 use Kanboard\Core\Security\SessionCheckProviderInterface;
 use Kanboard\User\ReverseProxyUserProvider;
@@ -13,7 +14,7 @@ use Kanboard\User\ReverseProxyUserProvider;
  * @package  Kanboard\Auth
  * @author   Frederic Guillot
  */
-class ReverseProxyAuth extends Base implements PreAuthenticationProviderInterface, SessionCheckProviderInterface
+class ReverseProxyAuth extends Base implements PreAuthenticationProviderInterface, SessionCheckProviderInterface, OptionalAuthenticationProviderInterface
 {
     /**
      * User properties
@@ -75,5 +76,16 @@ class ReverseProxyAuth extends Base implements PreAuthenticationProviderInterfac
     public function getUser()
     {
         return $this->userInfo;
+    }
+
+    /**
+     * Check if the authentication provider should be used
+     *
+     * @access public
+     * @return boolean
+     */
+    public function isEnabled()
+    {
+        return ! empty($this->request->getRemoteUser());
     }
 }

--- a/app/Core/Security/AuthenticationManager.php
+++ b/app/Core/Security/AuthenticationManager.php
@@ -75,6 +75,10 @@ class AuthenticationManager extends Base
     {
         if ($this->userSession->isLogged()) {
             foreach ($this->filterProviders('SessionCheckProviderInterface') as $provider) {
+                if ($provider instanceof OptionalAuthenticationProviderInterface && ! $provider->isEnabled()) {
+                    continue;
+                }
+
                 if (! $provider->isValidSession()) {
                     $this->logger->debug('Invalidate session for '.$this->userSession->getUsername());
                     session_flush();
@@ -96,6 +100,10 @@ class AuthenticationManager extends Base
     public function preAuthentication()
     {
         foreach ($this->filterProviders('PreAuthenticationProviderInterface') as $provider) {
+            if ($provider instanceof OptionalAuthenticationProviderInterface && ! $provider->isEnabled()) {
+                continue;
+            }
+
             if ($provider->authenticate() && $this->userProfile->initialize($provider->getUser())) {
                 $this->dispatcher->dispatch(new AuthSuccessEvent($provider->getName()), self::EVENT_SUCCESS);
                 return true;

--- a/app/Core/Security/OptionalAuthenticationProviderInterface.php
+++ b/app/Core/Security/OptionalAuthenticationProviderInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Kanboard\Core\Security;
+
+/**
+ * Optional Authentication Provider Interface
+ *
+ * @package  security
+ * @author   Frederic Guillot
+ */
+interface OptionalAuthenticationProviderInterface
+{
+    /**
+     * Check if the authentication provider should be used
+     *
+     * @access public
+     * @return boolean
+     */
+    public function isEnabled();
+}

--- a/app/ServiceProvider/AuthenticationProvider.php
+++ b/app/ServiceProvider/AuthenticationProvider.php
@@ -41,7 +41,7 @@ class AuthenticationProvider implements ServiceProviderInterface
 
         $container['authenticationManager']->register(new DatabaseAuth($container));
 
-        if (REVERSE_PROXY_AUTH) {
+        if (REVERSE_PROXY_AUTH && ! empty(TRUSTED_PROXY_NETWORKS)) {
             $container['authenticationManager']->register(new ReverseProxyAuth($container));
         }
 

--- a/app/check_setup.php
+++ b/app/check_setup.php
@@ -42,3 +42,8 @@ foreach (array('gd', 'mbstring', 'hash', 'openssl', 'json', 'hash', 'ctype', 'fi
 if (ini_get('arg_separator.output') === '&amp;') {
     ini_set('arg_separator.output', '&');
 }
+
+// Check Reverse Proxy Authentication settings
+if (REVERSE_PROXY_AUTH && empty(TRUSTED_PROXY_NETWORKS)) {
+    throw new Exception('REVERSE_PROXY_AUTH is enabled but TRUSTED_PROXY_NETWORKS is not configured');
+}

--- a/app/constants.php
+++ b/app/constants.php
@@ -183,5 +183,8 @@ defined('DASHBOARD_MAX_PROJECTS') or define('DASHBOARD_MAX_PROJECTS', getenv('DA
 // Comma separated list of trusted proxy headers, for example: "HTTP_X_REAL_IP,HTTP_X_FORWARDED_FOR"
 defined('TRUSTED_PROXY_HEADERS') or define('TRUSTED_PROXY_HEADERS', getenv('TRUSTED_PROXY_HEADERS') ?: '');
 
+// Comma separated list of trusted proxy IP networks (CIDR), for example: "192.168.0.0/16,10.0.0.0/8"
+defined('TRUSTED_PROXY_NETWORKS') or define('TRUSTED_PROXY_NETWORKS', getenv('TRUSTED_PROXY_NETWORKS') ?: '');
+
 // Allow private network access when fetching metadata for external links
 defined('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS') or define('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS', getenv('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS') ? strtolower(getenv('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS')) === 'true' : false);

--- a/config.default.php
+++ b/config.default.php
@@ -290,5 +290,8 @@ define('DASHBOARD_MAX_PROJECTS', 10);
 // Comma separated list of trusted proxy headers, for example: "HTTP_X_REAL_IP,HTTP_X_FORWARDED_FOR"
 define('TRUSTED_PROXY_HEADERS', '');
 
+// Comma separated list of trusted proxy IP networks (CIDR), for example: "192.168.0.0/16,10.0.0.0/8,::1/128"
+define('TRUSTED_PROXY_NETWORKS', '');
+
 // Allow private network access when fetching metadata for external links
 define('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS', false);

--- a/docker/etc/php84/php-fpm.d/env.conf
+++ b/docker/etc/php84/php-fpm.d/env.conf
@@ -167,5 +167,8 @@ env[DASHBOARD_MAX_PROJECTS] = $DASHBOARD_MAX_PROJECTS
 ; Comma separated list of trusted proxy headers, for example: "HTTP_X_REAL_IP,HTTP_X_FORWARDED_FOR"
 env[TRUSTED_PROXY_HEADERS] = 'HTTP_X_REAL_IP,HTTP_X_FORWARDED_FOR'
 
+; Comma separated list of trusted proxy IP networks (CIDR), for example: "192.168.0.0/16,10.0.0.0/8"
+env[TRUSTED_PROXY_NETWORKS] = $TRUSTED_PROXY_NETWORKS
+
 ; Allow private network access when fetching metadata for external links
 env[EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS] = $EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS

--- a/tests/units/Core/Security/AuthenticationManagerTest.php
+++ b/tests/units/Core/Security/AuthenticationManagerTest.php
@@ -77,7 +77,15 @@ class AuthenticationManagerTest extends Base
 
     public function testPreAuthenticationSuccessful()
     {
-        $this->container['request'] = new Request($this->container, array(REVERSE_PROXY_USER_HEADER => 'admin'));
+        $request = $this
+            ->getMockBuilder(Request::class)
+            ->setConstructorArgs(array($this->container, array(REVERSE_PROXY_USER_HEADER => 'admin')))
+            ->onlyMethods(array('isTrustedProxy'))
+            ->getMock();
+
+        $request->method('isTrustedProxy')->willReturn(true);
+
+        $this->container['request'] = $request;
         $this->container['dispatcher']->addListener(AuthenticationManager::EVENT_SUCCESS, array($this, 'onSuccess'));
         $this->container['dispatcher']->addListener(AuthenticationManager::EVENT_FAILURE, array($this, 'onFailure'));
 
@@ -93,7 +101,15 @@ class AuthenticationManagerTest extends Base
 
     public function testPreAuthenticationFailed()
     {
-        $this->container['request'] = new Request($this->container, array(REVERSE_PROXY_USER_HEADER => ''));
+        $request = $this
+            ->getMockBuilder(Request::class)
+            ->setConstructorArgs(array($this->container, array(REVERSE_PROXY_USER_HEADER => '')))
+            ->onlyMethods(array('isTrustedProxy'))
+            ->getMock();
+
+        $request->method('isTrustedProxy')->willReturn(true);
+
+        $this->container['request'] = $request;
         $this->container['dispatcher']->addListener(AuthenticationManager::EVENT_SUCCESS, array($this, 'onSuccess'));
         $this->container['dispatcher']->addListener(AuthenticationManager::EVENT_FAILURE, array($this, 'onFailure'));
 


### PR DESCRIPTION
Add an IP-based allow list to prevent spoofing of HTTP headers that should only be set by trusted reverse proxies.

Note that `TRUSTED_PROXY_NETWORKS` must be configured when `REVERSE_PROXY_AUTH` is enabled.
