### PR TITLE
feat: Log password authentication failures

### DIFF
--- a/app/Validator/AuthValidator.php
+++ b/app/Validator/AuthValidator.php
@@ -62,6 +62,7 @@ class AuthValidator extends BaseValidator
         if ($this->userLockingModel->isLocked($values['username'])) {
             $result = false;
             $errors['login'] = t('Your account is locked for %d minutes', BRUTEFORCE_LOCKDOWN_DURATION);
+            $this->logger->error('Kanboard: Failed login from: ' . $_SERVER['REMOTE_ADDR'] . ' username: ' . $values['username']);
             $this->logger->error('Account locked: '.$values['username']);
         }
 
@@ -83,6 +84,7 @@ class AuthValidator extends BaseValidator
         if (! $this->authenticationManager->passwordAuthentication($values['username'], $values['password'])) {
             $result = false;
             $errors['login'] = t('Bad username or password');
+            $this->logger->error('Kanboard: Failed login from: ' . $_SERVER['REMOTE_ADDR'] . ' username: ' . $values['username']);
         }
 
         return array($result, $errors);


### PR DESCRIPTION
Log password authentication failures with the selected `LOG_DRIVER` for integration with `fail2ban`.

An example regex for a `fail2ban` filter is as follows:
`failregex = ^.*Kanboard: Failed login from: <HOST> username:.*$`

Please confirm that you've completed the following before submitting:

- [x] I have tested my changes thoroughly
- [x] No breaking changes were introduced
- [x] No regressions were observed
- [x] I have updated the unit tests and integration tests accordingly
- [x] I follow the existing [coding standards](https://docs.kanboard.org/v1/dev/coding_standards/)
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)

This is my first time working with a `php` project and I expect that this PR may not be merged without more changes.

The only changes made were two additional `logger` log lines that I have tested on my RaspberryPI4 running `Kanboard`, so I am certain that even though ~~this PR wasn't tested more rigorously~~, I am of the opinion that this code should work as expected.

EDIT 2026-05-22: I've tested this by banning my phone and Kanboard does output login failures (via password) properly with these changes and fail2ban did pick up on the logs properly.

I felt this commit was necessary because `fail2ban` depends on log output to work, and I could not find existing documentation or options for integration with `fail2ban`.

I am open to discussion and changes if needed.