### PR TITLE
feat: add SSRF protection for webhook notifications

### DIFF
--- a/app/Core/Http/Client.php
+++ b/app/Core/Http/Client.php
@@ -59,16 +59,18 @@ class Client extends Base
      * @param  array      $data
      * @param  string[]   $headers
      * @param  bool       $raiseForErrors
+     * @param  bool       $followRedirects
      * @return string
      */
-    public function postJson($url, array $data, array $headers = [], $raiseForErrors = false)
+    public function postJson($url, array $data, array $headers = [], $raiseForErrors = false, $followRedirects = true)
     {
         return $this->doRequest(
             'POST',
             $url,
             json_encode($data),
             array_merge(['Content-type: application/json'], $headers),
-            $raiseForErrors
+            $raiseForErrors,
+            $followRedirects
         );
     }
 
@@ -147,7 +149,6 @@ class Client extends Base
      */
     public function doRequest($method, $url, $content, array $headers, $raiseForErrors = false, $followRedirects = true)
     {
-        $followRedirects = strtoupper($method) === 'GET' ? $followRedirects : true;
         $requestBody = '';
 
         if (! empty($url)) {

--- a/app/Notification/WebhookNotification.php
+++ b/app/Notification/WebhookNotification.php
@@ -39,6 +39,11 @@ class WebhookNotification extends Base implements NotificationInterface
         $token = $this->configModel->get('webhook_token');
 
         if (! empty($url)) {
+            if (! WEBHOOK_ALLOW_PRIVATE_NETWORKS && $this->httpClient->isPrivateURL($url)) {
+                $this->logger->info('Blocked webhook request to private network URL: '.$url);
+                return;
+            }
+
             if (strpos($url, '?') !== false) {
                 $url .= '&token='.$token;
             } else {
@@ -51,7 +56,7 @@ class WebhookNotification extends Base implements NotificationInterface
                 'event_author' => ($this->userSession->isLogged() ? $this->userSession->getUsername() : null),
             );
 
-            $this->httpClient->postJson($url, $payload);
+            $this->httpClient->postJson($url, $payload, [], false, false);
         }
     }
 }

