### PR TITLE
Escape notification title in web notification template

### DIFF
--- a/app/Template/web_notification/show.php
+++ b/app/Template/web_notification/show.php
@@ -53,9 +53,9 @@
             <?php endif ?>
 
             <?php if ($this->text->contains($notification['event_name'], 'task.overdue') && count($notification['event_data']['tasks']) > 1): ?>
-                <?= $notification['title'] ?>
+                <?= $this->text->e($notification['title']) ?>
             <?php else: ?>
-                <?= $this->url->link($notification['title'], 'WebNotificationController', 'redirect', array('notification_id' => $notification['id'], 'user_id' => $user['id'])) ?>
+                <?= $this->url->link($this->text->e($notification['title']), 'WebNotificationController', 'redirect', array('notification_id' => $notification['id'], 'user_id' => $user['id'])) ?>
             <?php endif ?>
         </span>
         <div class="table-list-details">


### PR DESCRIPTION
## Summary

Escape the notification title using `TextHelper::e()` in the web notification
template to prevent HTML injection via crafted task titles or filenames.

Only the notification template is modified. `UrlHelper::link()` is left
unchanged.