### PR TITLE
fix(project): check permissions in the project creation handler

### DIFF
--- a/app/Controller/ProjectCreationController.php
+++ b/app/Controller/ProjectCreationController.php
@@ -42,6 +42,8 @@ class ProjectCreationController extends BaseController
      */
     public function createPrivate(array $values = array(), array $errors = array())
     {
+        $this->checkPrivateProjectCreationAllowed();
+
         $values['is_private'] = 1;
         $this->create($values, $errors);
     }
@@ -54,6 +56,18 @@ class ProjectCreationController extends BaseController
     public function save()
     {
         $values = $this->request->getValues();
+        $values['is_private'] = empty($values['is_private']) ? 0 : 1;
+
+        if (! empty($values['src_project_id'])) {
+            $this->checkSourceProjectAccessAllowed($values['src_project_id']);
+        }
+
+        if ($this->isDestinationProjectPrivate($values)) {
+            $this->checkPrivateProjectCreationAllowed();
+        } else {
+            $this->checkTeamProjectCreationAllowed();
+        }
+
         list($valid, $errors) = $this->projectValidator->validateCreation($values);
 
         if ($valid) {
@@ -68,6 +82,69 @@ class ProjectCreationController extends BaseController
         }
 
         return $this->create($values, $errors);
+    }
+
+    /**
+     * Get the visibility of the project that is going to be created
+     *
+     * Duplicated projects inherit the visibility of the source project when
+     * the form does not ask for a personal project.
+     *
+     * @access private
+     * @param  array $values
+     * @return boolean
+     */
+    private function isDestinationProjectPrivate(array $values)
+    {
+        if (! empty($values['is_private'])) {
+            return true;
+        }
+
+        if (! empty($values['src_project_id'])) {
+            return $this->projectModel->isPrivate($values['src_project_id']);
+        }
+
+        return false;
+    }
+
+    /**
+     * Check that the user has access to the project used as a template
+     *
+     * @access private
+     * @param  integer $projectId
+     * @throws AccessForbiddenException
+     */
+    private function checkSourceProjectAccessAllowed($projectId)
+    {
+        if (! $this->projectPermissionModel->isUserAllowed($projectId, $this->userSession->getId())) {
+            throw new AccessForbiddenException();
+        }
+    }
+
+    /**
+     * Check that the user is allowed to create team projects
+     *
+     * @access private
+     * @throws AccessForbiddenException
+     */
+    private function checkTeamProjectCreationAllowed()
+    {
+        if (! $this->helper->user->hasAccess('ProjectCreationController', 'create')) {
+            throw new AccessForbiddenException();
+        }
+    }
+
+    /**
+     * Check that personal projects are enabled
+     *
+     * @access private
+     * @throws AccessForbiddenException
+     */
+    private function checkPrivateProjectCreationAllowed()
+    {
+        if ($this->configModel->get('disable_private_project', 0) == 1) {
+            throw new AccessForbiddenException();
+        }
     }
 
     /**
@@ -116,10 +193,6 @@ class ProjectCreationController extends BaseController
     private function duplicateNewProject(array $values)
     {
         $selection = array();
-
-        if (! $this->projectPermissionModel->isUserAllowed($values['src_project_id'], $this->userSession->getId())) {
-            throw new AccessForbiddenException();
-        }
 
         foreach ($this->projectDuplicationModel->getOptionalSelection() as $item) {
             if (isset($values[$item]) && $values[$item] == 1) {

--- a/tests/units/Controller/ProjectCreationControllerTest.php
+++ b/tests/units/Controller/ProjectCreationControllerTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace KanboardTests\units\Controller;
+
+use Kanboard\Controller\ProjectCreationController;
+use Kanboard\Core\Controller\AccessForbiddenException;
+use Kanboard\Core\Http\Request;
+use Kanboard\Core\Http\Response;
+use Kanboard\Core\Security\Role;
+use KanboardTests\units\Base;
+
+class ProjectCreationControllerTest extends Base
+{
+    public function testSaveRejectsTeamProjectForRegularUser()
+    {
+        $this->buildSaveRequest(Role::APP_USER, 0);
+
+        try {
+            (new ProjectCreationController($this->container))->save();
+            $this->fail('A team project created by a regular user must be rejected');
+        } catch (AccessForbiddenException $e) {
+            $this->assertEmpty($this->container['projectModel']->getAll());
+        }
+    }
+
+    public function testSaveAllowsTeamProjectForManager()
+    {
+        $this->buildSaveRequest(Role::APP_MANAGER, 0);
+        $this->expectRedirect();
+
+        (new ProjectCreationController($this->container))->save();
+
+        $project = $this->container['projectModel']->getById(1);
+        $this->assertEquals('My project', $project['name']);
+        $this->assertEquals(0, $project['is_private']);
+    }
+
+    public function testSaveAllowsPersonalProjectForRegularUser()
+    {
+        $this->buildSaveRequest(Role::APP_USER, 1);
+        $this->expectRedirect();
+
+        (new ProjectCreationController($this->container))->save();
+
+        $project = $this->container['projectModel']->getById(1);
+        $this->assertEquals('My project', $project['name']);
+        $this->assertEquals(1, $project['is_private']);
+    }
+
+    public function testSaveRejectsPersonalProjectWhenDisabled()
+    {
+        $this->container['configModel']->save(array('disable_private_project' => 1));
+        $this->buildSaveRequest(Role::APP_USER, 1);
+
+        try {
+            (new ProjectCreationController($this->container))->save();
+            $this->fail('A personal project must be rejected when they are disabled');
+        } catch (AccessForbiddenException $e) {
+            $this->assertEmpty($this->container['projectModel']->getAll());
+        }
+    }
+
+    public function testCreatePrivateRejectedWhenPersonalProjectsDisabled()
+    {
+        $this->container['configModel']->save(array('disable_private_project' => 1));
+        $this->buildSaveRequest(Role::APP_USER, 1);
+
+        $this->expectException(AccessForbiddenException::class);
+
+        (new ProjectCreationController($this->container))->createPrivate();
+    }
+
+    public function testSaveNeverDuplicatesATeamProjectForARegularUser()
+    {
+        $this->createSourceProject(0);
+        $this->buildSaveRequest(Role::APP_USER, 2, array('src_project_id' => 1));
+        $this->assertTrue($this->container['projectUserRoleModel']->addUser(1, 2, Role::PROJECT_MEMBER));
+        $this->expectRedirect();
+
+        (new ProjectCreationController($this->container))->save();
+
+        $project = $this->container['projectModel']->getById(2);
+        $this->assertEquals('My project', $project['name']);
+        $this->assertEquals(1, $project['is_private'], 'An unexpected is_private value must not produce a team project');
+    }
+
+    public function testSaveRejectsPrivateDuplicationWhenPersonalProjectsDisabled()
+    {
+        $this->container['configModel']->save(array('disable_private_project' => 1));
+        $this->createSourceProject(1);
+        $this->buildSaveRequest(Role::APP_MANAGER, 0, array('src_project_id' => 1));
+        $this->assertTrue($this->container['projectUserRoleModel']->addUser(1, 2, Role::PROJECT_MANAGER));
+
+        try {
+            (new ProjectCreationController($this->container))->save();
+            $this->fail('A personal project must be rejected when they are disabled');
+        } catch (AccessForbiddenException $e) {
+            $this->assertCount(1, $this->container['projectModel']->getAll());
+        }
+    }
+
+    public function testSaveRejectsInaccessibleSourceProjectBeforeReadingItsVisibility()
+    {
+        $this->createSourceProject(1);
+        $this->buildSaveRequest(Role::APP_USER, 0, array('src_project_id' => 1, 'name' => ''));
+
+        $this->expectException(AccessForbiddenException::class);
+
+        (new ProjectCreationController($this->container))->save();
+    }
+
+    public function testSaveRejectsInaccessibleSourceProjectForManager()
+    {
+        $this->createSourceProject(0);
+        $this->buildSaveRequest(Role::APP_MANAGER, 0, array('src_project_id' => 1));
+
+        $this->expectException(AccessForbiddenException::class);
+
+        (new ProjectCreationController($this->container))->save();
+    }
+
+    public function testSaveAllowsPersonalProjectDuplicationForRegularUser()
+    {
+        $this->createSourceProject(1);
+        $this->buildSaveRequest(Role::APP_USER, 1, array('src_project_id' => 1));
+        $this->assertTrue($this->container['projectUserRoleModel']->addUser(1, 2, Role::PROJECT_MANAGER));
+        $this->expectRedirect();
+
+        (new ProjectCreationController($this->container))->save();
+
+        $project = $this->container['projectModel']->getById(2);
+        $this->assertEquals('My project', $project['name']);
+        $this->assertEquals(1, $project['is_private']);
+    }
+
+    private function expectRedirect()
+    {
+        $this->container['response'] = $this->getMockBuilder(Response::class)
+            ->setConstructorArgs(array($this->container))
+            ->onlyMethods(array('redirect'))
+            ->getMock();
+
+        $this->container['response']
+            ->expects($this->once())
+            ->method('redirect');
+    }
+
+    private function buildSaveRequest($role, $isPrivate, array $extraValues = array())
+    {
+        $this->assertEquals(2, $this->container['userModel']->create(array('username' => 'user1', 'role' => $role)));
+        $this->container['userSession']->initialize($this->container['userModel']->getById(2));
+
+        $this->container['request'] = new Request(
+            $this->container,
+            array('REQUEST_METHOD' => 'POST'),
+            array(),
+            array_merge(array(
+                'csrf_token' => $this->container['token']->getCSRFToken(),
+                'name' => 'My project',
+                'identifier' => '',
+                'task_limit' => 0,
+                'is_private' => $isPrivate,
+            ), $extraValues),
+            array(),
+            array()
+        );
+    }
+
+    private function createSourceProject($isPrivate)
+    {
+        $this->assertEquals(1, $this->container['projectModel']->create(array(
+            'name' => 'Source project',
+            'is_private' => $isPrivate,
+        )));
+    }
+}


### PR DESCRIPTION
The access list only covered the form, not the handler that creates the project.

Personal projects and duplications are now checked against the visibility of the project actually created.

Closes #5861
