### PR TITLE
fix(user): scope remember me session removal to its owner

### DIFF
--- a/app/Controller/UserViewController.php
+++ b/app/Controller/UserViewController.php
@@ -128,7 +128,7 @@ class UserViewController extends BaseController
     {
         $this->checkCSRFParam();
         $user = $this->getUser();
-        $this->rememberMeSessionModel->remove($this->request->getIntegerParam('id'));
+        $this->rememberMeSessionModel->remove($this->request->getIntegerParam('id'), $user['id']);
 
         if ($this->request->isAjax()) {
             $this->sessions();

--- a/app/Model/RememberMeSessionModel.php
+++ b/app/Model/RememberMeSessionModel.php
@@ -104,13 +104,15 @@ class RememberMeSessionModel extends Base
      *
      * @access public
      * @param  integer  $session_id   Session id
+     * @param  integer  $user_id      User id
      * @return mixed
      */
-    public function remove($session_id)
+    public function remove($session_id, $user_id)
     {
         return $this->db
             ->table(self::TABLE)
             ->eq('id', $session_id)
+            ->eq('user_id', $user_id)
             ->remove();
     }
 

--- a/app/Subscriber/AuthSubscriber.php
+++ b/app/Subscriber/AuthSubscriber.php
@@ -79,7 +79,7 @@ class AuthSubscriber extends BaseSubscriber implements EventSubscriberInterface
             $session = $this->rememberMeSessionModel->find($credentials['token'], $credentials['sequence']);
 
             if (! empty($session)) {
-                $this->rememberMeSessionModel->remove($session['id']);
+                $this->rememberMeSessionModel->remove($session['id'], $session['user_id']);
             }
 
             $this->rememberMeCookie->remove();


### PR DESCRIPTION
Constrain `RememberMeSessionModel::remove()` by `user_id` in addition to the session id so a session row can only be removed by the user that owns it.

- Pass the authenticated user id from the controller.
- Pass the cookie-derived user id from the logout subscriber.
