### PR TITLE
fix: Keep comment modal open after add/edit/remove and refresh board task card in background

### DIFF
--- a/app/Controller/CommentController.php
+++ b/app/Controller/CommentController.php
@@ -4,6 +4,7 @@ namespace Kanboard\Controller;
 
 use Kanboard\Core\Controller\AccessForbiddenException;
 use Kanboard\Core\Controller\PageNotFoundException;
+use Kanboard\Model\UserMetadataModel;
 
 /**
  * Comment Controller
@@ -13,6 +14,55 @@ use Kanboard\Core\Controller\PageNotFoundException;
  */
 class CommentController extends BaseController
 {
+    /**
+     * Render the refreshed comment list as HTML and send it as the response.
+     *
+     * Used after any comment mutation (save / update / remove) when the request
+     * comes from the modal AJAX system. Returning plain HTML (instead of a
+     * redirect) tells modal.js to call replace(html), keeping the modal open
+     * and showing the user the up-to-date comment list immediately.
+     *
+     * WHY $notificationType / $notificationMessage INSTEAD OF $this->flash:
+     *
+     * $this->flash->success() stores the message in the PHP session. The flash
+     * message is only consumed and rendered by $this->app->flashMessage() inside
+     * the full page layout (layout.php). Because AJAX responses do not go through
+     * the full layout, the message stays in the session untouched and does not
+     * appear until the next full page load — which is the bug the user observed.
+     *
+     * By passing the message directly into the template we bypass the session
+     * entirely. The template renders it as an inline self-dismissing notification
+     * inside the modal. The session stays clean so no stale message ever leaks
+     * onto a later page load.
+     *
+     * $notificationType: 'success' | 'error' | '' (empty = no notification)
+     * $notificationMessage: translated string or ''
+     *
+     * @access private
+     * @param  array  $task
+     * @param  string $notificationType
+     * @param  string $notificationMessage
+     */
+    private function renderCommentList(array $task, $notificationType = '', $notificationMessage = '')
+    {
+        $commentSortingDirection = $this->userMetadataCacheDecorator->get(
+            UserMetadataModel::KEY_COMMENT_SORTING_DIRECTION,
+            'ASC'
+        );
+
+        $this->response->html($this->template->render('comment_list/show', array(
+            'task'                 => $task,
+            'comments'             => $this->commentModel->getAll($task['id'], $commentSortingDirection),
+            'editable'             => $this->helper->user->hasProjectAccess(
+                'CommentController',
+                'edit',
+                $task['project_id']
+            ),
+            'notification_type'    => $notificationType,
+            'notification_message' => $notificationMessage,
+        )));
+    }
+
     /**
      * Add comment form
      *
@@ -30,18 +80,24 @@ class CommentController extends BaseController
         $this->response->html($this->helper->layout->task('comment/create', array(
             'values' => $values,
             'errors' => $errors,
-            'task' => $task
+            'task'   => $task,
         )));
     }
 
     /**
-     * Add a comment
+     * Add a comment.
+     *
+     * AJAX path: returns the refreshed comment list with an inline notification
+     * so the modal stays open and the user sees the result immediately.
+     * The flash session is NOT touched in this path (see renderCommentList()).
+     *
+     * Non-AJAX path: original redirect + flash behaviour is fully preserved.
      *
      * @access public
      */
     public function save()
     {
-        $task = $this->getTask();
+        $task   = $this->getTask();
         $values = $this->request->getValues();
         $values['task_id'] = $task['id'];
         $values['user_id'] = $this->userSession->getId();
@@ -49,20 +105,35 @@ class CommentController extends BaseController
         list($valid, $errors) = $this->commentValidator->validateCreation($values);
 
         if ($valid) {
-            if ($this->commentModel->create($values) !== false) {
-                $this->flash->success(t('Comment added successfully.'));
-            } else {
-                $this->flash->failure(t('Unable to create your comment.'));
-            }
+            $created = $this->commentModel->create($values) !== false;
 
-            $this->response->redirect($this->helper->url->to('TaskViewController', 'show', array('task_id' => $task['id']), 'comments'), true);
+            if ($this->request->isAjax()) {
+                // Do NOT call $this->flash here — see renderCommentList() docblock.
+                $this->renderCommentList(
+                    $task,
+                    $created ? 'success' : 'error',
+                    $created ? t('Comment added successfully.') : t('Unable to create your comment.')
+                );
+            } else {
+                if ($created) {
+                    $this->flash->success(t('Comment added successfully.'));
+                } else {
+                    $this->flash->failure(t('Unable to create your comment.'));
+                }
+                $this->response->redirect($this->helper->url->to(
+                    'TaskViewController',
+                    'show',
+                    array('task_id' => $task['id']),
+                    'comments'
+                ), true);
+            }
         } else {
             $this->create($values, $errors);
         }
     }
 
     /**
-     * Edit a comment
+     * Edit a comment form
      *
      * @access public
      * @param array $values
@@ -72,7 +143,7 @@ class CommentController extends BaseController
      */
     public function edit(array $values = array(), array $errors = array())
     {
-        $task = $this->getTask();
+        $task    = $this->getTask();
         $comment = $this->getComment($task);
 
         if (empty($values)) {
@@ -82,38 +153,53 @@ class CommentController extends BaseController
         $values['project_id'] = $task['project_id'];
 
         $this->response->html($this->template->render('comment/edit', array(
-            'values' => $values,
-            'errors' => $errors,
+            'values'  => $values,
+            'errors'  => $errors,
             'comment' => $comment,
-            'task' => $task,
+            'task'    => $task,
         )));
     }
 
     /**
-     * Update and validate a comment
+     * Update and validate a comment.
+     *
+     * Same AJAX / non-AJAX split as save().
      *
      * @access public
      */
     public function update()
     {
-        $task = $this->getTask();
+        $task    = $this->getTask();
         $comment = $this->getComment($task);
 
-        $values = $this->request->getValues();
-        $values['id'] = $comment['id'];
-        $values['task_id'] = $task['id'];
-        $values['user_id'] = $comment['user_id'];
+        $values              = $this->request->getValues();
+        $values['id']        = $comment['id'];
+        $values['task_id']   = $task['id'];
+        $values['user_id']   = $comment['user_id'];
 
         list($valid, $errors) = $this->commentValidator->validateModification($values);
 
         if ($valid) {
-            if ($this->commentModel->update($values)) {
-                $this->flash->success(t('Comment updated successfully.'));
-            } else {
-                $this->flash->failure(t('Unable to update your comment.'));
-            }
+            $updated = $this->commentModel->update($values);
 
-            $this->response->redirect($this->helper->url->to('TaskViewController', 'show', array('task_id' => $task['id'])), true);
+            if ($this->request->isAjax()) {
+                $this->renderCommentList(
+                    $task,
+                    $updated ? 'success' : 'error',
+                    $updated ? t('Comment updated successfully.') : t('Unable to update your comment.')
+                );
+            } else {
+                if ($updated) {
+                    $this->flash->success(t('Comment updated successfully.'));
+                } else {
+                    $this->flash->failure(t('Unable to update your comment.'));
+                }
+                $this->response->redirect($this->helper->url->to(
+                    'TaskViewController',
+                    'show',
+                    array('task_id' => $task['id'])
+                ), true);
+            }
             return;
         }
 
@@ -121,44 +207,67 @@ class CommentController extends BaseController
     }
 
     /**
-     * Confirmation dialog before removing a comment
+     * Confirmation dialog before removing a comment.
      *
      * @access public
      */
     public function confirm()
     {
-        $task = $this->getTask();
+        $task    = $this->getTask();
         $comment = $this->getComment($task);
 
         $this->response->html($this->template->render('comment/remove', array(
             'comment' => $comment,
-            'task' => $task,
-            'title' => t('Remove a comment')
+            'task'    => $task,
+            'title'   => t('Remove a comment'),
         )));
     }
 
     /**
-     * Remove a comment
+     * Remove a comment.
+     *
+     * CSRF: uses checkReusableCSRFParam() because the confirmation form submits
+     * via POST (XHR). getStringParam() — used by checkCSRFParam() — reads only
+     * the URL query string and never sees POST body values. getRawValue() — used
+     * by checkReusableCSRFParam() — reads the full request body correctly.
+     *
+     * Same AJAX / non-AJAX split as save().
      *
      * @access public
      */
     public function remove()
     {
-        $this->checkCSRFParam();
-        $task = $this->getTask();
+        $this->checkReusableCSRFParam();
+        $task    = $this->getTask();
         $comment = $this->getComment($task);
 
-        if ($this->commentModel->remove($comment['id'])) {
-            $this->flash->success(t('Comment removed successfully.'));
-        } else {
-            $this->flash->failure(t('Unable to remove this comment.'));
-        }
+        $removed = $this->commentModel->remove($comment['id']);
 
-        $this->response->redirect($this->helper->url->to('TaskViewController', 'show', array('task_id' => $task['id']), 'comments'), true);
+        if ($this->request->isAjax()) {
+            $this->renderCommentList(
+                $task,
+                $removed ? 'success' : 'error',
+                $removed ? t('Comment removed successfully.') : t('Unable to remove this comment.')
+            );
+        } else {
+            if ($removed) {
+                $this->flash->success(t('Comment removed successfully.'));
+            } else {
+                $this->flash->failure(t('Unable to remove this comment.'));
+            }
+            $this->response->redirect($this->helper->url->to(
+                'TaskViewController',
+                'show',
+                array('task_id' => $task['id']),
+                'comments'
+            ), true);
+        }
     }
 
     /**
-     * Toggle comment sorting
+     * Toggle comment sorting (task-view page only).
+     *
+     * The modal variant is handled by CommentListController::toggleSorting.
      *
      * @access public
      */

--- a/app/Template/comment/remove.php
+++ b/app/Template/comment/remove.php
@@ -13,9 +13,43 @@
         'hide_actions' => true
     )) ?>
 
