### PR TITLE
fix(comments): enforce visibility controls for public and unprivileged access

### DIFF
--- a/app/Controller/TaskViewController.php
+++ b/app/Controller/TaskViewController.php
@@ -4,6 +4,7 @@ namespace Kanboard\Controller;
 
 use Kanboard\Core\Controller\AccessForbiddenException;
 use Kanboard\Core\Controller\PageNotFoundException;
+use Kanboard\Core\Security\Role;
 use Kanboard\Model\UserMetadataModel;
 
 /**
@@ -39,7 +40,9 @@ class TaskViewController extends BaseController
 
         $this->response->html($this->helper->layout->app('task/public', array(
             'project' => $project,
-            'comments' => $this->commentModel->getAll($task['id']),
+            'comments' => array_filter($this->commentModel->getAll($task['id']), function ($comment) {
+                return $comment['visibility'] === Role::APP_USER;
+            }),
             'subtasks' => $this->subtaskModel->getAll($task['id']),
             'links' => $this->taskLinkModel->getAllGroupedByLabel($task['id']),
             'task' => $task,

--- a/app/Model/CommentModel.php
+++ b/app/Model/CommentModel.php
@@ -147,6 +147,7 @@ class CommentModel extends Base
      */
     public function create(array $values)
     {
+        $values = $this->clampVisibility($values);
         $values['date_creation'] = time();
         $values['date_modification'] = time();
         $comment_id = $this->db->table(self::TABLE)->persist($values);
@@ -177,6 +178,33 @@ class CommentModel extends Base
         }
 
         return $result;
+    }
+
+    /**
+     * Clamp the visibility field so it never exceeds the current user's role
+     *
+     * @access protected
+     * @param  array $values
+     * @return array
+     */
+    protected function clampVisibility(array $values)
+    {
+        if (! $this->userSession->isLogged()) {
+            return $values;
+        }
+
+        $visibility = isset($values['visibility']) ? $values['visibility'] : Role::APP_USER;
+        $userRole = $this->userSession->getRole();
+
+        if ($userRole === Role::APP_MANAGER && $visibility === Role::APP_ADMIN) {
+            $values['visibility'] = Role::APP_MANAGER;
+        }
+
+        if ($userRole === Role::APP_USER && $visibility !== Role::APP_USER) {
+            $values['visibility'] = Role::APP_USER;
+        }
+
+        return $values;
     }
 
     /**

--- a/app/Template/comment/show.php
+++ b/app/Template/comment/show.php
@@ -2,11 +2,17 @@
 
 use Kanboard\Core\Security\Role;
 
-if ($this->user->getRole() === Role::APP_MANAGER && $comment['visibility'] === Role::APP_ADMIN) {
+$userRole = $this->user->getRole();
+
+if ($userRole === '' && $comment['visibility'] !== Role::APP_USER) {
     return;
 }
 
-if ($this->user->getRole() === Role::APP_USER && $comment['visibility'] !== Role::APP_USER) {
+if ($userRole === Role::APP_MANAGER && $comment['visibility'] === Role::APP_ADMIN) {
+    return;
+}
+
+if ($userRole === Role::APP_USER && $comment['visibility'] !== Role::APP_USER) {
     return;
 }
 


### PR DESCRIPTION
Filter restricted comments from public task views both at the controller level (TaskViewController::readonly) and the template level (comment/show.php) so unauthenticated users only see app-user comments.

Clamp the visibility field in CommentModel::create() so no user can persist a visibility level above their own role, covering all web controller paths (CommentController, CommentListController, CommentMailController).