### PR TITLE
fix: prevent unsafe deserialization in database session handler (CWE-502)

### DIFF
--- a/app/Core/Session/SessionManager.php
+++ b/app/Core/Session/SessionManager.php
@@ -95,6 +95,10 @@ class SessionManager extends Base
             true
         );
 
+        // Use php_serialize handler so session data is a single serialize() call,
+        // which allows safe sanitization in SessionHandler::read() (CWE-502 mitigation).
+        ini_set('session.serialize_handler', 'php_serialize');
+
         // Avoid session id in the URL
         ini_set('session.use_only_cookies', '1');
         ini_set('session.use_trans_sid', '0');


### PR DESCRIPTION
Sanitize session data in `SessionHandler::read()` by deserializing with `allowed_classes: false` before returning data to PHP's `session_start()`. This converts any injected object payloads into `__PHP_Incomplete_Class`, neutralizing gadget chains (e.g. SwiftMailer arbitrary file deletion).

Also switch `session.serialize_handler` to `php_serialize` for consistent round-trip sanitization.

This addresses an incomplete fix for CVE-2025-55010, which left the database-backed session handler as an alternative deserialization sink.