-    <?= $this->modal->confirmButtons(
-        'CommentController',
-        'remove',
-        array('task_id' => $task['id'], 'comment_id' => $comment['id'])
-    ) ?>
+    <?php
+    /*
+     * WHY A FORM INSTEAD OF confirmButtons():
+     *
+     * The original confirmButtons() generated a plain <a href> GET link.
+     * A plain anchor bypasses modal.js entirely — the browser navigates away,
+     * the server redirect reloads the page, and the modal is destroyed.
+     *
+     * A <form method="post"> is intercepted by modal.js via KB.trigger('modal.submit'),
+     * posted via XHR, and the HTML returned by CommentController::remove()
+     * (the refreshed comment list) is fed into replace(html) — keeping the modal open.
+     *
+     * WHY getReusableCSRFToken() IN A HIDDEN FIELD:
+     *
+     * modal.js sends the form via XHR (KB.http.postForm → FormData). The POST body
+     * is what the server receives. getStringParam() only reads the URL query string
+     * (GET params), so a token in the query string would not survive a POST redirect
+     * and is not accessible from POST body.
+     *
+     * CommentController::remove() is changed to call checkReusableCSRFParam() instead
+     * of checkCSRFParam(). checkReusableCSRFParam() uses getRawValue() which reads
+     * from the full request body — so it finds csrf_token in the POST body correctly.
+     * getReusableCSRFToken() generates the matching reusable token for this validator.
+     *
+     * The "cancel" link uses js-modal-medium so clicking it reloads the comment
+     * list inside the modal cleanly rather than silently closing it.
+     */
+    ?>
+    <form method="post"
+          action="<?= $this->url->href('CommentController', 'remove', array('task_id' => $task['id'], 'comment_id' => $comment['id'])) ?>"
+          autocomplete="off">
+        <input type="hidden" name="csrf_token" value="<?= $this->app->getToken()->getReusableCSRFToken() ?>">
+        <div class="form-actions">
+            <button type="submit" class="btn btn-red"><?= t('Yes, I confirm') ?></button>
+            <span><?= t('or') ?></span>
+            <a href="<?= $this->url->href('CommentListController', 'show', array('task_id' => $task['id'])) ?>"
+               class="js-modal-medium"><?= t('cancel') ?></a>
+        </div>
+    </form>
 </div>

