### PR TITLE
fix(api): return only public user columns

### DIFF
--- a/app/Api/Procedure/BaseProcedure.php
+++ b/app/Api/Procedure/BaseProcedure.php
@@ -32,6 +32,16 @@ abstract class BaseProcedure extends Base
         return $values;
     }
 
+    protected function filterUser($user)
+    {
+        return is_array($user) ? $this->userModel->removePrivateColumns($user) : $user;
+    }
+
+    protected function filterUsers($users)
+    {
+        return is_array($users) ? array_map(array($this, 'filterUser'), $users) : $users;
+    }
+
     protected function getClassName()
     {
         $reflection = new ReflectionClass(get_called_class());

--- a/app/Api/Procedure/GroupMemberProcedure.php
+++ b/app/Api/Procedure/GroupMemberProcedure.php
@@ -17,7 +17,7 @@ class GroupMemberProcedure extends BaseProcedure
 
     public function getGroupMembers($group_id)
     {
-        return $this->groupMemberModel->getMembers($group_id);
+        return $this->filterUsers($this->groupMemberModel->getMembers($group_id));
     }
 
     public function addGroupMember($group_id, $user_id)

--- a/app/Api/Procedure/UserProcedure.php
+++ b/app/Api/Procedure/UserProcedure.php
@@ -20,17 +20,17 @@ class UserProcedure extends BaseProcedure
 {
     public function getUser($user_id)
     {
-        return $this->userModel->getById($user_id);
+        return $this->filterUser($this->userModel->getById($user_id));
     }
 
     public function getUserByName($username)
     {
-        return $this->userModel->getByUsername($username);
+        return $this->filterUser($this->userModel->getByUsername($username));
     }
 
     public function getAllUsers()
     {
-        return $this->userModel->getAll();
+        return $this->filterUsers($this->userModel->getAll());
     }
 
     public function removeUser($user_id)

--- a/app/Model/UserModel.php
+++ b/app/Model/UserModel.php
@@ -30,6 +30,29 @@ class UserModel extends Base
      */
     const EVERYBODY_ID = -1;
 
+    /**
+     * Columns that must never be exposed outside of the application
+     *
+     * @var string[]
+     */
+    const PRIVATE_COLUMNS = array('password', 'twofactor_secret', 'api_access_token', 'token');
+
+    /**
+     * Remove sensitive columns from a user row
+     *
+     * @access public
+     * @param  array $user
+     * @return array
+     */
+    public function removePrivateColumns(array $user)
+    {
+        foreach (self::PRIVATE_COLUMNS as $column) {
+            unset($user[$column]);
+        }
+
+        return $user;
+    }
+
     public function isValidSession($userID, $sessionRole)
     {
         return $this->db->table(self::TABLE)

--- a/tests/integration/BaseProcedureTest.php
+++ b/tests/integration/BaseProcedureTest.php
@@ -38,6 +38,13 @@ abstract class BaseProcedureTest extends TestCase
         $this->setUpStandardUser();
     }
 
+    public function assertNoPrivateColumns(array $user)
+    {
+        foreach (array('password', 'twofactor_secret', 'api_access_token', 'token') as $column) {
+            $this->assertArrayNotHasKey($column, $user);
+        }
+    }
+
     public function setUpAppClient()
     {
         $this->app = new Client(API_URL);

--- a/tests/integration/GroupMemberProcedureTest.php
+++ b/tests/integration/GroupMemberProcedureTest.php
@@ -29,6 +29,7 @@ class GroupMemberProcedureTest extends BaseProcedureTest
         $members = $this->app->getGroupMembers($this->groupId1);
         $this->assertCount(1, $members);
         $this->assertEquals($this->username, $members[0]['username']);
+        $this->assertNoPrivateColumns($members[0]);
     }
 
     public function assertIsGroupMember()

--- a/tests/integration/UserProcedureTest.php
+++ b/tests/integration/UserProcedureTest.php
@@ -20,6 +20,7 @@ class UserProcedureTest extends BaseProcedureTest
         $user = $this->app->getUser($this->userId);
         $this->assertNotNull($user);
         $this->assertEquals($this->username, $user['username']);
+        $this->assertNoPrivateColumns($user);
     }
 
     public function assertGetUserByName()
@@ -27,6 +28,7 @@ class UserProcedureTest extends BaseProcedureTest
         $user = $this->app->getUserByName($this->username);
         $this->assertNotNull($user);
         $this->assertEquals($this->username, $user['username']);
+        $this->assertNoPrivateColumns($user);
     }
 
     public function assertGetAllUsers()
@@ -34,6 +36,10 @@ class UserProcedureTest extends BaseProcedureTest
         $users = $this->app->getAllUsers();
         $this->assertIsArray($users);
         $this->assertNotEmpty($users);
+
+        foreach ($users as $user) {
+            $this->assertNoPrivateColumns($user);
+        }
     }
 
     public function assertEnableDisableUser()

--- a/tests/units/Model/UserModelTest.php
+++ b/tests/units/Model/UserModelTest.php
@@ -13,6 +13,22 @@ use Kanboard\Core\Security\Role;
 
 class UserModelTest extends Base
 {
+    public function testRemovePrivateColumns()
+    {
+        $userModel = new UserModel($this->container);
+        $this->assertNotFalse($userModel->create(array('username' => 'user1', 'password' => '123456')));
+
+        $user = $userModel->getById(2);
+        $this->assertArrayHasKey('password', $user);
+
+        $user = $userModel->removePrivateColumns($user);
+        $this->assertEquals('user1', $user['username']);
+        $this->assertArrayNotHasKey('password', $user);
+        $this->assertArrayNotHasKey('twofactor_secret', $user);
+        $this->assertArrayNotHasKey('api_access_token', $user);
+        $this->assertArrayNotHasKey('token', $user);
+    }
+
     public function testGetByEmail()
     {
         $userModel = new UserModel($this->container);


### PR DESCRIPTION
Strip `password`, `twofactor_secret`, `api_access_token` and `token` from the user rows returned by:

- `getUser`
- `getUserByName`
- `getAllUsers`
- `getGroupMembers`

Closes #5877
