### PR TITLE
fix(db): use parameterized queries in task finder and iCal

### DIFF
--- a/app/Controller/ICalendarController.php
+++ b/app/Controller/ICalendarController.php
@@ -101,6 +101,9 @@ class ICalendarController extends BaseController
 
     protected function getConditionForTasksWithStartAndDueDate($start_time, $end_time, $start_column, $end_column)
     {
+        $start_time = (int) $start_time;
+        $end_time = (int) $end_time;
+
         $start_column = $this->db->escapeIdentifier($start_column);
         $end_column = $this->db->escapeIdentifier($end_column);
 

--- a/app/Model/TaskFinderModel.php
+++ b/app/Model/TaskFinderModel.php
@@ -62,7 +62,7 @@ class TaskFinderModel extends Base
         return $this->getExtendedQuery()
                     ->beginOr()
                     ->eq(TaskModel::TABLE.'.owner_id', $user_id)
-                    ->addCondition(TaskModel::TABLE.".id IN (SELECT task_id FROM ".SubtaskModel::TABLE." WHERE ".SubtaskModel::TABLE.".user_id='$user_id')")
+                    ->inSubquery(TaskModel::TABLE.'.id', $this->db->table(SubtaskModel::TABLE)->columns('task_id')->eq('user_id', $user_id))
                     ->closeOr()
                     ->eq(TaskModel::TABLE.'.is_active', TaskModel::STATUS_OPEN)
                     ->eq(ProjectModel::TABLE.'.is_active', ProjectModel::ACTIVE)


### PR DESCRIPTION
Replace raw string interpolation with inSubquery() in TaskFinderModel::getUserQuery(), and cast timestamp values to int in ICalendarController::getConditionForTasksWithStartAndDueDate().
