### PR TITLE
fix(file): check the project of the task when fetching a task file

### DIFF
--- a/app/Controller/BaseController.php
+++ b/app/Controller/BaseController.php
@@ -111,7 +111,17 @@ abstract class BaseController extends Base
             throw new PageNotFoundException();
         }
 
-        if (isset($file['project_id']) && $file['project_id'] != $project_id) {
+        if ($model === 'taskFileModel') {
+            // The table task_has_files has no project_id column, the owner project comes from the task
+            $file['project_id'] = $this->taskFileModel->getProjectId($file['id']);
+
+            // Task files are also linked from URLs that do not carry any project_id
+            if ($project_id == 0) {
+                $project_id = $file['project_id'];
+            }
+        }
+
+        if (empty($file['project_id']) || $file['project_id'] != $project_id) {
             throw new PageNotFoundException();
         }
 

--- a/app/Middleware/ProjectAuthorizationMiddleware.php
+++ b/app/Middleware/ProjectAuthorizationMiddleware.php
@@ -21,14 +21,33 @@ class ProjectAuthorizationMiddleware extends BaseMiddleware
         $project_id = $this->request->getIntegerParam('project_id');
         $task_id = $this->request->getIntegerParam('task_id');
 
-        if ($task_id > 0 && $project_id === 0) {
-            $project_id = $this->taskFinderModel->getProjectId($task_id);
+        // The project of the task always prevails over the project given in the URL
+        if ($task_id > 0) {
+            $task_project_id = $this->taskFinderModel->getProjectId($task_id);
+
+            if ($task_project_id > 0 && $task_project_id != $project_id) {
+                $this->checkProjectAccess($task_project_id);
+            }
         }
 
-        if ($project_id > 0 && ! $this->helper->user->hasProjectAccess($this->router->getController(), $this->router->getAction(), $project_id)) {
-            throw new AccessForbiddenException();
+        if ($project_id > 0) {
+            $this->checkProjectAccess($project_id);
         }
 
         $this->next();
+    }
+
+    /**
+     * Check the access of the current user for the given project
+     *
+     * @access protected
+     * @param  integer $project_id
+     * @throws AccessForbiddenException
+     */
+    protected function checkProjectAccess($project_id)
+    {
+        if (! $this->helper->user->hasProjectAccess($this->router->getController(), $this->router->getAction(), $project_id)) {
+            throw new AccessForbiddenException();
+        }
     }
 }

--- a/tests/units/Controller/FileViewerControllerTest.php
+++ b/tests/units/Controller/FileViewerControllerTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace KanboardTests\units\Controller;
+
+use Kanboard\Controller\FileViewerController;
+use Kanboard\Core\Http\Request;
+use Kanboard\Core\Http\Response;
+use Kanboard\Core\ObjectStorage\FileStorage;
+use Kanboard\Core\Security\Role;
+use Kanboard\Model\ProjectFileModel;
+use Kanboard\Model\ProjectModel;
+use Kanboard\Model\TaskCreationModel;
+use Kanboard\Model\TaskFileModel;
+use Kanboard\Model\UserModel;
+use KanboardTests\units\Base;
+
+class FileViewerControllerTest extends Base
+{
+    public function testDownloadTaskFileWithTheProjectIdOfAnotherProject()
+    {
+        $this->createFixtures();
+        $this->buildRequest(array('project_id' => 1, 'task_id' => 1, 'file_id' => 1));
+        $this->expectNoDownload();
+
+        $controller = new FileViewerController($this->container);
+
+        $this->expectException('Kanboard\Core\Controller\PageNotFoundException');
+        $controller->download();
+    }
+
+    public function testDownloadTaskFileWithTheProjectIdOfTheTask()
+    {
+        $this->createFixtures();
+        $this->buildRequest(array('project_id' => 2, 'task_id' => 1, 'file_id' => 1));
+        $this->expectDownload();
+
+        $controller = new FileViewerController($this->container);
+        $controller->download();
+    }
+
+    public function testDownloadTaskFileWithoutProjectId()
+    {
+        $this->createFixtures();
+        $this->buildRequest(array('task_id' => 1, 'file_id' => 1));
+        $this->expectDownload();
+
+        $controller = new FileViewerController($this->container);
+        $controller->download();
+    }
+
+    public function testDownloadProjectFileWithoutProjectId()
+    {
+        $this->createFixtures();
+
+        $projectFileModel = new ProjectFileModel($this->container);
+        $this->assertEquals(1, $projectFileModel->create(2, 'contract.txt', 'projects/2/contract.txt', 42));
+
+        $this->buildRequest(array('file_id' => 1));
+        $this->expectNoDownload();
+
+        $controller = new FileViewerController($this->container);
+
+        $this->expectException('Kanboard\Core\Controller\PageNotFoundException');
+        $controller->download();
+    }
+
+    private function expectDownload()
+    {
+        $this->container['response']
+            ->expects($this->once())
+            ->method('withFileDownload')
+            ->with('secret.txt');
+
+        $this->container['objectStorage']
+            ->expects($this->once())
+            ->method('output')
+            ->with('tasks/1/secret.txt');
+    }
+
+    private function expectNoDownload()
+    {
+        $this->container['response']
+            ->expects($this->never())
+            ->method('withFileDownload');
+
+        $this->container['objectStorage']
+            ->expects($this->never())
+            ->method('output');
+    }
+
+    private function buildRequest(array $params)
+    {
+        $this->container['request'] = new Request($this->container, array('REQUEST_METHOD' => 'GET'), $params);
+
+        $this->container['response'] = $this
+            ->getMockBuilder(Response::class)
+            ->setConstructorArgs(array($this->container))
+            ->onlyMethods(array('withFileDownload', 'send'))
+            ->getMock();
+
+        $this->container['objectStorage'] = $this
+            ->getMockBuilder(FileStorage::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(array('output'))
+            ->getMock();
+    }
+
+    private function createFixtures()
+    {
+        $projectModel = new ProjectModel($this->container);
+        $taskCreationModel = new TaskCreationModel($this->container);
+        $taskFileModel = new TaskFileModel($this->container);
+        $userModel = new UserModel($this->container);
+
+        $this->assertEquals(2, $userModel->create(array('username' => 'bob')));
+
+        $this->assertEquals(1, $projectModel->create(array('name' => 'Project A')));
+        $this->assertEquals(2, $projectModel->create(array('name' => 'Project B')));
+
+        $this->assertEquals(1, $taskCreationModel->create(array('project_id' => 2, 'title' => 'Task B')));
+        $this->assertEquals(1, $taskFileModel->create(1, 'secret.txt', 'tasks/1/secret.txt', 42));
+
+        $_SESSION['user'] = array(
+            'id' => 2,
+            'role' => Role::APP_USER,
+            'username' => 'bob',
+        );
+    }
+}

--- a/tests/units/Middleware/ProjectAuthorizationMiddlewareTest.php
+++ b/tests/units/Middleware/ProjectAuthorizationMiddlewareTest.php
@@ -2,9 +2,11 @@
 
 namespace KanboardTests\units\Middleware;
 
-use KanboardTests\units\Base;
+use Kanboard\Core\Http\Request;
 use Kanboard\Middleware\ProjectAuthorizationMiddleware;
-use stdClass;
+use Kanboard\Model\ProjectModel;
+use Kanboard\Model\TaskCreationModel;
+use KanboardTests\units\Base;
 
 #[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 class ProjectAuthorizationMiddlewareTest extends Base
@@ -18,8 +20,6 @@ class ProjectAuthorizationMiddlewareTest extends Base
     protected function setUp(): void
     {
         parent::setUp();
-
-        $this->container['helper'] = new stdClass();
 
         $this->container['helper']->user = $this
             ->getMockBuilder('Kanboard\Helper\UserHelper')
@@ -78,5 +78,55 @@ class ProjectAuthorizationMiddlewareTest extends Base
             ->method('execute');
 
         $this->middleware->execute();
+    }
+
+    public function testWithTaskFromAnotherProject()
+    {
+        $this->createFixtures();
+
+        // The user has access to the project given in the URL but not to the project of the task
+        $this->container['request'] = new Request($this->container, array(), array('project_id' => 1, 'task_id' => 1));
+
+        $this->container['helper']->user
+            ->expects($this->once())
+            ->method('hasProjectAccess')
+            ->with($this->anything(), $this->anything(), 2)
+            ->willReturn(false);
+
+        $this->nextMiddleware
+            ->expects($this->never())
+            ->method('execute');
+
+        $this->expectException('Kanboard\Core\Controller\AccessForbiddenException');
+        $this->middleware->execute();
+    }
+
+    public function testWithTaskFromTheSameProject()
+    {
+        $this->createFixtures();
+
+        $this->container['request'] = new Request($this->container, array(), array('project_id' => 2, 'task_id' => 1));
+
+        $this->container['helper']->user
+            ->expects($this->once())
+            ->method('hasProjectAccess')
+            ->with($this->anything(), $this->anything(), 2)
+            ->willReturn(true);
+
+        $this->nextMiddleware
+            ->expects($this->once())
+            ->method('execute');
+
+        $this->middleware->execute();
+    }
+
+    private function createFixtures()
+    {
+        $projectModel = new ProjectModel($this->container);
+        $taskCreationModel = new TaskCreationModel($this->container);
+
+        $this->assertEquals(1, $projectModel->create(array('name' => 'Project A')));
+        $this->assertEquals(2, $projectModel->create(array('name' => 'Project B')));
+        $this->assertEquals(1, $taskCreationModel->create(array('project_id' => 2, 'title' => 'Task B')));
     }
 }


### PR DESCRIPTION
The table `task_has_files` has no `project_id` column, so the ownership check in `getFile()` never applied to task files. Resolve the project from the task instead.

Also authorize the project of the task in addition to the project given in the URL.

Closes #5880
