### PR TITLE
Validate dst_project_id in task duplication form

### DIFF
--- a/app/Controller/TaskDuplicationController.php
+++ b/app/Controller/TaskDuplicationController.php
@@ -132,6 +132,10 @@ class TaskDuplicationController extends BaseController
         if (! empty($projects_list)) {
             $dst_project_id = $this->request->getIntegerParam('dst_project_id', key($projects_list));
 
+            if (! isset($projects_list[$dst_project_id])) {
+                $dst_project_id = key($projects_list);
+            }
+
             $swimlanes_list = $this->swimlaneModel->getList($dst_project_id, false, true);
             $columns_list = $this->columnModel->getList($dst_project_id);
             $categories_list = $this->categoryModel->getList($dst_project_id);


### PR DESCRIPTION
## Summary

- Validate the `dst_project_id` request parameter against the authenticated user's project list in `TaskDuplicationController::chooseDestination()`
- Fall back to the first accessible project if the provided ID is not in the user's project list

## Context

The move/copy task form accepts a `dst_project_id` parameter to populate destination project metadata (columns, swimlanes, categories, assignable users). This parameter was not validated against the user's accessible projects, allowing enumeration of metadata for arbitrary projects.