### PR TITLE
fix(markdown): stop consuming text after an "#id" task link at line start

### DIFF
--- a/app/Core/Markdown.php
+++ b/app/Core/Markdown.php
@@ -49,19 +49,8 @@ class Markdown extends Parsedown
 
     protected function blockCustomHeader($Line)
     {
-        if (preg_match('!#(\d+)!i', $Line['text'], $matches)) {
-            $link = $this->buildTaskLink($matches[1]);
-
-            if (! empty($link)) {
-                return [
-                    'extent' => strlen($matches[0]),
-                    'element' => [
-                        'name' => 'a',
-                        'text' => $matches[0],
-                        'attributes' => ['href' => $link],
-                    ],
-                ];
-            }
+        if (preg_match('!^#\d+!i', $Line['text'])) {
+            return null;
         }
 
         return $this->blockHeader($Line);

--- a/tests/units/Helper/TextHelperTest.php
+++ b/tests/units/Helper/TextHelperTest.php
@@ -31,7 +31,7 @@ class TextHelperTest extends Base
         $this->assertEquals('<p>Test</p>', $textHelper->markdown('Test'));
 
         $this->assertEquals(
-            '<a href="?controller=TaskViewController&amp;action=show&amp;task_id=123">#123</a>',
+            '<p><a href="?controller=TaskViewController&amp;action=show&amp;task_id=123">#123</a></p>',
             $textHelper->markdown('#123')
         );
 
@@ -67,6 +67,11 @@ class TextHelperTest extends Base
             $textHelper->markdown(
                 '[item #123 is here](http://localhost)'
             )
+        );
+
+        $this->assertEquals(
+            '<p><a href="?controller=TaskViewController&amp;action=show&amp;task_id=123">#123</a> extra text not consumed</p>',
+            $textHelper->markdown('#123 extra text not consumed')
         );
     }
 


### PR DESCRIPTION
- [x] I have tested my changes thoroughly
- [x] No breaking changes were introduced
- [x] No regressions were observed
- [x] I have updated the unit tests and integration tests accordingly
- [x] I follow the existing [coding standards](https://docs.kanboard.org/v1/dev/coding_standards/)
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)

This change fixes a bug that I run into when commenting on a task where my comment starts with a link to another task, e.g. "#123 might fix this issue?". The behaviour before this change would render this comment as "#123" (consuming the text after the task link), and after this change "#123 might fix this issue?".

I believe the changes I made are inline with the initial intention of the code. However instead of returning a single <a> element and dropping any text after, it returns null which causes no header block and falls back to a <p> and the inline #id handling is used instead. This causes the existing (modified) test to now get wrapped in a <p> rather than just return an <a>.

An extra test has been added to test this scenario specifically.

Let me know if there's any issues with this that I haven't thought of.