### PR TITLE
fix(user): invalidate existing sessions when the password changes

### DIFF
--- a/app/Auth/DatabaseAuth.php
+++ b/app/Auth/DatabaseAuth.php
@@ -84,7 +84,11 @@ class DatabaseAuth extends Base implements PasswordAuthenticationProviderInterfa
      */
     public function isValidSession()
     {
-        return $this->userModel->isValidSession($this->userSession->getId(), $this->userSession->getRole());
+        return $this->userModel->isValidSession(
+            $this->userSession->getId(),
+            $this->userSession->getRole(),
+            $this->userSession->getCredentialsFingerprint()
+        );
     }
 
     /**

--- a/app/Core/User/UserSession.php
+++ b/app/Core/User/UserSession.php
@@ -16,13 +16,23 @@ class UserSession extends Base
     /**
      * Refresh current session if necessary
      *
+     * The credentials fingerprint is preserved: an ordinary refresh must never revalidate
+     * a session opened before the password changed. Only the session that changed the
+     * password gets the new fingerprint.
+     *
      * @access public
      * @param integer $user_id
+     * @param boolean $renewCredentialsFingerprint
      */
-    public function refresh($user_id)
+    public function refresh($user_id, $renewCredentialsFingerprint = false)
     {
         if ($this->getId() == $user_id) {
+            $fingerprint = $this->getCredentialsFingerprint();
             $this->initialize($this->userModel->getById($user_id));
+
+            if (! $renewCredentialsFingerprint) {
+                session_merge('user', array('credentials_fingerprint' => $fingerprint));
+            }
         }
     }
 
@@ -34,6 +44,9 @@ class UserSession extends Base
      */
     public function initialize(array $user)
     {
+        // Keep a fingerprint of the password to invalidate the session when the credentials change
+        $fingerprint = hash('sha256', isset($user['password']) ? $user['password'] : '');
+
         foreach (array('password', 'is_admin', 'is_project_admin', 'twofactor_secret') as $column) {
             if (isset($user[$column])) {
                 unset($user[$column]);
@@ -41,6 +54,7 @@ class UserSession extends Base
         }
 
         $user['id'] = (int) $user['id'];
+        $user['credentials_fingerprint'] = $fingerprint;
         $user['is_ldap_user'] = isset($user['is_ldap_user']) ? (bool) $user['is_ldap_user'] : false;
         $user['twofactor_activated'] = isset($user['twofactor_activated']) ? (bool) $user['twofactor_activated'] : false;
 
@@ -51,6 +65,21 @@ class UserSession extends Base
 
         session_set('user', $user);
         session_set('postAuthenticationValidated', false);
+    }
+
+    /**
+     * Get the credentials fingerprint stored in the session
+     *
+     * Returns an empty string for sessions created before this value was stored,
+     * which never matches a real fingerprint and forces a new authentication.
+     *
+     * @access public
+     * @return string
+     */
+    public function getCredentialsFingerprint()
+    {
+        $user = session_get('user');
+        return isset($user['credentials_fingerprint']) ? $user['credentials_fingerprint'] : '';
     }
 
     /**

--- a/app/Model/RememberMeSessionModel.php
+++ b/app/Model/RememberMeSessionModel.php
@@ -117,6 +117,21 @@ class RememberMeSessionModel extends Base
     }
 
     /**
+     * Remove all sessions for a given user
+     *
+     * @access public
+     * @param  integer  $user_id  User id
+     * @return bool
+     */
+    public function removeAll($user_id)
+    {
+        return $this->db
+            ->table(self::TABLE)
+            ->eq('user_id', $user_id)
+            ->remove();
+    }
+
+    /**
      * Remove old sessions for a given user
      *
      * @access public

--- a/app/Model/UserModel.php
+++ b/app/Model/UserModel.php
@@ -53,13 +53,33 @@ class UserModel extends Base
         return $user;
     }
 
-    public function isValidSession($userID, $sessionRole)
+    /**
+     * Check that the session belongs to an active user whose credentials did not change
+     *
+     * The fingerprint is compared strictly: a session without one (created before this
+     * check existed) never matches and is therefore rejected.
+     *
+     * @access public
+     * @param  integer  $userID
+     * @param  string   $sessionRole
+     * @param  string   $credentialsFingerprint
+     * @return boolean
+     */
+    public function isValidSession($userID, $sessionRole, $credentialsFingerprint = '')
     {
-        return $this->db->table(self::TABLE)
+        $user = $this->db->table(self::TABLE)
+            ->columns('password')
             ->eq('id', $userID)
             ->eq('is_active', 1)
             ->eq('role', $sessionRole)
-            ->exists();
+            ->findOne();
+
+        if (empty($user)) {
+            return false;
+        }
+
+        // Sessions opened before the last password change are no longer valid
+        return $credentialsFingerprint === hash('sha256', (string) $user['password']);
     }
 
     public function has2FA($username)
@@ -329,7 +349,15 @@ class UserModel extends Base
         $updates = $values;
         unset($updates['id']);
         $result = $this->db->table(self::TABLE)->eq('id', $values['id'])->update($updates);
-        $this->userSession->refresh($values['id']);
+
+        // prepare() removed the field if no new password was submitted
+        $passwordChanged = $result && isset($values['password']);
+
+        if ($passwordChanged) {
+            $this->rememberMeSessionModel->removeAll($values['id']);
+        }
+
+        $this->userSession->refresh($values['id'], $passwordChanged);
         return $result;
     }
 

