### PR TITLE
fix(date): correct age helper "<30m" threshold to 30 minutes

### DIFF
--- a/app/Helper/DateHelper.php
+++ b/app/Helper/DateHelper.php
@@ -109,7 +109,7 @@ class DateHelper extends Base
         if ($diff < 900) {
             return t('<15m');
         }
-        if ($diff < 1200) {
+        if ($diff < 1800) {
             return t('<30m');
         } elseif ($diff < 3600) {
             return t('<1h');

--- a/tests/units/Helper/DatetimeHelperTest.php
+++ b/tests/units/Helper/DatetimeHelperTest.php
@@ -35,6 +35,7 @@ class DatetimeHelperTest extends Base
 
         $this->assertEquals('&lt;15m', $helper->age(0, 30));
         $this->assertEquals('&lt;30m', $helper->age(0, 1000));
+        $this->assertEquals('&lt;30m', $helper->age(0, 1500));
         $this->assertEquals('&lt;1h', $helper->age(0, 3000));
         $this->assertEquals('~2h', $helper->age(0, 2*3600));
         $this->assertEquals('1d', $helper->age(0, 30*3600));


### PR DESCRIPTION
### What

`DateHelper::age()` returned the "&lt;30m" label using a **1200-second** threshold, which is 20 minutes rather than 30. An item aged between 20 and 30 minutes was therefore labelled "&lt;1h" instead of "&lt;30m", inconsistent with the "&lt;15m" (900s) and "&lt;1h" (3600s) buckets. This label is shown on the board and task list ("Task age in days" / "Days in this column").

### Fix

Use 1800 seconds so the threshold matches its own "&lt;30m" label and the 900 / 1800 / 3600 progression.

### Tests

Extended `DatetimeHelperTest::testAge()` with a 25-minute (1500s) case that returns "&lt;1h" before the change and "&lt;30m" after. All previous assertions are unaffected (none covered the 20–30 minute window).

- [x] I have tested my changes thoroughly
- [x] No breaking changes were introduced
- [x] No regressions were observed
- [x] I have updated the unit tests accordingly
- [x] I follow the existing coding standards
- [x] My commit messages follow the Conventional Commits specification

---
*Disclosure: this change was prepared with AI assistance (Claude) and reviewed and verified by me before submission.*
