### PR TITLE
fix(board): verify task belongs to project before moving

### DIFF
--- a/app/Controller/BoardAjaxController.php
+++ b/app/Controller/BoardAjaxController.php
@@ -30,6 +30,10 @@ class BoardAjaxController extends BaseController
 
         $values = $this->request->getJson();
 
+        if ($this->taskFinderModel->getProjectId($values['task_id']) !== $project_id) {
+            throw new AccessForbiddenException(e("You don't have the permission to move this task"));
+        }
+
         if (! $this->helper->projectRole->canMoveTask($project_id, $values['src_column_id'], $values['dst_column_id'])) {
             throw new AccessForbiddenException(e("You don't have the permission to move this task"));
         }


### PR DESCRIPTION
The board drag-and-drop endpoint (`BoardAjaxController::save`) validated the caller's role on the request's `project_id` but never checked that the task being moved actually belonged to that project. Since task ids are sequential and shared across the instance, any project member could move and effectively hide arbitrary tasks in projects they have no access to.

Add the same ownership check already used by the JSON-RPC API path (`TaskProcedure::moveTaskPosition`) so cross-project moves are rejected.

Refs: #5852