--- a/tests/units/Auth/DatabaseAuthTest.php
+++ b/tests/units/Auth/DatabaseAuthTest.php
@@ -4,6 +4,7 @@ namespace KanboardTests\units\Auth;
 
 use KanboardTests\units\Base;
 use Kanboard\Auth\DatabaseAuth;
+use Kanboard\Core\User\UserSession;
 use Kanboard\Model\UserModel;
 
 class DatabaseAuthTest extends Base
@@ -50,21 +51,78 @@ class DatabaseAuthTest extends Base
         $this->assertEquals(2, $userModel->create(array('username' => 'user1')));
         $this->assertEquals(3, $userModel->create(array('username' => 'user2')));
 
-        $_SESSION['user'] = array('id' => 2, 'role' => 'app-user');
+        $fingerprint = hash('sha256', '');
+
+        $_SESSION['user'] = array('id' => 2, 'role' => 'app-user', 'credentials_fingerprint' => $fingerprint);
         $this->assertTrue($provider->isValidSession());
 
-        $_SESSION['user'] = array('id' => 4, 'role' => 'app-user');
+        $_SESSION['user'] = array('id' => 4, 'role' => 'app-user', 'credentials_fingerprint' => $fingerprint);
         $this->assertFalse($provider->isValidSession());
 
         $this->assertTrue($userModel->disable(2));
 
-        $_SESSION['user'] = array('id' => 2, 'role' => 'app-user');
+        $_SESSION['user'] = array('id' => 2, 'role' => 'app-user', 'credentials_fingerprint' => $fingerprint);
         $this->assertFalse($provider->isValidSession());
 
-        $_SESSION['user'] = array('id' => 3, 'role' => 'app-user');
+        $_SESSION['user'] = array('id' => 3, 'role' => 'app-user', 'credentials_fingerprint' => $fingerprint);
         $this->assertTrue($provider->isValidSession());
 
-        $_SESSION['user'] = array('id' => 3, 'role' => 'app-admin');
+        $_SESSION['user'] = array('id' => 3, 'role' => 'app-admin', 'credentials_fingerprint' => $fingerprint);
+        $this->assertFalse($provider->isValidSession());
+    }
+
+    public function testIsValidSessionAfterPasswordChange()
+    {
+        $userModel = new UserModel($this->container);
+        $userSession = new UserSession($this->container);
+        $provider = new DatabaseAuth($this->container);
+
+        $this->assertEquals(2, $userModel->create(array('username' => 'user1', 'password' => 'first_password')));
+
+        $userSession->initialize($userModel->getById(2));
+        $this->assertTrue($provider->isValidSession());
+
+        $this->assertTrue($userModel->update(array('id' => 2, 'password' => 'second_password')));
+
+        // The session of the user who made the change is refreshed and stays valid
+        $this->assertTrue($provider->isValidSession());
+
+        // Any other session opened before the change is now invalid
+        $_SESSION['user']['credentials_fingerprint'] = hash('sha256', 'stale');
+        $this->assertFalse($provider->isValidSession());
+    }
+
+    public function testIsValidSessionAfterOrdinaryUpdate()
+    {
+        $userModel = new UserModel($this->container);
+        $userSession = new UserSession($this->container);
+        $provider = new DatabaseAuth($this->container);
+
+        $this->assertEquals(2, $userModel->create(array('username' => 'user1', 'password' => 'first_password')));
+
+        $userSession->initialize($userModel->getById(2));
+        $staleFingerprint = $userSession->getCredentialsFingerprint();
+
+        $this->assertTrue($userModel->update(array('id' => 2, 'password' => 'second_password')));
+
+        // Simulate a session opened before the password was changed somewhere else
+        $_SESSION['user']['credentials_fingerprint'] = $staleFingerprint;
+        $this->assertFalse($provider->isValidSession());
+
+        // An update that does not change the password must not revalidate that session
+        $this->assertTrue($userModel->update(array('id' => 2, 'name' => 'User #1')));
+        $this->assertFalse($provider->isValidSession());
+    }
+
+    public function testIsValidSessionWithoutFingerprint()
+    {
+        $userModel = new UserModel($this->container);
+        $provider = new DatabaseAuth($this->container);
+
+        $this->assertEquals(2, $userModel->create(array('username' => 'user1', 'password' => 'first_password')));
+
+        // Sessions created before the fingerprint existed cannot be validated
+        $_SESSION['user'] = array('id' => 2, 'role' => 'app-user');
         $this->assertFalse($provider->isValidSession());
     }
 }

