### PR TITLE
fix(csv): escape exported values starting with a special character

### DIFF
--- a/app/Core/Csv.php
+++ b/app/Core/Csv.php
@@ -174,6 +174,7 @@ class Csv
             }
 
             foreach ($rows as $row) {
+                $row = array_map(array($this, 'neutralizeFormula'), $row);
                 fputcsv($fp, $row, $this->delimiter, $this->enclosure, '\\');
             }
 
@@ -181,6 +182,22 @@ class Csv
         }
 
         return $this;
+    }
+
+    /**
+     * Prevent spreadsheet applications from interpreting a CSV cell as a formula
+     *
+     * @access private
+     * @param  mixed $value
+     * @return mixed
+     */
+    private function neutralizeFormula($value)
+    {
+        if (is_string($value) && $value !== '' && ! is_numeric($value) && strpbrk($value[0], "=+-@\t\r\n") !== false) {
+            return "'".$value;
+        }
+
+        return $value;
     }
 
     /**

--- a/tests/units/Core/CsvTest.php
+++ b/tests/units/Core/CsvTest.php
@@ -49,6 +49,69 @@ class CsvTest extends Base
         $this->expectOutputString('"Column A","Column B"'."\n".'"value a","value b"'."\n", $csv->output($rows));
     }
 
+    public function testWriteNeutralizesFormulaInjection()
+    {
+        $filename = tempnam(sys_get_temp_dir(), 'UT');
+        $rows = array(array(
+            '=1+1',
+            '+1+1',
+            '-1+1',
+            '@SUM(A1:A2)',
+            "\t=1+1",
+            "\r=1+1",
+            "\n=1+1",
+        ));
+
+        $csv = new Csv;
+        $csv->write($filename, $rows);
+
+        $fp = fopen($filename, 'r');
+        $row = fgetcsv($fp, null, ',', '"', '\\');
+        fclose($fp);
+        unlink($filename);
+
+        $this->assertSame(array(
+            "'=1+1",
+            "'+1+1",
+            "'-1+1",
+            "'@SUM(A1:A2)",
+            "'\t=1+1",
+            "'\r=1+1",
+            "'\n=1+1",
+        ), $row);
+    }
+
+    public function testWritePreservesSafeValues()
+    {
+        $filename = tempnam(sys_get_temp_dir(), 'UT');
+        $rows = array(array(
+            'Text',
+            '1=1',
+            '',
+            123,
+            -123,
+            1.5,
+            null,
+            '-2',
+            '+2',
+            '-1.5',
+            '-2e3',
+        ));
+
+        $csv = new Csv;
+        $csv->write($filename, $rows);
+
+        $fp = fopen($filename, 'r');
+        $row = fgetcsv($fp, null, ',', '"', '\\');
+        fclose($fp);
+        unlink($filename);
+
+        $this->assertSame(
+            array('Text', '1=1', '', '123', '-123', '1.5', '', '-2', '+2', '-1.5', '-2e3'),
+            $row
+        );
+    }
+
     public function readRow(array $row, $line)
     {
         $this->assertEquals(array('value a', 'value b', ''), $row);


### PR DESCRIPTION
Spreadsheet applications interpret a leading `=`, `+`, `-`, `@`, tab or newline as the beginning of an expression.

Prefix those values with an apostrophe on write, leaving purely numeric values untouched.
