### PR TITLE
fix(bulk): validate task ownership before applying property changes

### DIFF
--- a/app/Controller/TaskBulkChangePropertyController.php
+++ b/app/Controller/TaskBulkChangePropertyController.php
@@ -2,6 +2,8 @@
 
 namespace Kanboard\Controller;
 
+use Kanboard\Core\Controller\AccessForbiddenException;
+
 class TaskBulkChangePropertyController extends BaseController
 {
     public function show(array $values = [], array $errors = [])
@@ -29,6 +31,10 @@ class TaskBulkChangePropertyController extends BaseController
         $taskIDs = explode(',', $values['task_ids']);
 
         foreach ($taskIDs as $taskID) {
+            if ($this->taskFinderModel->getProjectId($taskID) != $project['id']) {
+                throw new AccessForbiddenException();
+            }
+
             $changes = [];
 
             if (isset($values['change_color']) && $values['change_color'] == 1) {


### PR DESCRIPTION
Verify each task belongs to the URL project before modifying it in TaskBulkChangePropertyController::save().