### PR TITLE
fix: enable Parsedown safe mode for Markdown rendering

### DIFF
--- a/app/Helper/TextHelper.php
+++ b/app/Helper/TextHelper.php
@@ -47,6 +47,7 @@ class TextHelper extends Base
     public function markdown($text, $isPublicLink = false)
     {
         $parser = new Markdown($this->container, $isPublicLink);
+        $parser->setSafeMode(true);
         $parser->setMarkupEscaped(MARKDOWN_ESCAPE_HTML);
         $parser->setBreaksEnabled(true);
         return $parser->text($text ?: '');

--- a/tests/units/Helper/TextHelperTest.php
+++ b/tests/units/Helper/TextHelperTest.php
@@ -127,6 +127,16 @@ class TextHelperTest extends Base
         );
     }
 
+    public function testMarkdownRejectsJavascriptScheme()
+    {
+        $textHelper = new TextHelper($this->container);
+
+        $this->assertEquals(
+            '<p><a href="javascript%3Aalert(1)">XSS</a></p>',
+            $textHelper->markdown('[XSS](javascript:alert(1))')
+        );
+    }
+
     public function testFormatBytes()
     {
         $textHelper = new TextHelper($this->container);


### PR DESCRIPTION
Add an extra layer of protection to make sure `javascript:` links are not rendered in the Markdown output. The default Content-Security-Policy already blocks inline script execution and it's not directly configurable.