--- a/app/constants.php
+++ b/app/constants.php
@@ -188,3 +188,6 @@ defined('TRUSTED_PROXY_NETWORKS') or define('TRUSTED_PROXY_NETWORKS', getenv('TR
 
 // Allow private network access when fetching metadata for external links
 defined('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS') or define('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS', getenv('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS') ? strtolower(getenv('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS')) === 'true' : false);
+
+// Allow private network access for webhook notifications
+defined('WEBHOOK_ALLOW_PRIVATE_NETWORKS') or define('WEBHOOK_ALLOW_PRIVATE_NETWORKS', getenv('WEBHOOK_ALLOW_PRIVATE_NETWORKS') ? strtolower(getenv('WEBHOOK_ALLOW_PRIVATE_NETWORKS')) === 'true' : false);

--- a/config.default.php
+++ b/config.default.php
@@ -295,3 +295,6 @@ define('TRUSTED_PROXY_NETWORKS', '');
 
 // Allow private network access when fetching metadata for external links
 define('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS', false);
+
+// Allow private network access for webhook notifications
+define('WEBHOOK_ALLOW_PRIVATE_NETWORKS', false);

--- a/docker/etc/php84/php-fpm.d/env.conf
+++ b/docker/etc/php84/php-fpm.d/env.conf
@@ -172,3 +172,6 @@ env[TRUSTED_PROXY_NETWORKS] = $TRUSTED_PROXY_NETWORKS
 
 ; Allow private network access when fetching metadata for external links
 env[EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS] = $EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS
+
+; Allow private network access for webhook notifications
+env[WEBHOOK_ALLOW_PRIVATE_NETWORKS] = $WEBHOOK_ALLOW_PRIVATE_NETWORKS

--- a/tests/units/Notification/WebhookNotificationTest.php
+++ b/tests/units/Notification/WebhookNotificationTest.php
@@ -17,7 +17,7 @@ class WebhookNotificationTest extends Base
         $this->container['httpClient'] = $this
             ->getMockBuilder('\Kanboard\Core\Http\Client')
             ->setConstructorArgs(array($this->container))
-            ->onlyMethods(array('get', 'getJson', 'postJson', 'postJsonAsync', 'postForm', 'postFormAsync'))
+            ->onlyMethods(array('get', 'getJson', 'postJson', 'postJsonAsync', 'postForm', 'postFormAsync', 'isPrivateURL'))
             ->getMock();
     }
 
@@ -32,10 +32,70 @@ class WebhookNotificationTest extends Base
 
         $this->container['httpClient']
             ->expects($this->once())
+            ->method('isPrivateURL')
+            ->willReturn(false);
+
+        $this->container['httpClient']
+            ->expects($this->once())
             ->method('postJson')
             ->with($this->stringContains('http://localhost/?task-creation&token='), $this->anything());
 
-        $this->assertEquals(1, $projectModel->create(array('name' => 'test')));
-        $this->assertEquals(1, $taskCreationModel->create(array('project_id' => 1, 'title' => 'test')));
+        $projectId = $projectModel->create(array('name' => 'test'));
+        $this->assertNotFalse($projectId);
+        $this->assertNotFalse($taskCreationModel->create(array('project_id' => $projectId, 'title' => 'test')));
+    }
+
+    public function testWebhookBlockedForPrivateNetwork()
+    {
+        $configModel = new ConfigModel($this->container);
+        $projectModel = new ProjectModel($this->container);
+        $taskCreationModel = new TaskCreationModel($this->container);
+        $this->container['dispatcher']->addSubscriber(new NotificationSubscriber($this->container));
+
+        $configModel->save(array('webhook_url' => 'http://192.168.1.1/webhook'));
+
+        $this->container['httpClient']
+            ->expects($this->once())
+            ->method('isPrivateURL')
+            ->with('http://192.168.1.1/webhook')
+            ->willReturn(true);
+
+        $this->container['httpClient']
+            ->expects($this->never())
+            ->method('postJson');
+
+        $projectId = $projectModel->create(array('name' => 'test'));
+        $this->assertNotFalse($projectId);
+        $this->assertNotFalse($taskCreationModel->create(array('project_id' => $projectId, 'title' => 'test')));
+    }
+
+    public function testWebhookDisablesRedirects()
+    {
+        $configModel = new ConfigModel($this->container);
+        $projectModel = new ProjectModel($this->container);
+        $taskCreationModel = new TaskCreationModel($this->container);
+        $this->container['dispatcher']->addSubscriber(new NotificationSubscriber($this->container));
+
+        $configModel->save(array('webhook_url' => 'https://example.com/webhook'));
+
+        $this->container['httpClient']
+            ->expects($this->once())
+            ->method('isPrivateURL')
+            ->willReturn(false);
+
+        $this->container['httpClient']
+            ->expects($this->once())
+            ->method('postJson')
+            ->with(
+                $this->stringContains('https://example.com/webhook'),
+                $this->anything(),
+                $this->identicalTo([]),
+                $this->identicalTo(false),
+                $this->identicalTo(false)
+            );
+
+        $projectId = $projectModel->create(array('name' => 'test'));
+        $this->assertNotFalse($projectId);
+        $this->assertNotFalse($taskCreationModel->create(array('project_id' => $projectId, 'title' => 'test')));
     }
 }

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'kanboard/kanboard',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => 'd865b9297a3216523c4fe442d4314d14962bb239',
+        'reference' => '9bfb6d14d374d78ecbedf814db3fb54876a4cedb',
         'type' => 'project',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -31,7 +31,7 @@
         'kanboard/kanboard' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'd865b9297a3216523c4fe442d4314d14962bb239',
+            'reference' => '9bfb6d14d374d78ecbedf814db3fb54876a4cedb',
             'type' => 'project',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
Add WEBHOOK_ALLOW_PRIVATE_NETWORKS config option to block webhook requests to private network addresses, mirroring the existing EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS protection. Disable redirect following on webhook POST requests to prevent SSRF redirect chains.