### PR TITLE
fix(auth): use timing-safe comparison for token validation

### DIFF
--- a/app/Api/Middleware/AuthenticationMiddleware.php
+++ b/app/Api/Middleware/AuthenticationMiddleware.php
@@ -77,7 +77,7 @@ class AuthenticationMiddleware extends Base implements MiddlewareInterface
      */
     private function isAppAuthenticated($username, $password)
     {
-        return $username === 'jsonrpc' && $password === $this->getApiToken();
+        return $username === 'jsonrpc' && hash_equals($this->getApiToken(), $password);
     }
 
     /**

--- a/app/Controller/BaseController.php
+++ b/app/Controller/BaseController.php
@@ -54,7 +54,7 @@ abstract class BaseController extends Base
      */
     protected function checkWebhookToken()
     {
-        if ($this->configModel->get('webhook_token') !== $this->request->getStringParam('token')) {
+        if (! hash_equals($this->configModel->get('webhook_token'), $this->request->getStringParam('token'))) {
             throw AccessForbiddenException::getInstance()->withoutLayout();
         }
     }


### PR DESCRIPTION
Replace === / !== with hash_equals() for webhook and API token checks to prevent timing side-channel attacks.