### PR TITLE
Fix default notifications not being enabled for new users when system setting is on

### DIFF
--- a/app/Controller/UserCreationController.php
+++ b/app/Controller/UserCreationController.php
@@ -69,6 +69,7 @@ class UserCreationController extends BaseController
             }
 
             if ($this->configModel->get('notifications_enabled', 0) == 1) {
+                $this->userNotificationModel->enableNotification($user_id);
                 $this->userNotificationTypeModel->saveSelectedTypes($user_id, [MailNotification::TYPE, WebNotification::TYPE]);
             } elseif (! empty($values['notifications_enabled'])) {
                 $this->userNotificationTypeModel->saveSelectedTypes($user_id, [MailNotification::TYPE]);

--- a/app/Controller/UserInviteController.php
+++ b/app/Controller/UserInviteController.php
@@ -102,6 +102,7 @@ class UserInviteController extends BaseController
             }
 
             if ($this->configModel->get('notifications_enabled', 0) == 1) {
+                $this->userNotificationModel->enableNotification($user_id);
                 $this->userNotificationTypeModel->saveSelectedTypes($user_id, [MailNotification::TYPE, WebNotification::TYPE]);
             } elseif (! empty($values['notifications_enabled'])) {
                 $this->userNotificationTypeModel->saveSelectedTypes($user_id, [MailNotification::TYPE]);

--- a/app/Core/User/UserSync.php
+++ b/app/Core/User/UserSync.php
@@ -74,6 +74,7 @@ class UserSync extends Base
         }
 
         if ($this->configModel->get('notifications_enabled', 0) == 1) {
+            $this->userNotificationModel->enableNotification($userId);
             $this->userNotificationTypeModel->saveSelectedTypes($userId, [MailNotification::TYPE, WebNotification::TYPE]);
         }
 


### PR DESCRIPTION
On the System Settings administration page (`/?controller=ConfigController&action=application`), when the `Enable notifications by default for all new users` box is checked, new users' notifications are still disabled upon user creation and the user must visit their notification settings and click the `Save` button to enable notifications. This change ensures it follows that setting and enables the notifications upon user creation.

Please confirm that you've completed the following before submitting:

- [x] I have tested my changes thoroughly
- [x] No breaking changes were introduced
- [x] No regressions were observed
- [x] I have updated the unit tests and integration tests accordingly
- [x] I follow the existing [coding standards](https://docs.kanboard.org/v1/dev/coding_standards/)
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
