### PR TITLE
Validate user_id in subtask time tracking write methods

### DIFF
--- a/app/Api/Procedure/SubtaskTimeTrackingProcedure.php
+++ b/app/Api/Procedure/SubtaskTimeTrackingProcedure.php
@@ -22,12 +22,22 @@ class SubtaskTimeTrackingProcedure extends BaseProcedure
     public function setSubtaskStartTime($subtask_id, $user_id)
     {
         SubtaskAuthorization::getInstance($this->container)->check($this->getClassName(), 'setSubtaskStartTime', $subtask_id);
+
+        if ($this->userSession->isLogged() && $user_id != $this->userSession->getId()) {
+            return false;
+        }
+
         return $this->subtaskTimeTrackingModel->logStartTime($subtask_id, $user_id);
     }
 
     public function setSubtaskEndTime($subtask_id, $user_id)
     {
         SubtaskAuthorization::getInstance($this->container)->check($this->getClassName(), 'setSubtaskEndTime', $subtask_id);
+
+        if ($this->userSession->isLogged() && $user_id != $this->userSession->getId()) {
+            return false;
+        }
+
         return $this->subtaskTimeTrackingModel->logEndTime($subtask_id, $user_id);
     }
 


### PR DESCRIPTION
## Summary

Add user_id ownership check to the write methods `setSubtaskStartTime()`
and `setSubtaskEndTime()` to prevent project members from starting or
stopping timers attributed to other users.

The read methods `hasSubtaskTimer()` and `getSubtaskTimeSpent()` are left
unchanged as they are legitimate cross-user reads for project members.