### PR TITLE
fix(board): escape project name in task links tooltip

### DIFF
--- a/app/Template/board/tooltip_tasklinks.php
+++ b/app/Template/board/tooltip_tasklinks.php
@@ -25,7 +25,7 @@
                     <?php endif ?>
                 </td>
                 <td>
-                    <?= $link['project_name'] ?>
+                    <?= $this->text->e($link['project_name']) ?>
                 </td>
             </tr>
         <?php endforeach ?>


### PR DESCRIPTION
The task links tooltip rendered `project_name` without HTML escaping, unlike every other field in the template. Pass it through `$this->text->e()` to match the rest of the template and other templates that render `project_name`.

**Note:** the default Content-Security-Policy blocks inline JavaScript (no `'unsafe-inline'` for scripts), so injected event handlers do not execute in a default deployment.