--- a/tests/units/Core/Security/AuthenticationManagerTest.php
+++ b/tests/units/Core/Security/AuthenticationManagerTest.php
@@ -6,6 +6,7 @@ use KanboardTests\units\Base;
 use Kanboard\Core\Http\Request;
 use Kanboard\Core\Security\AuthenticationManager;
 use Kanboard\Auth\DatabaseAuth;
+use Kanboard\Model\UserModel;
 use Kanboard\Auth\TotpAuth;
 use Kanboard\Auth\ReverseProxyAuth;
 
@@ -58,7 +59,8 @@ class AuthenticationManagerTest extends Base
         $authManager = new AuthenticationManager($this->container);
         $authManager->register(new DatabaseAuth($this->container));
 
-        $_SESSION['user'] = array('id' => 1, 'username' => 'test', 'role' => 'app-admin');
+        $userModel = new UserModel($this->container);
+        $this->container['userSession']->initialize($userModel->getById(1));
 
         $this->assertTrue($this->container['userSession']->isLogged());
         $this->assertTrue($authManager->checkCurrentSession());

--- a/tests/units/Model/RememberMeSessionModelTest.php
+++ b/tests/units/Model/RememberMeSessionModelTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace KanboardTests\units\Model;
+
+use KanboardTests\units\Base;
+use Kanboard\Model\RememberMeSessionModel;
+use Kanboard\Model\UserModel;
+
+class RememberMeSessionModelTest extends Base
+{
+    public function testRemoveAll()
+    {
+        $userModel = new UserModel($this->container);
+        $rememberMeSessionModel = new RememberMeSessionModel($this->container);
+
+        $this->assertEquals(2, $userModel->create(array('username' => 'user1')));
+
+        $rememberMeSessionModel->create(1, '127.0.0.1', 'Firefox');
+        $rememberMeSessionModel->create(1, '127.0.0.1', 'Chrome');
+        $rememberMeSessionModel->create(2, '127.0.0.1', 'Firefox');
+
+        $this->assertCount(2, $rememberMeSessionModel->getAll(1));
+        $this->assertCount(1, $rememberMeSessionModel->getAll(2));
+
+        $this->assertTrue($rememberMeSessionModel->removeAll(1));
+
+        $this->assertCount(0, $rememberMeSessionModel->getAll(1));
+        $this->assertCount(1, $rememberMeSessionModel->getAll(2));
+    }
+
+    public function testRemoveAllOnPasswordChange()
+    {
+        $userModel = new UserModel($this->container);
+        $rememberMeSessionModel = new RememberMeSessionModel($this->container);
+
+        $rememberMeSessionModel->create(1, '127.0.0.1', 'Firefox');
+        $this->assertCount(1, $rememberMeSessionModel->getAll(1));
+
+        // Updating something else keeps the persistent sessions
+        $this->assertTrue($userModel->update(array('id' => 1, 'name' => 'Bob')));
+        $this->assertCount(1, $rememberMeSessionModel->getAll(1));
+
+        $this->assertTrue($userModel->update(array('id' => 1, 'password' => 'new_password')));
+        $this->assertCount(0, $rememberMeSessionModel->getAll(1));
+    }
+}


### PR DESCRIPTION
Store a fingerprint of the password in the session and compare it on every request, so sessions opened before a password change are rejected.

- Remember me tokens are deleted at the same time.
- Sessions without a fingerprint are rejected too, which logs everyone out once on upgrade.

Closes #5864
