### PR TITLE
fix(docker): only execute PHP front controllers in nginx

### DIFF
--- a/docker/etc/nginx/nginx.conf
+++ b/docker/etc/nginx/nginx.conf
@@ -44,7 +44,8 @@ http {
             try_files $uri $uri/ /index.php$is_args$args;
         }
 
-        location ~ \.php$ {
+        # Only the front controllers are allowed to run PHP
+        location ~ ^/(index|jsonrpc|healthcheck)\.php(/|$) {
             try_files $uri =404;
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
             fastcgi_pass unix:/var/run/php-fpm.sock;
@@ -56,15 +57,26 @@ http {
             fastcgi_param HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
         }
 
-        location ~ /data {
+        # Source code and private data are never served
+        location ~ ^/(app|libs|vendor|data)/ {
             return 404;
         }
 
-        location ~* ^.+\.(log|sqlite)$ {
+        location ~ ^/cli$ {
             return 404;
         }
 
-        location ~ /\.ht {
+        # Any other PHP file (plugins included) is neither executed nor served,
+        # but plugin static assets under plugins/*/Assets/ remain reachable
+        location ~ \.php$ {
+            return 404;
+        }
+
+        location ~* \.(log|sqlite)$ {
+            return 404;
+        }
+
+        location ~ /\. {
             return 404;
         }
 


### PR DESCRIPTION
## Problem

Any path ending in `.php` was routed to PHP-FPM, so every file under `app/`, `libs/`, `vendor/` and `plugins/` ran outside the middleware chain that implements authentication and both ACLs.

Regex locations are evaluated in definition order, so the `.php` block also shadowed the `/data` guard.

## Fix

- Restrict execution to `index.php`, `jsonrpc.php` and `healthcheck.php`.
- Deny the source directories, `cli` and every remaining `.php` file.

The catch-all comes after the directory rules so plugin assets under `plugins/*/Assets/` stay reachable.

Fixes: #5865