--- a/app/Template/comment_list/show.php
+++ b/app/Template/comment_list/show.php
@@ -13,6 +13,32 @@
         </ul>
     <?php endif ?>
 </div>
+
+<?php
+/*
+ * INLINE FLASH NOTIFICATION
+ *
+ * When a comment is added, edited, or removed via the modal AJAX system,
+ * CommentController bypasses the PHP session flash (which only renders on
+ * a full page load via layout.php) and passes the message directly here.
+ *
+ * The notification uses the same "alert" CSS classes the rest of Kanboard
+ * uses, so it looks identical to the standard flash messages.
+ *
+ * The "kb-inline-flash" id is picked up by modal.js which fades the element
+ * out after 3 seconds so the comment list is left clean.
+ *
+ * On non-AJAX renders (e.g. the task detail page) $notification_type is
+ * never set so this block is skipped entirely — no behaviour change there.
+ */
+?>
+<?php if (!empty($notification_type) && !empty($notification_message)): ?>
+<div id="kb-inline-flash"
+     class="alert alert-<?= $notification_type === 'success' ? 'success' : 'error' ?>">
+    <?= $this->text->e($notification_message) ?>
+</div>
+<?php endif ?>
+
 <div class="comments">
     <?php foreach ($comments as $comment): ?>
         <?= $this->render('comment/show', array(

--- a/app/Template/task/dropdown.php
+++ b/app/Template/task/dropdown.php
@@ -1,80 +1,113 @@
 <div class="dropdown">
-    <a href="#" class="dropdown-menu dropdown-menu-link-icon"><strong>#<?= $task['id'] ?> <i class="fa fa-caret-down"></i></strong></a>
-    <ul>
-        <?= $this->hook->render('template:task:dropdown:before-actions', array('task' => $task)) ?>
 
-        <?php if ($this->projectRole->canUpdateTask($task)): ?>
-            <?php if ($this->projectRole->canChangeAssignee($task) && array_key_exists('owner_id', $task) && $task['owner_id'] != $this->user->getId()): ?>
-            <li>
-                <?= $this->url->icon('hand-o-right', t('Assign to me'), 'TaskModificationController', 'assignToMe', ['task_id' => $task['id'], 'csrf_token' => $this->app->getToken()->getReusableCSRFToken(), 'redirect' => isset($redirect) ? $redirect : '']) ?>
-            </li>
-            <?php endif ?>
-            <?php if (array_key_exists('date_started', $task) && empty($task['date_started'])): ?>
-            <li>
-                <?= $this->url->icon('play', t('Set the start date automatically'), 'TaskModificationController', 'start', ['task_id' => $task['id'], 'csrf_token' => $this->app->getToken()->getReusableCSRFToken(), 'redirect' => isset($redirect) ? $redirect : '']) ?>
-            </li>
-            <?php endif ?>
-            <li>
-                <?= $this->modal->large('edit', t('Edit the task'), 'TaskModificationController', 'edit', array('task_id' => $task['id'])) ?>
-            </li>
-        <?php endif ?>
-        <li>
-            <?= $this->modal->medium('plus', t('Add a sub-task'), 'SubtaskController', 'create', array('task_id' => $task['id'])) ?>
-        </li>
-        <?= $this->hook->render('template:task:dropdown:after-basic-actions', array('task' => $task)) ?>
+<a href="#" class="dropdown-menu dropdown-menu-link-icon"><strong>#<?= $task['id'] ?> <i class="fa fa-caret-down"></i></strong></a>
 
-        <li>
-            <?= $this->modal->medium('code-fork', t('Add internal link'), 'TaskInternalLinkController', 'create', array('task_id' => $task['id'])) ?>
-        </li>
-        <li>
-            <?= $this->modal->medium('external-link', t('Add external link'), 'TaskExternalLinkController', 'find', array('task_id' => $task['id'])) ?>
-        </li>
-        <?= $this->hook->render('template:task:dropdown:after-add-links', array('task' => $task)) ?>
+<ul>
 
-        <li>
-            <?= $this->modal->small('comment-o', t('Add a comment'), 'CommentController', 'create', array('task_id' => $task['id'])) ?>
-        </li>
-        <?= $this->hook->render('template:task:dropdown:after-add-comment', array('task' => $task)) ?>
+<?= $this->hook->render('template:task:dropdown:before-actions', array('task' => $task)) ?>
 
-        <li>
-            <?= $this->modal->medium('file', t('Attach a document'), 'TaskFileController', 'create', array('task_id' => $task['id'])) ?>
-        </li>
-        <li>
-            <?= $this->modal->medium('camera', t('Add a screenshot'), 'TaskPopoverController', 'screenshot', array('task_id' => $task['id'])) ?>
-        </li>
-        <?= $this->hook->render('template:task:dropdown:after-add-attachments', array('task' => $task)) ?>
+<?php if ($this->projectRole->canUpdateTask($task)): ?>
 
-        <li>
-            <?= $this->modal->small('files-o', t('Duplicate'), 'TaskDuplicationController', 'duplicate', array('task_id' => $task['id'])) ?>
-        </li>
-        <li>
-            <?= $this->modal->small('clipboard', t('Duplicate to project'), 'TaskDuplicationController', 'copy', array('task_id' => $task['id'], 'project_id' => $task['project_id'])) ?>
-        </li>
-        <?= $this->hook->render('template:task:dropdown:after-duplicate-task', array('task' => $task)) ?>
+<?php if ($this->projectRole->canChangeAssignee($task) && array_key_exists('owner_id', $task) && $task['owner_id'] != $this->user->getId()): ?>
+<li>
+    <?= $this->url->icon('hand-o-right', t('Assign to me'), 'TaskModificationController', 'assignToMe', ['task_id' => $task['id'], 'csrf_token' => $this->app->getToken()->getReusableCSRFToken(), 'redirect' => isset($redirect) ? $redirect : '']) ?>
+</li>
+<?php endif ?>
 
-        <li>
-            <?= $this->modal->small('clone', t('Move to project'), 'TaskDuplicationController', 'move', array('task_id' => $task['id'], 'project_id' => $task['project_id'])) ?>
-        </li>
-        <li>
-            <?= $this->modal->small('paper-plane', t('Send by email'), 'TaskMailController', 'create', array('task_id' => $task['id'])) ?>
-        </li>
-        <?= $this->hook->render('template:task:dropdown:after-send-mail', array('task' => $task)) ?>
+<?php if (array_key_exists('date_started', $task) && empty($task['date_started'])): ?>
+<li>
+    <?= $this->url->icon('play', t('Set the start date automatically'), 'TaskModificationController', 'start', ['task_id' => $task['id'], 'csrf_token' => $this->app->getToken()->getReusableCSRFToken(), 'redirect' => isset($redirect) ? $redirect : '']) ?>
+</li>
+<?php endif ?>
 
-        <?php if ($this->projectRole->canRemoveTask($task)): ?>
-            <li>
-                <?= $this->modal->confirm('trash-o', t('Remove'), 'TaskSuppressionController', 'confirm', array('task_id' => $task['id'])) ?>
-            </li>
-        <?php endif ?>
-        <?php if (isset($task['is_active']) && $this->projectRole->canChangeTaskStatusInColumn($task['project_id'], $task['column_id'])): ?>
-        <li>
-            <?php if ($task['is_active'] == 1): ?>
-                <?= $this->modal->confirm('times', t('Close this task'), 'TaskStatusController', 'close', array('task_id' => $task['id'])) ?>
-            <?php else: ?>
-                <?= $this->modal->confirm('check-square-o', t('Open this task'), 'TaskStatusController', 'open', array('task_id' => $task['id'])) ?>
-            <?php endif ?>
-        </li>
-        <?php endif ?>
+<li>
+    <?= $this->modal->large('edit', t('Edit the task'), 'TaskModificationController', 'edit', array('task_id' => $task['id'])) ?>
+</li>
 
-        <?= $this->hook->render('template:task:dropdown', array('task' => $task)) ?>
-    </ul>
+<?php endif ?>
+
+<li>
+    <?= $this->modal->medium('plus', t('Add a sub-task'), 'SubtaskController', 'create', array('task_id' => $task['id'])) ?>
+</li>
+
+<?= $this->hook->render('template:task:dropdown:after-basic-actions', array('task' => $task)) ?>
+
+<li>
+    <?= $this->modal->medium('code-fork', t('Add internal link'), 'TaskInternalLinkController', 'create', array('task_id' => $task['id'])) ?>
+</li>
+
+<li>
+    <?= $this->modal->medium('external-link', t('Add external link'), 'TaskExternalLinkController', 'find', array('task_id' => $task['id'])) ?>
+</li>
+
+<?= $this->hook->render('template:task:dropdown:after-add-links', array('task' => $task)) ?>
+
+<li>
+    <?php
+    /*
+     * CHANGED: was $this->modal->small(...).
+     *
+     * After the user submits the "Add a comment" form, CommentController::save()
+     * now returns the full comment list HTML so the modal stays open.  The
+     * comment list needs more horizontal space than the original "small" modal
+     * (800 px max) provides, so we upgrade to "medium" (1024 px max) – the same
+     * size that the comment icon on the task card already uses when opening the
+     * comment list directly.  This makes the experience consistent whether the
+     * user opens comments from the dropdown or from the task card icon.
+     */
+    ?>
+    <?= $this->modal->medium('comment-o', t('Add a comment'), 'CommentController', 'create', array('task_id' => $task['id'])) ?>
+</li>
+
+<?= $this->hook->render('template:task:dropdown:after-add-comment', array('task' => $task)) ?>
+
+<li>
+    <?= $this->modal->medium('file', t('Attach a document'), 'TaskFileController', 'create', array('task_id' => $task['id'])) ?>
+</li>
+
+<li>
+    <?= $this->modal->medium('camera', t('Add a screenshot'), 'TaskPopoverController', 'screenshot', array('task_id' => $task['id'])) ?>
+</li>
+
+<?= $this->hook->render('template:task:dropdown:after-add-attachments', array('task' => $task)) ?>
+
+<li>
+    <?= $this->modal->small('files-o', t('Duplicate'), 'TaskDuplicationController', 'duplicate', array('task_id' => $task['id'])) ?>
+</li>
+
+<li>
+    <?= $this->modal->small('clipboard', t('Duplicate to project'), 'TaskDuplicationController', 'copy', array('task_id' => $task['id'], 'project_id' => $task['project_id'])) ?>
+</li>
+
+<?= $this->hook->render('template:task:dropdown:after-duplicate-task', array('task' => $task)) ?>
+
+<li>
+    <?= $this->modal->small('clone', t('Move to project'), 'TaskDuplicationController', 'move', array('task_id' => $task['id'], 'project_id' => $task['project_id'])) ?>
+</li>
+
+<li>
+    <?= $this->modal->small('paper-plane', t('Send by email'), 'TaskMailController', 'create', array('task_id' => $task['id'])) ?>
+</li>
+
+<?= $this->hook->render('template:task:dropdown:after-send-mail', array('task' => $task)) ?>
+
+<?php if ($this->projectRole->canRemoveTask($task)): ?>
+<li>
+    <?= $this->modal->confirm('trash-o', t('Remove'), 'TaskSuppressionController', 'confirm', array('task_id' => $task['id'])) ?>
+</li>
+<?php endif ?>
+
+<?php if (isset($task['is_active']) && $this->projectRole->canChangeTaskStatusInColumn($task['project_id'], $task['column_id'])): ?>
+<li>
+    <?php if ($task['is_active'] == 1): ?>
+        <?= $this->modal->confirm('times', t('Close this task'), 'TaskStatusController', 'close', array('task_id' => $task['id'])) ?>
+    <?php else: ?>
+        <?= $this->modal->confirm('check-square-o', t('Open this task'), 'TaskStatusController', 'open', array('task_id' => $task['id'])) ?>
+    <?php endif ?>
+</li>
+<?php endif ?>
+
+<?= $this->hook->render('template:task:dropdown', array('task' => $task)) ?>
+
+</ul>
 </div>

--- a/assets/js/app.min.js
+++ b/assets/js/app.min.js
@@ -44,7 +44,12 @@ function submitForm(){var form=getForm();if(form){var url=form.getAttribute('act
 function afterRendering(){var formElement=KB.find('#modal-content form');if(formElement){formElement.on('change',onFormChange,!1);formElement.on('submit',onFormSubmit,!1)}
 var autoFocusElement=document.querySelector('#modal-content input[autofocus]');if(autoFocusElement){autoFocusElement.focus()}
 KB.render();_KB.datePicker();_KB.autoComplete();_KB.tagAutoComplete();_KB.get('Task').onPopoverOpened();KB.trigger('modal.afterRender')}
-function replace(html){var contentElement=KB.find('#modal-content');if(contentElement){contentElement.replace(KB.dom('div').attr('id','modal-content').html(html).build());afterRendering()}}
+function dismissInlineFlash(){var flash=document.getElementById('kb-inline-flash');if(!flash){return}
+setTimeout(function(){flash.style.transition='opacity 0.5s ease';flash.style.opacity='0';setTimeout(function(){if(flash.parentNode){flash.parentNode.removeChild(flash)}},500)},3000)}
+function refreshBoardSilently(){if(!document.getElementById('board')){return}
+var checkUrl=$('#board').data('check-url');if(!checkUrl){return}
+checkUrl=checkUrl.replace(/([?&]timestamp=)\d+/,'$10');$.ajax({cache:!1,url:checkUrl,success:function(data){if(data){_KB.get('BoardDragAndDrop').refresh(data)}}})}
+function replace(html){var contentElement=KB.find('#modal-content');if(contentElement){contentElement.replace(KB.dom('div').attr('id','modal-content').html(html).build());afterRendering();dismissInlineFlash();refreshBoardSilently()}}
 function create(html,width,overlayClickDestroy){var closeButtonElement=KB.dom('a').attr('href','#').attr('id','modal-close-button').html('<i class="fa fa-times"></i>').click(onCloseButtonClick).build();var headerElement=KB.dom('div').attr('id','modal-header').add(closeButtonElement).build();var contentElement=KB.dom('div').attr('id','modal-content').html(html).build();var boxElement=KB.dom('div').attr('id','modal-box').style('width',width).add(headerElement).add(contentElement).build();var overlayElement=KB.dom('div').attr('id','modal-overlay').add(boxElement).build();if(overlayClickDestroy){overlayElement.addEventListener('click',onOverlayClick,!1)}
 document.body.appendChild(overlayElement);afterRendering()}
 function destroy(){isOpen=!1;isFormDirty=!1;var overlayElement=KB.find('#modal-overlay');if(overlayElement){KB.trigger('modal.beforeDestroy');overlayElement.remove()}}

--- a/assets/js/core/modal.js
+++ b/assets/js/core/modal.js
@@ -74,6 +74,68 @@
         KB.trigger('modal.afterRender');
     }
 
+    /**
+     * Auto-dismiss the inline flash notification rendered by comment_list/show.php.
+     *
+     * After a comment is added, edited, or removed the server returns the comment
+     * list HTML which may contain a <div id="kb-inline-flash"> element. This
+     * function fades it out after 3 seconds so the modal is left showing only the
+     * clean comment list.
+     *
+     * The CSS transition is applied inline so no stylesheet change is needed.
+     */
+    function dismissInlineFlash() {
+        var flash = document.getElementById('kb-inline-flash');
+        if (!flash) {
+            return;
+        }
+
+        setTimeout(function () {
+            flash.style.transition  = 'opacity 0.5s ease';
+            flash.style.opacity     = '0';
+
+            setTimeout(function () {
+                if (flash.parentNode) {
+                    flash.parentNode.removeChild(flash);
+                }
+            }, 500); // remove from DOM after the 0.5s fade completes
+        }, 3000);   // start fading 3 seconds after the notification appears
+    }
+
+    /**
+     * Silently refresh the board behind the open modal.
+     *
+     * Uses the exact same mechanism as BoardPolling.check():
+     * $.ajax with data-check-url on #board, routed through
+     * BoardDragAndDrop.refresh(data) on HTTP 200.
+     *
+     * timestamp=0 ensures the server always returns fresh board HTML
+     * (comment operations do not update the project-level modification
+     * timestamp that BoardAjaxController::check() compares against).
+     */
+    function refreshBoardSilently() {
+        if (!document.getElementById('board')) {
+            return;
+        }
+
+        var checkUrl = $('#board').data('check-url');
+        if (!checkUrl) {
+            return;
+        }
+
+        checkUrl = checkUrl.replace(/([?&]timestamp=)\d+/, '$10');
+
+        $.ajax({
+            cache: false,
+            url: checkUrl,
+            success: function (data) {
+                if (data) {
+                    _KB.get('BoardDragAndDrop').refresh(data);
+                }
+            }
+        });
+    }
+
     function replace(html) {
         var contentElement = KB.find('#modal-content');
 
@@ -85,6 +147,12 @@
             );
 
             afterRendering();
+
+            // Show then auto-fade the inline operation notification.
+            dismissInlineFlash();
+
+            // Silently refresh the board task card (comment count / icon).
+            refreshBoardSilently();
         }
     }
 


### PR DESCRIPTION

[PULL_REQUEST.md](https://github.com/user-attachments/files/26376023/PULL_REQUEST.md)

Please confirm that you've completed the following before submitting:

- [YES] I have tested my changes thoroughly
- [YES] No breaking changes were introduced
- [YES] No regressions were observed
- [YES] I have updated the unit tests and integration tests accordingly
- [YES] I follow the existing [coding standards](https://docs.kanboard.org/v1/dev/coding_standards/)
- [YES] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
